### PR TITLE
Initial version of GPU codegen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,9 @@ endif()
 option(DPNP_ENABLE "Use DPNP for some math functions" OFF)
 option(GPU_ENABLE "Enable GPU codegen" OFF)
 
+message(STATUS "DPNP_ENABLE ${DPNP_ENABLE}")
+message(STATUS "GPU_ENABLE ${GPU_ENABLE}")
+
 include(CTest)
 
 macro(apply_llvm_compile_flags target)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 # SDL
 # set(CMAKE_VERBOSE_MAKEFILE on) # enable for debug
 if (CMAKE_SYSTEM_NAME STREQUAL Windows)
-    add_compile_options(-GS)
+    add_compile_options(-GS -D_CRT_SECURE_NO_WARNINGS)
     add_link_options(-DYNAMICBASE -NXCOMPAT -GUARD:CF)
     # add_link_options(-INTEGRITYCHECK) # require signatures of libs, only recommended
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL Darwin)
 endif()
 
 option(DPNP_ENABLE "Use DPNP for some math functions" OFF)
+option(GPU_ENABLE "Enable GPU codegen" OFF)
 
 include(CTest)
 
@@ -54,11 +55,14 @@ macro(apply_llvm_compile_flags target)
 endmacro()
 
 add_subdirectory(dpcomp)
-add_subdirectory(dpcomp_gpu_runtime)
 add_subdirectory(dpcomp_math_runtime)
 add_subdirectory(dpcomp_runtime)
 add_subdirectory(tools)
 add_subdirectory(numba_dpcomp/mlir_compiler)
+
+if(${GPU_ENABLE})
+    add_subdirectory(dpcomp_gpu_runtime)
+endif()
 
 if(${BUILD_TESTING})
     add_subdirectory(test)
@@ -68,7 +72,14 @@ set(CMAKE_INSTALL_BINDIR .)
 set(CMAKE_INSTALL_LIBDIR .)
 set(CMAKE_INSTALL_INCLUDEDIR .)
 
-install(TARGETS dpcomp-runtime dpcomp-gpu-runtime dpcomp-math-runtime mlir_compiler
+install(TARGETS dpcomp-runtime dpcomp-math-runtime mlir_compiler
         PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
         LIBRARY DESTINATION .
         )
+
+if(${GPU_ENABLE})
+    install(TARGETS dpcomp-gpu-runtime
+            PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+            LIBRARY DESTINATION .
+            )
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ macro(apply_llvm_compile_flags target)
 endmacro()
 
 add_subdirectory(dpcomp)
+add_subdirectory(dpcomp_gpu_runtime)
 add_subdirectory(dpcomp_math_runtime)
 add_subdirectory(dpcomp_runtime)
 add_subdirectory(tools)
@@ -67,7 +68,7 @@ set(CMAKE_INSTALL_BINDIR .)
 set(CMAKE_INSTALL_LIBDIR .)
 set(CMAKE_INSTALL_INCLUDEDIR .)
 
-install(TARGETS dpcomp-runtime dpcomp-math-runtime mlir_compiler
+install(TARGETS dpcomp-runtime dpcomp-gpu-runtime dpcomp-math-runtime mlir_compiler
         PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
         LIBRARY DESTINATION .
         )

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,6 +70,17 @@ jobs:
     displayName: 'Get TBB'
 
   - script: |
+      git clone git@github.com:oneapi-src/level-zero.git
+      cd level-zero
+      git checkout v1.5.0
+      mkdir level_zero_install
+      mkdir build
+      cd build
+      cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../level_zero_install ..
+      ninja install
+    displayName: 'Get L0'
+
+  - script: |
       source /usr/share/miniconda/bin/activate
       conda create -y -n build_env python=3.7 numpy=1.20 scikit-learn pytest-xdist ninja scipy pybind11 pytest lit dpnp=0.5.1 mkl=2021.1 -c conda-forge -c intel
       conda activate build_env
@@ -81,6 +92,7 @@ jobs:
       chmod -R 777 $(System.DefaultWorkingDirectory)/llvm_cache
       export LLVM_PATH=$(System.DefaultWorkingDirectory)/llvm_cache
       export TBB_PATH=$(System.DefaultWorkingDirectory)/tbb
+      export LEVEL_ZERO_DIR=$(System.DefaultWorkingDirectory)/level-zero/level_zero_install
       export OCL_ICD_FILENAMES_RESET=1
       export OCL_ICD_FILENAMES=libintelocl.so
       export SYCL_DEVICE_FILTER=opencl:cpu

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,8 +76,8 @@ jobs:
       mkdir level_zero_install
       mkdir build
       cd build
-      cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../level_zero_install ..
-      ninja install
+      cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../level_zero_install ..
+      make install
     displayName: 'Get L0'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,7 +70,7 @@ jobs:
     displayName: 'Get TBB'
 
   - script: |
-      git clone git@github.com:oneapi-src/level-zero.git
+      git clone https://github.com/oneapi-src/level-zero.git
       cd level-zero
       git checkout v1.5.0
       mkdir level_zero_install

--- a/dpcomp/include/plier/PlierOps.td
+++ b/dpcomp/include/plier/PlierOps.td
@@ -334,14 +334,14 @@ def DestroyGpuStreamOp : Plier_Op<"destroy_gpu_stream"> {
 }
 
 def LoadGpuModuleOp : Plier_Op<"load_gpu_module", [NoSideEffect]> {
-  let arguments = (ins Plier_OpaqueType : $stream, StrAttr : $blob);
+  let arguments = (ins Plier_OpaqueType : $stream, SymbolRefAttr : $module);
   let results = (outs Plier_OpaqueType : $result);
 
   let hasCanonicalizer = 1;
 
   let builders = [OpBuilder<(ins "::mlir::Value"
-                             : $stream, "::mlir::StringRef"
-                             : $blob)>];
+                             : $stream, "::mlir::gpu::GPUModuleOp"
+                             : $module)>];
 }
 
 def DestroyGpuModuleOp : Plier_Op<"destroy_gpu_module"> {
@@ -349,14 +349,14 @@ def DestroyGpuModuleOp : Plier_Op<"destroy_gpu_module"> {
 }
 
 def GetGpuKernelOp : Plier_Op<"get_gpu_kernel", [NoSideEffect]> {
-  let arguments = (ins Plier_OpaqueType : $module, StrAttr : $name);
+  let arguments = (ins Plier_OpaqueType : $module, SymbolRefAttr : $kernel);
   let results = (outs Plier_OpaqueType : $result);
 
   let hasCanonicalizer = 1;
 
   let builders = [OpBuilder<(ins "::mlir::Value"
-                             : $module, "::mlir::StringRef"
-                             : $name)>];
+                             : $module, "::mlir::gpu::GPUFuncOp"
+                             : $kernel)>];
 }
 
 def LaunchGpuKernelOp

--- a/dpcomp/include/plier/PlierOps.td
+++ b/dpcomp/include/plier/PlierOps.td
@@ -16,6 +16,7 @@
 #define PLIER_OPS
 
 include "mlir/IR/OpBase.td"
+include "mlir/Dialect/GPU/GPUBase.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/LoopLikeInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
@@ -30,6 +31,11 @@ def Plier_PyType
     : DialectType<Plier_Dialect, CPred<"$_self.isa<::plier::PyType>()">,
                   "pytype">,
       BuildableType<"$_builder.getType<::plier::PyType>()"> {}
+
+def Plier_OpaqueType
+    : DialectType<Plier_Dialect, CPred<"$_self.isa<::plier::OpaqueType>()">,
+                  "opaque_type">,
+      BuildableType<"$_builder.getType<::plier::OpaqueType>()"> {}
 
 class Plier_Op<string mnemonic, list<OpTrait> traits = []>
     : Op<Plier_Dialect, mnemonic, traits>;
@@ -313,6 +319,68 @@ def ExtractMemrefMetadataOp
     OpBuilder<(ins "::mlir::Value"
                : $src)>
   ];
+}
+
+def CreateGpuStreamOp : Plier_Op<"create_gpu_stream", [NoSideEffect]> {
+  let results = (outs Plier_OpaqueType : $result);
+
+  let hasCanonicalizer = 1;
+
+  let builders = [OpBuilder<(ins)>];
+}
+
+def DestroyGpuStreamOp : Plier_Op<"destroy_gpu_stream"> {
+  let arguments = (ins Plier_OpaqueType : $source);
+}
+
+def LoadGpuModuleOp : Plier_Op<"load_gpu_module", [NoSideEffect]> {
+  let arguments = (ins Plier_OpaqueType : $stream, StrAttr : $blob);
+  let results = (outs Plier_OpaqueType : $result);
+
+  let hasCanonicalizer = 1;
+
+  let builders = [OpBuilder<(ins "::mlir::Value"
+                             : $stream, "::mlir::StringRef"
+                             : $blob)>];
+}
+
+def DestroyGpuModuleOp : Plier_Op<"destroy_gpu_module"> {
+  let arguments = (ins Plier_OpaqueType : $source);
+}
+
+def GetGpuKernelOp : Plier_Op<"get_gpu_kernel", [NoSideEffect]> {
+  let arguments = (ins Plier_OpaqueType : $module, StrAttr : $name);
+  let results = (outs Plier_OpaqueType : $result);
+
+  let hasCanonicalizer = 1;
+
+  let builders = [OpBuilder<(ins "::mlir::Value"
+                             : $module, "::mlir::StringRef"
+                             : $name)>];
+}
+
+def LaunchGpuKernelOp
+    : Plier_Op<"launch_gpu_kernel",
+               [GPU_AsyncOpInterface, AttrSizedOperandSegments]> {
+  let arguments = (ins Variadic<GPU_AsyncToken>:$asyncDependencies,
+                     Plier_OpaqueType:$stream,
+                     Plier_OpaqueType:$kernel,
+                     Index:$gridSizeX, Index:$gridSizeY, Index:$gridSizeZ,
+                     Index:$blockSizeX, Index:$blockSizeY, Index:$blockSizeZ,
+                     Variadic<AnyType>:$operands);
+  let results = (outs Optional<GPU_AsyncToken> : $asyncToken);
+
+  let skipDefaultBuilders = 1;
+  let builders = [OpBuilder<(ins "::mlir::Value"
+                             : $stream, "::mlir::Value"
+                             : $kernel, "::mlir::gpu::KernelDim3"
+                             : $gridSize, "::mlir::gpu::KernelDim3"
+                             : $blockSize, "::mlir::ValueRange"
+                             : $kernelOperands)>];
+}
+
+def DestroyGpuKernelOp : Plier_Op<"destroy_gpu_kernel"> {
+  let arguments = (ins Plier_OpaqueType : $source);
 }
 
 #endif // PLIER_OPS

--- a/dpcomp/include/plier/PlierOps.td
+++ b/dpcomp/include/plier/PlierOps.td
@@ -383,4 +383,19 @@ def DestroyGpuKernelOp : Plier_Op<"destroy_gpu_kernel"> {
   let arguments = (ins Plier_OpaqueType : $source);
 }
 
+def GPUAllocOp
+    : Plier_Op<"gpu_alloc", [GPU_AsyncOpInterface, AttrSizedOperandSegments]> {
+
+  let arguments = (ins Variadic<GPU_AsyncToken>:$asyncDependencies,
+                     Plier_OpaqueType:$stream,
+                   Variadic<Index>:$dynamicSizes, Variadic<Index>:$symbolOperands);
+  let results = (outs Res<AnyMemRef, "", [MemAlloc]>:$memref,
+                 Optional<GPU_AsyncToken>:$asyncToken);
+
+  let extraClassDeclaration = [{
+    ::mlir::MemRefType getType() { return memref().getType().cast<::mlir::MemRefType>();
+}
+}];
+}
+
 #endif // PLIER_OPS

--- a/dpcomp/include/plier/dialect.hpp
+++ b/dpcomp/include/plier/dialect.hpp
@@ -38,6 +38,7 @@ llvm::StringRef getParallelName();
 llvm::StringRef getMaxConcurrencyName();
 llvm::StringRef getForceInlineName();
 llvm::StringRef getOptLevelName();
+llvm::StringRef getGpuRangeName();
 } // namespace attributes
 
 namespace detail {

--- a/dpcomp/include/plier/dialect.hpp
+++ b/dpcomp/include/plier/dialect.hpp
@@ -23,8 +23,10 @@
 #include <mlir/Interfaces/SideEffectInterfaces.h>
 #include <mlir/Interfaces/ViewLikeInterface.h>
 
+#include <mlir/Dialect/GPU/GPUDialect.h>
+
 #include "plier/PlierOpsDialect.h.inc"
-#include "plier/PlierOpsEnums.h.inc"
+//#include "plier/PlierOpsEnums.h.inc"
 #define GET_OP_CLASSES
 #include "plier/PlierOps.h.inc"
 

--- a/dpcomp/src/dialect.cpp
+++ b/dpcomp/src/dialect.cpp
@@ -845,11 +845,12 @@ void CreateGpuStreamOp::getCanonicalizationPatterns(
 
 void LoadGpuModuleOp::build(::mlir::OpBuilder &odsBuilder,
                             ::mlir::OperationState &odsState,
-                            ::mlir::Value stream, ::mlir::StringRef blob) {
-  assert(!blob.empty());
+                            ::mlir::Value stream,
+                            ::mlir::gpu::GPUModuleOp module) {
   auto ctx = odsBuilder.getContext();
   LoadGpuModuleOp::build(odsBuilder, odsState, plier::OpaqueType::get(ctx),
-                         stream, mlir::StringAttr::get(ctx, blob));
+                         stream,
+                         mlir::SymbolRefAttr::get(ctx, module.getName()));
 }
 
 void LoadGpuModuleOp::getCanonicalizationPatterns(
@@ -859,11 +860,12 @@ void LoadGpuModuleOp::getCanonicalizationPatterns(
 
 void GetGpuKernelOp::build(::mlir::OpBuilder &odsBuilder,
                            ::mlir::OperationState &odsState,
-                           ::mlir::Value module, ::mlir::StringRef name) {
-  assert(!name.empty());
+                           ::mlir::Value module,
+                           ::mlir::gpu::GPUFuncOp kernel) {
   auto ctx = odsBuilder.getContext();
   GetGpuKernelOp::build(odsBuilder, odsState, plier::OpaqueType::get(ctx),
-                        module, mlir::StringAttr::get(ctx, name));
+                        module,
+                        mlir::SymbolRefAttr::get(ctx, kernel.getName()));
 }
 
 void GetGpuKernelOp::getCanonicalizationPatterns(

--- a/dpcomp/src/dialect.cpp
+++ b/dpcomp/src/dialect.cpp
@@ -21,6 +21,7 @@
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/Transforms/InliningUtils.h>
 
+#include <mlir/Dialect/GPU/GPUDialect.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/StandardOps/IR/Ops.h>
 
@@ -808,6 +809,86 @@ ExtractMemrefMetadataOp::fold(llvm::ArrayRef<mlir::Attribute> /*operands*/) {
   return nullptr;
 }
 
+namespace {
+template <typename Op, typename DelOp>
+struct RemoveUnusedOp : public mlir::OpRewritePattern<Op> {
+  using mlir::OpRewritePattern<Op>::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(Op op, mlir::PatternRewriter &rewriter) const override {
+    for (auto user : op->getUsers()) {
+      if (!mlir::isa<DelOp>(user))
+        return mlir::failure();
+    }
+
+    for (auto user : llvm::make_early_inc_range(op->getUsers())) {
+      assert(user->getNumResults() == 0);
+      rewriter.eraseOp(user);
+    }
+    rewriter.eraseOp(op);
+    return mlir::success();
+  }
+};
+} // namespace
+
+void CreateGpuStreamOp::build(::mlir::OpBuilder &odsBuilder,
+                              ::mlir::OperationState &odsState) {
+  auto ctx = odsBuilder.getContext();
+  CreateGpuStreamOp::build(odsBuilder, odsState, plier::OpaqueType::get(ctx));
+}
+
+void CreateGpuStreamOp::getCanonicalizationPatterns(
+    ::mlir::RewritePatternSet &results, ::mlir::MLIRContext *context) {
+  results.insert<RemoveUnusedOp<CreateGpuStreamOp, DestroyGpuStreamOp>>(
+      context);
+}
+
+void LoadGpuModuleOp::build(::mlir::OpBuilder &odsBuilder,
+                            ::mlir::OperationState &odsState,
+                            ::mlir::Value stream, ::mlir::StringRef blob) {
+  assert(!blob.empty());
+  auto ctx = odsBuilder.getContext();
+  LoadGpuModuleOp::build(odsBuilder, odsState, plier::OpaqueType::get(ctx),
+                         stream, mlir::StringAttr::get(ctx, blob));
+}
+
+void LoadGpuModuleOp::getCanonicalizationPatterns(
+    ::mlir::RewritePatternSet &results, ::mlir::MLIRContext *context) {
+  results.insert<RemoveUnusedOp<LoadGpuModuleOp, DestroyGpuModuleOp>>(context);
+}
+
+void GetGpuKernelOp::build(::mlir::OpBuilder &odsBuilder,
+                           ::mlir::OperationState &odsState,
+                           ::mlir::Value module, ::mlir::StringRef name) {
+  assert(!name.empty());
+  auto ctx = odsBuilder.getContext();
+  GetGpuKernelOp::build(odsBuilder, odsState, plier::OpaqueType::get(ctx),
+                        module, mlir::StringAttr::get(ctx, name));
+}
+
+void GetGpuKernelOp::getCanonicalizationPatterns(
+    ::mlir::RewritePatternSet &results, ::mlir::MLIRContext *context) {
+  results.insert<RemoveUnusedOp<GetGpuKernelOp, DestroyGpuKernelOp>>(context);
+}
+
+void LaunchGpuKernelOp::build(::mlir::OpBuilder &builder,
+                              ::mlir::OperationState &result,
+                              ::mlir::Value stream, ::mlir::Value kernel,
+                              ::mlir::gpu::KernelDim3 gridSize,
+                              ::mlir::gpu::KernelDim3 blockSize,
+                              ::mlir::ValueRange kernelOperands) {
+  result.addOperands(stream);
+  result.addOperands(kernel);
+  result.addOperands({gridSize.x, gridSize.y, gridSize.z, blockSize.x,
+                      blockSize.y, blockSize.z});
+  result.addOperands(kernelOperands);
+  llvm::SmallVector<int32_t> segmentSizes(10, 1);
+  segmentSizes.front() = 0; // Initially no async dependencies.
+  segmentSizes.back() = static_cast<int32_t>(kernelOperands.size());
+  result.addAttribute(getOperandSegmentSizeAttr(),
+                      builder.getI32VectorAttr(segmentSizes));
+}
+
 } // namespace plier
 
 #include "plier/PlierOpsDialect.cpp.inc"
@@ -815,4 +896,4 @@ ExtractMemrefMetadataOp::fold(llvm::ArrayRef<mlir::Attribute> /*operands*/) {
 #define GET_OP_CLASSES
 #include "plier/PlierOps.cpp.inc"
 
-#include "plier/PlierOpsEnums.cpp.inc"
+//#include "plier/PlierOpsEnums.cpp.inc"

--- a/dpcomp/src/dialect.cpp
+++ b/dpcomp/src/dialect.cpp
@@ -65,6 +65,8 @@ llvm::StringRef attributes::getForceInlineName() {
 
 llvm::StringRef attributes::getOptLevelName() { return "#plier.opt_level"; }
 
+llvm::StringRef attributes::getGpuRangeName() { return "#plier.gpu_range"; }
+
 namespace detail {
 struct PyTypeStorage : public mlir::TypeStorage {
   using KeyTy = mlir::StringRef;

--- a/dpcomp_gpu_runtime/CMakeLists.txt
+++ b/dpcomp_gpu_runtime/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project(dpcomp-gpu-runtime LANGUAGES CXX C)
+
+include(GenerateExportHeader)
+
+set(SOURCES_LIST
+    src/gpu_runtime.cpp
+    )
+set(HEADERS_LIST
+    )
+
+add_library(${PROJECT_NAME} SHARED ${SOURCES_LIST} ${HEADERS_LIST})
+generate_export_header(${PROJECT_NAME})
+
+target_include_directories(${PROJECT_NAME} PRIVATE
+    ${PROJECT_BINARY_DIR}
+    )
+

--- a/dpcomp_gpu_runtime/CMakeLists.txt
+++ b/dpcomp_gpu_runtime/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SOURCES_LIST
     src/gpu_runtime.cpp
     )
 set(HEADERS_LIST
+    src/level_zero_printing.hpp
     src/level_zero_wrapper.hpp
     )
 

--- a/dpcomp_gpu_runtime/CMakeLists.txt
+++ b/dpcomp_gpu_runtime/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SOURCES_LIST
     src/gpu_runtime.cpp
     )
 set(HEADERS_LIST
+    src/level_zero_wrapper.hpp
     )
 
 add_library(${PROJECT_NAME} SHARED ${SOURCES_LIST} ${HEADERS_LIST})

--- a/dpcomp_gpu_runtime/CMakeLists.txt
+++ b/dpcomp_gpu_runtime/CMakeLists.txt
@@ -16,6 +16,10 @@ project(dpcomp-gpu-runtime LANGUAGES CXX C)
 
 include(GenerateExportHeader)
 
+if(NOT LEVEL_ZERO_DIR)
+    message(FATAL_ERROR "LEVEL_ZERO_DIR is not set")
+endif()
+
 set(SOURCES_LIST
     src/gpu_runtime.cpp
     )
@@ -27,5 +31,11 @@ generate_export_header(${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME} PRIVATE
     ${PROJECT_BINARY_DIR}
+    ${LEVEL_ZERO_DIR}/include
     )
 
+target_link_directories(${PROJECT_NAME} PRIVATE
+    ${LEVEL_ZERO_DIR}/lib
+    )
+
+target_link_libraries(${PROJECT_NAME} PRIVATE ze_loader)

--- a/dpcomp_gpu_runtime/src/gpu_runtime.cpp
+++ b/dpcomp_gpu_runtime/src/gpu_runtime.cpp
@@ -458,3 +458,17 @@ dpcompGpuAlloc(void *stream, size_t size, size_t alignment, int shared,
     *ret = AllocResult{std::get<0>(res), std::get<1>(res), std::get<2>(res)};
   });
 }
+
+// Stubs for kernel interface
+[[noreturn]] static void stub(const char *funcName) {
+  fprintf(stderr, "This function should never be called: %s\n", funcName);
+  fflush(stderr);
+  abort();
+}
+
+#define STUB() stub(__func__)
+
+extern "C" DPCOMP_GPU_RUNTIME_EXPORT int64_t
+_mlir_ciface_get_global_id(int64_t) {
+  STUB();
+}

--- a/dpcomp_gpu_runtime/src/gpu_runtime.cpp
+++ b/dpcomp_gpu_runtime/src/gpu_runtime.cpp
@@ -18,6 +18,7 @@
 #include <cassert>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <vector>
 
 #include "dpcomp-gpu-runtime_export.h"
@@ -36,7 +37,7 @@ struct MemInfo {
 
 using AllocFuncT = void *(*)(size_t);
 
-#if 1 // Log functions
+#if 0 // Log functions
 namespace {
 struct FuncScope {
   FuncScope(const char *funcName) : name(funcName) {
@@ -59,6 +60,14 @@ private:
 #endif
 
 namespace {
+static bool printGpuInfoEnabled() {
+  static bool value = []() {
+    auto env = std::getenv("DPCOMP_PRINT_GPU_INFO");
+    return env != nullptr && std::atoi(env) != 0;
+  }();
+  return value;
+}
+
 template <typename F> auto catchAll(F &&func) {
   try {
     return func();
@@ -201,7 +210,7 @@ struct Stream {
     driver = driverAndDevice.driver;
     device = driverAndDevice.device;
 
-    if (1) {
+    if (printGpuInfoEnabled()) {
       printDriverProps(driver);
       printDeviceProps(device);
     }

--- a/dpcomp_gpu_runtime/src/gpu_runtime.cpp
+++ b/dpcomp_gpu_runtime/src/gpu_runtime.cpp
@@ -1,0 +1,116 @@
+// Copyright 2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdint>
+#include <cstdio>
+
+#include "dpcomp-gpu-runtime_export.h"
+
+#if 1 // Log functions
+namespace {
+struct FuncScope {
+  FuncScope(const char *funcName) : name(funcName) {
+    fprintf(stdout, "%s enter\n", name);
+    fflush(stdout);
+  }
+
+  ~FuncScope() {
+    fprintf(stdout, "%s exit\n", name);
+    fflush(stdout);
+  }
+
+private:
+  const char *name;
+};
+} // namespace
+#define LOG_FUNC() FuncScope _scope(__func__)
+#else
+#define LOG_FUNC() (void)0
+#endif
+
+extern "C" DPCOMP_GPU_RUNTIME_EXPORT void *mgpuModuleLoad(void *data) {
+  LOG_FUNC();
+  return nullptr;
+}
+
+extern "C" DPCOMP_GPU_RUNTIME_EXPORT void mgpuModuleUnload(void *module) {
+  LOG_FUNC();
+}
+
+extern "C" DPCOMP_GPU_RUNTIME_EXPORT void *
+mgpuModuleGetFunction(void *module, const char *name) {
+  LOG_FUNC();
+  return nullptr;
+}
+
+// The wrapper uses intptr_t instead of CUDA's unsigned int to match
+// the type of MLIR's index type. This avoids the need for casts in the
+// generated MLIR code.
+extern "C" DPCOMP_GPU_RUNTIME_EXPORT void
+mgpuLaunchKernel(void *function, intptr_t gridX, intptr_t gridY, intptr_t gridZ,
+                 intptr_t blockX, intptr_t blockY, intptr_t blockZ,
+                 int32_t smem, void *stream, void **params, void **extra) {
+  LOG_FUNC();
+}
+
+extern "C" DPCOMP_GPU_RUNTIME_EXPORT void *mgpuStreamCreate() {
+  LOG_FUNC();
+  return nullptr;
+}
+
+extern "C" DPCOMP_GPU_RUNTIME_EXPORT void mgpuStreamDestroy(void *stream) {
+  LOG_FUNC();
+}
+
+extern "C" DPCOMP_GPU_RUNTIME_EXPORT void mgpuStreamSynchronize(void *stream) {
+  LOG_FUNC();
+}
+
+extern "C" DPCOMP_GPU_RUNTIME_EXPORT void mgpuStreamWaitEvent(void *stream,
+                                                              void *event) {
+  LOG_FUNC();
+}
+
+extern "C" DPCOMP_GPU_RUNTIME_EXPORT void *mgpuEventCreate() {
+  LOG_FUNC();
+  return nullptr;
+}
+
+extern "C" DPCOMP_GPU_RUNTIME_EXPORT void mgpuEventDestroy(void *event) {
+  LOG_FUNC();
+}
+
+extern "C" DPCOMP_GPU_RUNTIME_EXPORT void mgpuEventSynchronize(void *event) {
+  LOG_FUNC();
+}
+
+extern "C" DPCOMP_GPU_RUNTIME_EXPORT void mgpuEventRecord(void *event,
+                                                          void *stream) {
+  LOG_FUNC();
+}
+
+extern "C" DPCOMP_GPU_RUNTIME_EXPORT void *mgpuMemAlloc(uint64_t sizeBytes,
+                                                        void *stream) {
+  LOG_FUNC();
+  return nullptr;
+}
+
+extern "C" DPCOMP_GPU_RUNTIME_EXPORT void mgpuMemFree(void *ptr, void *stream) {
+  LOG_FUNC();
+}
+
+extern "C" DPCOMP_GPU_RUNTIME_EXPORT void
+mgpuMemcpy(void *dst, void *src, uint64_t sizeBytes, void *stream) {
+  LOG_FUNC();
+}

--- a/dpcomp_gpu_runtime/src/gpu_runtime.cpp
+++ b/dpcomp_gpu_runtime/src/gpu_runtime.cpp
@@ -344,7 +344,7 @@ struct Stream {
   }
 
 private:
-  std::atomic<size_t> refcout = {1};
+  std::atomic<unsigned> refcout = {1};
   ze_driver_handle_t driver = nullptr;
   ze_device_handle_t device = nullptr;
   ze::Context context;

--- a/dpcomp_gpu_runtime/src/gpu_runtime.cpp
+++ b/dpcomp_gpu_runtime/src/gpu_runtime.cpp
@@ -12,10 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cassert>
 #include <cstdint>
 #include <cstdio>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
 
 #include "dpcomp-gpu-runtime_export.h"
+
+#include "level_zero_wrapper.hpp"
 
 #if 1 // Log functions
 namespace {
@@ -39,8 +45,143 @@ private:
 #define LOG_FUNC() (void)0
 #endif
 
-extern "C" DPCOMP_GPU_RUNTIME_EXPORT void *mgpuModuleLoad(void *data) {
+namespace {
+
+template <typename CheckFunc>
+std::pair<ze_driver_handle_t, ze_device_handle_t>
+getDevice(CheckFunc &&checkFunc) {
+  uint32_t driverCount = 0;
+  CHECK_ZE_RESULT(zeDriverGet(&driverCount, nullptr));
+
+  auto drivers = std::make_unique<ze_driver_handle_t[]>(driverCount);
+  CHECK_ZE_RESULT(zeDriverGet(&driverCount, drivers.get()));
+
+  std::vector<ze_device_handle_t>
+      devices; // vector here so we can reuse memory between iterations
+  for (uint32_t i = 0; i < driverCount; ++i) {
+    auto driver = drivers[i];
+    assert(driver);
+    uint32_t deviceCount = 0;
+    CHECK_ZE_RESULT(zeDeviceGet(driver, &deviceCount, nullptr));
+    devices.resize(deviceCount);
+    CHECK_ZE_RESULT(zeDeviceGet(driver, &deviceCount, devices.data()));
+    for (uint32_t i = 0; i < deviceCount; ++i) {
+      auto device = devices[i];
+      assert(device);
+      if (checkFunc(device))
+        return {driver, device};
+    }
+  }
+  throw std::runtime_error("getDevice failed");
+}
+
+struct L0State {
+  static std::unique_ptr<L0State> get() {
+    CHECK_ZE_RESULT(zeInit(0));
+
+    auto driverAndDev = getDevice([](ze_device_handle_t device) {
+      ze_device_properties_t props = {};
+      CHECK_ZE_RESULT(zeDeviceGetProperties(device, &props));
+      return props.type == ZE_DEVICE_TYPE_GPU;
+    });
+    auto driver = std::get<0>(driverAndDev);
+    auto device = std::get<1>(driverAndDev);
+
+    ze_context_desc_t contextDesc = {};
+    auto context = ze::Context::create(driver, contextDesc);
+
+    return std::unique_ptr<L0State>(new L0State(device, std::move(context)));
+  }
+
+  ze_command_list_handle_t getCommandList() {
+    std::lock_guard<std::mutex> lock(mutex);
+    if (!commandLists.empty()) {
+      auto ret = std::move(commandLists.back());
+      commandLists.pop_back();
+      return ret.release();
+    }
+
+    ze_command_queue_desc_t desc = {};
+    desc.mode = ZE_COMMAND_QUEUE_MODE_ASYNCHRONOUS;
+    return ze::CommandList::createImmediate(context, device, desc).release();
+  }
+
+  void returnCommandList(ze_command_list_handle_t handle) {
+    assert(handle);
+    std::lock_guard<std::mutex> lock(mutex);
+    commandLists.push_back(ze::CommandList(handle));
+  }
+
+  ze_module_handle_t getModule(const void *data, size_t dataSize) {
+    // We assume data is statically allocated and didn't change, so we can use
+    // ptr value as key.
+    assert(data);
+    std::lock_guard<std::mutex> lock(mutex);
+    auto it = modules.find(data);
+    if (it != modules.end())
+      return it->second.get();
+
+    ze_module_desc_t desc = {};
+    desc.format = ZE_MODULE_FORMAT_IL_SPIRV;
+    desc.pInputModule = static_cast<const uint8_t *>(data);
+    desc.inputSize = dataSize;
+    auto mod = ze::Module::create(context, device, desc).first;
+    auto modPtr = mod.get();
+    modules[data] = std::move(mod);
+    return modPtr;
+  }
+
+  void returnModule(ze_module_handle_t mod) {
+    assert(mod);
+    (void)mod;
+    // Nothing To do, modules always owned by context
+  }
+
+  ze_kernel_handle_t getKernel(ze_module_handle_t module, const char* name) {
+    assert(module);
+    assert(name);
+    auto key = std::make_pair(module, name);
+    auto it = kernels.find(key);
+    if (it != kernels.end())
+      return it->second.get();
+
+    ze_kernel_desc_t desc = {};
+    auto kernel = ze::Kernel::create(module, desc);
+    auto ret = kernel.get();
+    kernels[key] = std::move(kernel);
+    return ret;
+  }
+
+private:
+  L0State(ze_device_handle_t dev, ze::Context ctx)
+      : device(dev), context(std::move(ctx)) {}
+
+  std::mutex mutex;
+  ze_device_handle_t device;
+  ze::Context context;
+
+  std::vector<ze::CommandList> commandLists;
+
+  std::unordered_map<const void *, ze::Module> modules;
+
+  using KernelKey = std::pair<ze_module_handle_t, const char*>;
+  struct KernelHasher
+  {
+    size_t operator()(const KernelKey val) const {
+      return std::hash<decltype (val.first)>()(val.first) |
+             std::hash<decltype (val.second)>()(val.second);
+    }
+  };
+
+  std::unordered_map<KernelKey, ze::Kernel, KernelHasher> kernels;
+};
+} // namespace
+
+extern "C" DPCOMP_GPU_RUNTIME_EXPORT void *mgpuModuleLoad(const void *ptr) {
   LOG_FUNC();
+  auto data = static_cast<const uint32_t *>(ptr);
+  auto size = data[0] * sizeof(uint32_t);
+  ++data;
   return nullptr;
 }
 
@@ -54,9 +195,6 @@ mgpuModuleGetFunction(void *module, const char *name) {
   return nullptr;
 }
 
-// The wrapper uses intptr_t instead of CUDA's unsigned int to match
-// the type of MLIR's index type. This avoids the need for casts in the
-// generated MLIR code.
 extern "C" DPCOMP_GPU_RUNTIME_EXPORT void
 mgpuLaunchKernel(void *function, intptr_t gridX, intptr_t gridY, intptr_t gridZ,
                  intptr_t blockX, intptr_t blockY, intptr_t blockZ,

--- a/dpcomp_gpu_runtime/src/gpu_runtime.cpp
+++ b/dpcomp_gpu_runtime/src/gpu_runtime.cpp
@@ -261,7 +261,12 @@ private:
   ze::EventPool eventPool;
   std::unique_ptr<ze::Event[]> events;
 
+  static const constexpr size_t NoEvent = static_cast<size_t>(-1);
+
   ze_event_handle_t getEvent(size_t index) {
+    if (index == NoEvent)
+      return nullptr;
+
     assert(eventPool);
     if (events[index] != nullptr) {
       auto ev = events[index].get();

--- a/dpcomp_gpu_runtime/src/level_zero_printing.hpp
+++ b/dpcomp_gpu_runtime/src/level_zero_printing.hpp
@@ -1,0 +1,215 @@
+// Copyright 2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <string>
+#include <type_traits>
+
+#include <level_zero/ze_api.h>
+
+namespace {
+
+template <typename T, size_t N, typename F>
+static void print(T (&array)[N], F &&printer) {
+  printer("[");
+  for (size_t i = 0; i < N; ++i) {
+    if (i != 0)
+      printer(", ");
+
+    print(array[i], printer);
+  }
+  printer("]");
+}
+
+template <typename T, typename F>
+static auto print(T val, F &&printer) ->
+    typename std::enable_if<std::is_arithmetic<T>::value>::type {
+  printer(std::to_string(val));
+}
+
+template <typename F> static void print(const char *str, F &&printer) {
+  printer(str);
+}
+
+template <typename F> static void print(ze_device_type_t val, F &&printer) {
+  auto index = static_cast<size_t>(val);
+  std::array<const char *, 6> res;
+  if (index > res.size()) {
+    printer("?");
+    return;
+  }
+
+  std::fill(res.begin(), res.end(), "?");
+
+#define ENUM_ELEMENT(elem) res[static_cast<size_t>(elem)] = #elem
+  ENUM_ELEMENT(ZE_DEVICE_TYPE_GPU);
+  ENUM_ELEMENT(ZE_DEVICE_TYPE_CPU);
+  ENUM_ELEMENT(ZE_DEVICE_TYPE_FPGA);
+  ENUM_ELEMENT(ZE_DEVICE_TYPE_MCA);
+  ENUM_ELEMENT(ZE_DEVICE_TYPE_VPU);
+#undef ENUM_ELEM
+
+  printer(res[index]);
+}
+
+template <typename F>
+static void print(ze_device_property_flag_t flags, F &&printer) {
+  printer("[");
+  bool first = true;
+  auto printFlag = [&](auto val, auto name) {
+    if (flags & val) {
+      if (!first)
+        printer("|");
+
+      printer(name);
+      first = false;
+    }
+  };
+#define PRINT_FLAG(flag) printFlag(flag, #flag)
+  PRINT_FLAG(ZE_DEVICE_PROPERTY_FLAG_INTEGRATED);
+  PRINT_FLAG(ZE_DEVICE_PROPERTY_FLAG_SUBDEVICE);
+  PRINT_FLAG(ZE_DEVICE_PROPERTY_FLAG_ECC);
+  PRINT_FLAG(ZE_DEVICE_PROPERTY_FLAG_ONDEMANDPAGING);
+#undef PRINT_FLAG
+  printer("]");
+}
+
+template <typename F>
+static void print(const ze_device_properties_t val, F &&printer) {
+  auto write = [&](auto desc, auto val) {
+    printer(desc);
+    print(val, printer);
+    printer("\n");
+  };
+
+  write("Device::properties_t::type : ", val.type);
+  write("Device::properties_t::vendorId : ", val.vendorId);
+  write("Device::properties_t::deviceId : ", val.deviceId);
+  write("Device::properties_t::flags : ",
+        static_cast<ze_device_property_flag_t>(val.flags));
+  write("Device::properties_t::subdeviceId : ", val.subdeviceId);
+  write("Device::properties_t::coreClockRate : ", val.coreClockRate);
+  write("Device::properties_t::maxMemAllocSize : ", val.maxMemAllocSize);
+  write("Device::properties_t::maxHardwareContexts : ",
+        val.maxHardwareContexts);
+  write("Device::properties_t::maxCommandQueuePriority : ",
+        val.maxCommandQueuePriority);
+  write("Device::properties_t::numThreadsPerEU : ", val.numThreadsPerEU);
+  write("Device::properties_t::physicalEUSimdWidth : ",
+        val.physicalEUSimdWidth);
+  write("Device::properties_t::numEUsPerSubslice : ", val.numEUsPerSubslice);
+  write("Device::properties_t::numSubslicesPerSlice : ",
+        val.numSubslicesPerSlice);
+  write("Device::properties_t::numSlices : ", val.numSlices);
+  write("Device::properties_t::timerResolution : ", val.timerResolution);
+  write("Device::properties_t::timestampValidBits : ", val.timestampValidBits);
+  write("Device::properties_t::kernelTimestampValidBits : ",
+        val.kernelTimestampValidBits);
+  write("Device::properties_t::name : ", val.name);
+}
+
+template <typename F>
+static void print(const ze_device_compute_properties_t val, F &&printer) {
+  auto write = [&](auto desc, auto val) {
+    printer(desc);
+    print(val, printer);
+    printer("\n");
+  };
+  write("maxTotalGroupSize : ", val.maxTotalGroupSize);
+  write("maxGroupSizeX : ", val.maxGroupSizeX);
+  write("maxGroupSizeY : ", val.maxGroupSizeY);
+  write("maxGroupSizeZ : ", val.maxGroupSizeZ);
+  write("maxGroupCountX : ", val.maxGroupCountX);
+  write("maxGroupCountY : ", val.maxGroupCountY);
+  write("maxGroupCountZ : ", val.maxGroupCountZ);
+  write("maxSharedLocalMemory : ", val.maxSharedLocalMemory);
+  write("numSubGroupSizes : ", val.numSubGroupSizes);
+  printer("subGroupSizes : ");
+  print(val.subGroupSizes, printer);
+  printer("\n");
+}
+
+template <typename F>
+static void print(ze_device_module_flag_t flags, F &&printer) {
+  printer("[");
+  bool first = true;
+  auto printFlag = [&](auto val, auto name) {
+    if (flags & val) {
+      if (!first)
+        printer("|");
+
+      printer(name);
+      first = false;
+    }
+  };
+#define PRINT_FLAG(flag) printFlag(flag, #flag)
+  PRINT_FLAG(ZE_DEVICE_MODULE_FLAG_FP16);
+  PRINT_FLAG(ZE_DEVICE_MODULE_FLAG_FP64);
+  PRINT_FLAG(ZE_DEVICE_MODULE_FLAG_INT64_ATOMICS);
+  PRINT_FLAG(ZE_DEVICE_MODULE_FLAG_DP4A);
+#undef PRINT_FLAG
+  printer("]");
+}
+
+template <typename F>
+static void print(ze_device_fp_flag_t flags, F &&printer) {
+  printer("[");
+  bool first = true;
+  auto printFlag = [&](auto val, auto name) {
+    if (flags & val) {
+      if (!first)
+        printer("|");
+
+      printer(name);
+      first = false;
+    }
+  };
+#define PRINT_FLAG(flag) printFlag(flag, #flag)
+  PRINT_FLAG(ZE_DEVICE_FP_FLAG_DENORM);
+  PRINT_FLAG(ZE_DEVICE_FP_FLAG_INF_NAN);
+  PRINT_FLAG(ZE_DEVICE_FP_FLAG_ROUND_TO_NEAREST);
+  PRINT_FLAG(ZE_DEVICE_FP_FLAG_ROUND_TO_ZERO);
+  PRINT_FLAG(ZE_DEVICE_FP_FLAG_ROUND_TO_INF);
+  PRINT_FLAG(ZE_DEVICE_FP_FLAG_FMA);
+  PRINT_FLAG(ZE_DEVICE_FP_FLAG_ROUNDED_DIVIDE_SQRT);
+  PRINT_FLAG(ZE_DEVICE_FP_FLAG_SOFT_FLOAT);
+#undef PRINT_FLAG
+  printer("]");
+}
+
+template <typename F>
+static void print(ze_device_module_properties_t properties, F &&printer) {
+  auto write = [&](auto desc, auto val) {
+    printer(desc);
+    print(val, printer);
+    printer("\n");
+  };
+
+  printer("Supported spir-v version: ");
+  printer(ZE_MAJOR_VERSION(properties.spirvVersionSupported));
+  printer(".");
+  printer(ZE_MINOR_VERSION(properties.spirvVersionSupported));
+  printer("\n");
+
+  write("Flags: ", static_cast<ze_device_module_flag_t>(properties.flags));
+  write("FP16 flags: ", static_cast<ze_device_fp_flag_t>(properties.fp16flags));
+  write("FP32 flags: ", static_cast<ze_device_fp_flag_t>(properties.fp32flags));
+  write("FP64 flags: ", static_cast<ze_device_fp_flag_t>(properties.fp64flags));
+  write("Max argument size: ", properties.maxArgumentsSize);
+  write("Print buffer size: ", properties.printfBufferSize);
+}
+} // namespace

--- a/dpcomp_gpu_runtime/src/level_zero_wrapper.hpp
+++ b/dpcomp_gpu_runtime/src/level_zero_wrapper.hpp
@@ -64,7 +64,7 @@ struct Type : public std::unique_ptr<std::remove_pointer_t<T>,
   using std::unique_ptr<std::remove_pointer_t<T>,
                         DeleterImpl<T, Deleter>>::unique_ptr;
 
-  explicit operator T() const { return get(); }
+  explicit operator T() const { return this->get(); }
 };
 
 template <typename SrcT, ze_structure_type_t Type> struct DescWrapper {
@@ -124,7 +124,7 @@ struct Context : public detail::Type<ze_context_handle_t, zeContextDestroy> {
 
   template <typename... Args> static auto create(Args &&...args) {
     return Context(
-        detail::createImpl<ze_context_handle_t, decltype(zeContextCreate),
+        detail::createImpl<ze_context_handle_t, decltype(&zeContextCreate),
                            zeContextCreate, Args...>(
             std::forward<Args>(args)...));
   }
@@ -139,7 +139,7 @@ struct CommandList
   template <typename... Args> static auto createImmediate(Args &&...args) {
     return CommandList(
         detail::createImpl<ze_command_list_handle_t,
-                           decltype(zeCommandListCreateImmediate),
+                           decltype(&zeCommandListCreateImmediate),
                            zeCommandListCreateImmediate, Args...>(
             std::forward<Args>(args)...));
   }
@@ -188,7 +188,7 @@ struct Kernel : public detail::Type<ze_kernel_handle_t, zeKernelDestroy> {
 
   template <typename... Args> static auto create(Args &&...args) {
     return Kernel(
-        detail::createImpl<ze_kernel_handle_t, decltype(zeKernelCreate),
+        detail::createImpl<ze_kernel_handle_t, decltype(&zeKernelCreate),
                            zeKernelCreate, Args...>(
             std::forward<Args>(args)...));
   }
@@ -200,7 +200,7 @@ struct EventPool
 
   template <typename... Args> static auto create(Args &&...args) {
     return EventPool(
-        detail::createImpl<ze_event_pool_handle_t, decltype(zeEventPoolCreate),
+        detail::createImpl<ze_event_pool_handle_t, decltype(&zeEventPoolCreate),
                            zeEventPoolCreate, Args...>(
             std::forward<Args>(args)...));
   }
@@ -212,7 +212,7 @@ struct Event : public detail::Type<ze_event_handle_t, zeEventDestroy> {
   using detail::Type<ze_event_handle_t, zeEventDestroy>::Type;
 
   template <typename... Args> static auto create(Args &&...args) {
-    return Event(detail::createImpl<ze_event_handle_t, decltype(zeEventCreate),
+    return Event(detail::createImpl<ze_event_handle_t, decltype(&zeEventCreate),
                                     zeEventCreate, Args...>(
         std::forward<Args>(args)...));
   }

--- a/dpcomp_gpu_runtime/src/level_zero_wrapper.hpp
+++ b/dpcomp_gpu_runtime/src/level_zero_wrapper.hpp
@@ -87,6 +87,10 @@ auto wrapZeType(ze_device_handle_t src) { return src; }
 
 auto wrapZeType(ze_module_handle_t src) { return src; }
 
+auto wrapZeType(int32_t src) { return src; }
+auto wrapZeType(uint32_t src) { return src; }
+auto wrapZeType(std::nullptr_t src) { return src; }
+
 auto wrapZeType(const ze_device_properties_t &src) {
   return detail::makeDescWrapper<ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES>(src);
 }
@@ -105,6 +109,14 @@ auto wrapZeType(const ze_module_desc_t &src) {
 
 auto wrapZeType(const ze_kernel_desc_t &src) {
   return detail::makeDescWrapper<ZE_STRUCTURE_TYPE_KERNEL_DESC>(src);
+}
+
+auto wrapZeType(const ze_event_pool_desc_t &src) {
+  return detail::makeDescWrapper<ZE_STRUCTURE_TYPE_EVENT_POOL_DESC>(src);
+}
+
+auto wrapZeType(const ze_event_desc_t &src) {
+  return detail::makeDescWrapper<ZE_STRUCTURE_TYPE_EVENT_DESC>(src);
 }
 
 struct Context : public detail::Type<ze_context_handle_t, zeContextDestroy> {
@@ -132,6 +144,8 @@ struct CommandList
             std::forward<Args>(args)...));
   }
 };
+
+CommandList::pointer wrapZeType(const CommandList &src) { return src.get(); }
 
 struct BuildLog : public detail::Type<ze_module_build_log_handle_t,
                                       zeModuleBuildLogDestroy> {
@@ -179,6 +193,32 @@ struct Kernel : public detail::Type<ze_kernel_handle_t, zeKernelDestroy> {
             std::forward<Args>(args)...));
   }
 };
+
+struct EventPool
+    : public detail::Type<ze_event_pool_handle_t, zeEventPoolDestroy> {
+  using detail::Type<ze_event_pool_handle_t, zeEventPoolDestroy>::Type;
+
+  template <typename... Args> static auto create(Args &&...args) {
+    return EventPool(
+        detail::createImpl<ze_event_pool_handle_t, decltype(zeEventPoolCreate),
+                           zeEventPoolCreate, Args...>(
+            std::forward<Args>(args)...));
+  }
+};
+
+EventPool::pointer wrapZeType(const EventPool &src) { return src.get(); }
+
+struct Event : public detail::Type<ze_event_handle_t, zeEventDestroy> {
+  using detail::Type<ze_event_handle_t, zeEventDestroy>::Type;
+
+  template <typename... Args> static auto create(Args &&...args) {
+    return Event(detail::createImpl<ze_event_handle_t, decltype(zeEventCreate),
+                                    zeEventCreate, Args...>(
+        std::forward<Args>(args)...));
+  }
+};
+
+Event::pointer wrapZeType(const Event &src) { return src.get(); }
 
 namespace detail {
 template <typename T> auto wrapZeTypeHelper(T &&arg) {

--- a/dpcomp_gpu_runtime/src/level_zero_wrapper.hpp
+++ b/dpcomp_gpu_runtime/src/level_zero_wrapper.hpp
@@ -1,0 +1,189 @@
+// Copyright 2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include <level_zero/ze_api.h>
+
+namespace {
+
+namespace ze {
+namespace detail {
+
+inline void checkResult(ze_result_t res, const char *func) {
+  if (res != ZE_RESULT_SUCCESS) {
+    throw std::runtime_error(std::string(func) +
+                             " failed: " + std::to_string(res));
+  }
+}
+
+#define CHECK_ZE_RESULT(expr) ze::detail::checkResult((expr), #expr)
+
+template <typename Func, typename InfoFunc>
+auto addInfo(Func &&func, InfoFunc &&infoFunc) {
+  try {
+    return func();
+  } catch (const std::runtime_error &e) {
+    throw std::runtime_error(std::string(e.what()) + infoFunc());
+  }
+}
+
+template <typename T> auto wrapZeTypeHelper(T &&arg);
+
+template <typename T, ze_result_t (*deleter)(T)> struct DeleterImpl {
+  void operator()(T obj) const { deleter(obj); }
+};
+
+template <typename T, typename CreatorT, CreatorT Creator, typename... Args>
+inline auto createImpl(Args &&...args) {
+  T ret;
+  CHECK_ZE_RESULT(Creator(wrapZeTypeHelper(std::forward<Args>(args))..., &ret));
+  return ret;
+}
+
+template <typename T, ze_result_t (*Deleter)(T)>
+struct Type : public std::unique_ptr<std::remove_pointer_t<T>,
+                                     DeleterImpl<T, Deleter>> {
+  using std::unique_ptr<std::remove_pointer_t<T>,
+                        DeleterImpl<T, Deleter>>::unique_ptr;
+
+  explicit operator T() const { return get(); }
+};
+
+template <typename SrcT, ze_structure_type_t Type> struct DescWrapper {
+  DescWrapper(const SrcT &src) : desc(src) { desc.stype = Type; }
+
+  operator SrcT *() { return &desc; }
+
+  SrcT desc;
+};
+
+template <ze_structure_type_t Type, typename SrcT>
+auto makeDescWrapper(const SrcT &arg) {
+  return DescWrapper<SrcT, Type>(arg);
+}
+} // namespace detail
+
+auto wrapZeType(ze_driver_handle_t src) { return src; }
+
+auto wrapZeType(ze_device_handle_t src) { return src; }
+
+auto wrapZeType(ze_module_handle_t src) { return src; }
+
+auto wrapZeType(const ze_device_properties_t &src) {
+  return detail::makeDescWrapper<ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES>(src);
+}
+
+auto wrapZeType(const ze_context_desc_t &src) {
+  return detail::makeDescWrapper<ZE_STRUCTURE_TYPE_CONTEXT_DESC>(src);
+}
+
+auto wrapZeType(const ze_command_queue_desc_t &src) {
+  return detail::makeDescWrapper<ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC>(src);
+}
+
+auto wrapZeType(const ze_module_desc_t &src) {
+  return detail::makeDescWrapper<ZE_STRUCTURE_TYPE_MODULE_DESC>(src);
+}
+
+auto wrapZeType(const ze_kernel_desc_t &src) {
+  return detail::makeDescWrapper<ZE_STRUCTURE_TYPE_KERNEL_DESC>(src);
+}
+
+struct Context : public detail::Type<ze_context_handle_t, zeContextDestroy> {
+  using detail::Type<ze_context_handle_t, zeContextDestroy>::Type;
+
+  template <typename... Args> static auto create(Args &&...args) {
+    return Context(
+        detail::createImpl<ze_context_handle_t, decltype(zeContextCreate),
+                           zeContextCreate, Args...>(
+            std::forward<Args>(args)...));
+  }
+};
+
+Context::pointer wrapZeType(const Context &src) { return src.get(); }
+
+struct CommandList
+    : public detail::Type<ze_command_list_handle_t, zeCommandListDestroy> {
+  using detail::Type<ze_command_list_handle_t, zeCommandListDestroy>::Type;
+
+  template <typename... Args> static auto createImmediate(Args &&...args) {
+    return CommandList(
+        detail::createImpl<ze_command_list_handle_t,
+                           decltype(zeCommandListCreateImmediate),
+                           zeCommandListCreateImmediate, Args...>(
+            std::forward<Args>(args)...));
+  }
+};
+
+struct BuildLog : public detail::Type<ze_module_build_log_handle_t,
+                                      zeModuleBuildLogDestroy> {
+  using detail::Type<ze_module_build_log_handle_t,
+                     zeModuleBuildLogDestroy>::Type;
+};
+
+struct Module : public detail::Type<ze_module_handle_t, zeModuleDestroy> {
+  using detail::Type<ze_module_handle_t, zeModuleDestroy>::Type;
+
+  template <typename... Args> static auto create(Args &&...args) {
+    ze_module_handle_t mod;
+    ze_module_build_log_handle_t log;
+    detail::addInfo(
+        [&]() {
+          CHECK_ZE_RESULT(zeModuleCreate(
+              detail::wrapZeTypeHelper(std::forward<Args>(args))..., &mod,
+              &log));
+        },
+        [&]() {
+          BuildLog bl(log);
+          size_t size = 0;
+          CHECK_ZE_RESULT(zeModuleBuildLogGetString(bl.get(), &size, nullptr));
+          std::string log;
+          log.resize(size + 1);
+          log[0] = '\n';
+          // TODO: need C++17 for std::string mutable data
+          CHECK_ZE_RESULT(zeModuleBuildLogGetString(
+              bl.get(), &size, const_cast<char *>(log.data()) + 1));
+          if (log.back() == '\0')
+            log.pop_back();
+          return log;
+        });
+    return std::make_pair(Module(mod), BuildLog(log));
+  }
+};
+
+struct Kernel : public detail::Type<ze_kernel_handle_t, zeKernelDestroy> {
+  using detail::Type<ze_kernel_handle_t, zeKernelDestroy>::Type;
+
+  template <typename... Args> static auto create(Args &&...args) {
+    return Kernel(
+        detail::createImpl<ze_kernel_handle_t, decltype(zeKernelCreate),
+                           zeKernelCreate, Args...>(
+            std::forward<Args>(args)...));
+  }
+};
+
+namespace detail {
+template <typename T> auto wrapZeTypeHelper(T &&arg) {
+  return ::ze::wrapZeType(std::forward<T>(arg));
+}
+} // namespace detail
+} // namespace ze
+} // namespace

--- a/dpcomp_runtime/CMakeLists.txt
+++ b/dpcomp_runtime/CMakeLists.txt
@@ -17,9 +17,11 @@ project(dpcomp-runtime LANGUAGES CXX C)
 include(GenerateExportHeader)
 
 find_package(TBB REQUIRED)
+find_package(MLIR REQUIRED CONFIG)
 
 set(SOURCES_LIST
     src/tbb_parallel.cpp
+    src/memory.cpp
     )
 set(HEADERS_LIST
     )
@@ -27,7 +29,9 @@ set(HEADERS_LIST
 add_library(${PROJECT_NAME} SHARED ${SOURCES_LIST} ${HEADERS_LIST})
 generate_export_header(${PROJECT_NAME})
 
-target_include_directories(${PROJECT_NAME} PRIVATE
+target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE
+    ${MLIR_INCLUDE_DIRS}
+    PRIVATE
     ${PROJECT_BINARY_DIR}
     )
 

--- a/dpcomp_runtime/src/memory.cpp
+++ b/dpcomp_runtime/src/memory.cpp
@@ -14,6 +14,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <malloc.h>
 
 #define mlir_c_runner_utils_EXPORTS 1
 #include <mlir/ExecutionEngine/CRunnerUtils.h>

--- a/dpcomp_runtime/src/memory.cpp
+++ b/dpcomp_runtime/src/memory.cpp
@@ -1,0 +1,81 @@
+// Copyright 2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdint>
+#include <cstring>
+
+#define mlir_c_runner_utils_EXPORTS 1
+#include <mlir/ExecutionEngine/CRunnerUtils.h>
+
+#include "dpcomp-runtime_export.h"
+
+extern "C" DPCOMP_RUNTIME_EXPORT void
+memrefCopy(int64_t elemSize, UnrankedMemRefType<char> *srcArg,
+           UnrankedMemRefType<char> *dstArg) {
+  DynamicMemRefType<char> src(*srcArg);
+  DynamicMemRefType<char> dst(*dstArg);
+
+  int64_t rank = src.rank;
+  // Handle empty shapes -> nothing to copy.
+  for (int rankp = 0; rankp < rank; ++rankp)
+    if (src.sizes[rankp] == 0)
+      return;
+
+  char *srcPtr = src.data + src.offset * elemSize;
+  char *dstPtr = dst.data + dst.offset * elemSize;
+
+  if (rank == 0) {
+    memcpy(dstPtr, srcPtr, static_cast<size_t>(elemSize));
+    return;
+  }
+
+  int64_t *indices = static_cast<int64_t *>(
+      alloca(sizeof(int64_t) * static_cast<size_t>(rank)));
+  int64_t *srcStrides = static_cast<int64_t *>(
+      alloca(sizeof(int64_t) * static_cast<size_t>(rank)));
+  int64_t *dstStrides = static_cast<int64_t *>(
+      alloca(sizeof(int64_t) * static_cast<size_t>(rank)));
+
+  // Initialize index and scale strides.
+  for (int rankp = 0; rankp < rank; ++rankp) {
+    indices[rankp] = 0;
+    srcStrides[rankp] = src.strides[rankp] * elemSize;
+    dstStrides[rankp] = dst.strides[rankp] * elemSize;
+  }
+
+  int64_t readIndex = 0, writeIndex = 0;
+  for (;;) {
+    // Copy over the element, byte by byte.
+    memcpy(dstPtr + writeIndex, srcPtr + readIndex,
+           static_cast<size_t>(elemSize));
+    // Advance index and read position.
+    for (int64_t axis = rank - 1; axis >= 0; --axis) {
+      // Advance at current axis.
+      auto newIndex = ++indices[axis];
+      readIndex += srcStrides[axis];
+      writeIndex += dstStrides[axis];
+      // If this is a valid index, we have our next index, so continue copying.
+      if (src.sizes[axis] != newIndex)
+        break;
+      // We reached the end of this axis. If this is axis 0, we are done.
+      if (axis == 0)
+        return;
+      // Else, reset to 0 and undo the advancement of the linear index that
+      // this axis had. Then continue with the axis one outer.
+      indices[axis] = 0;
+      readIndex -= src.sizes[axis] * srcStrides[axis];
+      writeIndex -= dst.sizes[axis] * dstStrides[axis];
+    }
+  }
+}

--- a/numba_dpcomp/decorators.py
+++ b/numba_dpcomp/decorators.py
@@ -16,7 +16,7 @@
 Define @jit and related decorators.
 """
 
-from .mlir.compiler import mlir_compiler_pipeline
+from .mlir.compiler import mlir_compiler_pipeline, mlir_compiler_gpu_pipeline
 from .mlir.vectorize import vectorize as mlir_vectorize
 from .mlir.settings import USE_MLIR
 
@@ -27,10 +27,12 @@ from numba.np.ufunc import vectorize as orig_vectorize
 if USE_MLIR:
     def jit(signature_or_function=None, locals={}, cache=False,
             pipeline_class=None, boundscheck=False, **options):
+        pipeline = mlir_compiler_gpu_pipeline if options.get('enable_gpu_pipeline') else mlir_compiler_pipeline
+        options.pop('enable_gpu_pipeline', None)
         return orig_jit(signature_or_function=signature_or_function,
                         locals=locals,
                         cache=cache,
-                        pipeline_class=mlir_compiler_pipeline,
+                        pipeline_class=pipeline,
                         boundscheck=boundscheck,
                         **options)
 

--- a/numba_dpcomp/mlir/gpu_runtime.py
+++ b/numba_dpcomp/mlir/gpu_runtime.py
@@ -17,6 +17,8 @@ import atexit
 import llvmlite.binding as ll
 from .utils import load_lib, mlir_func_name
 
+from numba.core.runtime import _nrt_python as _nrt
+
 runtime_lib = load_lib('dpcomp-gpu-runtime')
 assert not runtime_lib is None
 
@@ -29,8 +31,14 @@ _funcs = [
     'dpcompGpuKernelDestroy',
     'dpcompGpuLaunchKernel',
     'dpcompGpuWait',
+    'dpcompGpuAlloc',
 ]
 
 for name in _funcs:
     func = getattr(runtime_lib, name)
     ll.add_symbol(name, ctypes.cast(func, ctypes.c_void_p).value)
+
+
+_alloc_func = runtime_lib.dpcompGpuSetMemInfoAllocFunc
+_alloc_func.argtypes = [ctypes.c_void_p]
+_alloc_func(ctypes.cast(_nrt.c_helpers['Allocate'], ctypes.c_void_p))

--- a/numba_dpcomp/mlir/gpu_runtime.py
+++ b/numba_dpcomp/mlir/gpu_runtime.py
@@ -19,25 +19,30 @@ from .utils import load_lib, mlir_func_name
 
 from numba.core.runtime import _nrt_python as _nrt
 
-runtime_lib = load_lib('dpcomp-gpu-runtime')
+try:
+    runtime_lib = load_lib('dpcomp-gpu-runtime')
+    IS_GPU_RUNTIME_AVAILABLE = True
+except:
+    IS_GPU_RUNTIME_AVAILABLE = False
 
-_funcs = [
-    'dpcompGpuStreamCreate',
-    'dpcompGpuStreamDestroy',
-    'dpcompGpuModuleLoad',
-    'dpcompGpuModuleDestroy',
-    'dpcompGpuKernelGet',
-    'dpcompGpuKernelDestroy',
-    'dpcompGpuLaunchKernel',
-    'dpcompGpuWait',
-    'dpcompGpuAlloc',
-]
+if IS_GPU_RUNTIME_AVAILABLE:
+    _funcs = [
+        'dpcompGpuStreamCreate',
+        'dpcompGpuStreamDestroy',
+        'dpcompGpuModuleLoad',
+        'dpcompGpuModuleDestroy',
+        'dpcompGpuKernelGet',
+        'dpcompGpuKernelDestroy',
+        'dpcompGpuLaunchKernel',
+        'dpcompGpuWait',
+        'dpcompGpuAlloc',
+    ]
 
-for name in _funcs:
-    func = getattr(runtime_lib, name)
-    ll.add_symbol(name, ctypes.cast(func, ctypes.c_void_p).value)
+    for name in _funcs:
+        func = getattr(runtime_lib, name)
+        ll.add_symbol(name, ctypes.cast(func, ctypes.c_void_p).value)
 
 
-_alloc_func = runtime_lib.dpcompGpuSetMemInfoAllocFunc
-_alloc_func.argtypes = [ctypes.c_void_p]
-_alloc_func(ctypes.cast(_nrt.c_helpers['Allocate'], ctypes.c_void_p))
+    _alloc_func = runtime_lib.dpcompGpuSetMemInfoAllocFunc
+    _alloc_func.argtypes = [ctypes.c_void_p]
+    _alloc_func(ctypes.cast(_nrt.c_helpers['Allocate'], ctypes.c_void_p))

--- a/numba_dpcomp/mlir/gpu_runtime.py
+++ b/numba_dpcomp/mlir/gpu_runtime.py
@@ -21,13 +21,14 @@ runtime_lib = load_lib('dpcomp-gpu-runtime')
 assert not runtime_lib is None
 
 _funcs = [
-    'mgpuModuleLoad',
-    'mgpuModuleGetFunction',
-    'mgpuStreamCreate',
-    'mgpuLaunchKernel',
-    'mgpuStreamSynchronize',
-    'mgpuStreamDestroy',
-    'mgpuModuleUnload',
+    'dpcompGpuStreamCreate',
+    'dpcompGpuStreamDestroy',
+    'dpcompGpuModuleLoad',
+    'dpcompGpuModuleDestroy',
+    'dpcompGpuKernelGet',
+    'dpcompGpuKernelDestroy',
+    'dpcompGpuLaunchKernel',
+    'dpcompGpuWait',
 ]
 
 for name in _funcs:

--- a/numba_dpcomp/mlir/gpu_runtime.py
+++ b/numba_dpcomp/mlir/gpu_runtime.py
@@ -20,7 +20,6 @@ from .utils import load_lib, mlir_func_name
 from numba.core.runtime import _nrt_python as _nrt
 
 runtime_lib = load_lib('dpcomp-gpu-runtime')
-assert not runtime_lib is None
 
 _funcs = [
     'dpcompGpuStreamCreate',

--- a/numba_dpcomp/mlir/gpu_runtime.py
+++ b/numba_dpcomp/mlir/gpu_runtime.py
@@ -1,0 +1,35 @@
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ctypes
+import atexit
+import llvmlite.binding as ll
+from .utils import load_lib, mlir_func_name
+
+runtime_lib = load_lib('dpcomp-gpu-runtime')
+assert not runtime_lib is None
+
+_funcs = [
+    'mgpuModuleLoad',
+    'mgpuModuleGetFunction',
+    'mgpuStreamCreate',
+    'mgpuLaunchKernel',
+    'mgpuStreamSynchronize',
+    'mgpuStreamDestroy',
+    'mgpuModuleUnload',
+]
+
+for name in _funcs:
+    func = getattr(runtime_lib, name)
+    ll.add_symbol(name, ctypes.cast(func, ctypes.c_void_p).value)

--- a/numba_dpcomp/mlir/kernel_impl.py
+++ b/numba_dpcomp/mlir/kernel_impl.py
@@ -68,14 +68,16 @@ def _kernel_body1(global_size, local_size, body, *args):
         body(*args)
 
 def _kernel_body2(global_size, local_size, body, *args):
-    for i in _gpu_range(global_size[0]):
-        for j in _gpu_range(global_size[1]):
+    x, y = global_size
+    for i in _gpu_range(x):
+        for j in _gpu_range(y):
             body(*args)
 
 def _kernel_body3(global_size, local_size, body, *args):
-    for i in _gpu_range(global_size[0]):
-        for j in _gpu_range(global_size[1]):
-            for k in _gpu_range(global_size[2]):
+    x, y, z = global_size
+    for i in _gpu_range(x):
+        for j in _gpu_range(y):
+            for k in _gpu_range(z):
                 body(*args)
 
 _kernel_body_selector = [

--- a/numba_dpcomp/mlir/kernel_impl.py
+++ b/numba_dpcomp/mlir/kernel_impl.py
@@ -102,6 +102,10 @@ class Kernel:
         ret.local_size = local_size
         return ret
 
+    def check_call_args(self, args, kwargs):
+        if kwargs:
+            _raise_error('kwargs not supported')
+
     def __getitem__(self, args):
         nargs = len(args)
         if nargs < 1 or nargs > 2:
@@ -112,8 +116,7 @@ class Kernel:
         return self.configure(gs, ls)
 
     def __call__(self, *args, **kwargs):
-        if kwargs:
-            _raise_error('kwargs not supported')
+        self.check_call_args(args, kwargs)
 
         jit_func = njit(parallel=True, inline='always')(self.py_func)
         jit_kern = njit(parallel=True, enable_gpu_pipeline=True)(_kernel_body_selector[len(self.global_size)])

--- a/numba_dpcomp/mlir/kernel_impl.py
+++ b/numba_dpcomp/mlir/kernel_impl.py
@@ -17,7 +17,7 @@ import copy
 from numba import prange
 from numba.core import types
 from numba.core.typing.templates import ConcreteTemplate, signature, infer_global
-from numba_dpcomp.mlir.func_registry import add_func
+from .linalg_builder import register_func, is_int
 
 from ..decorators import njit
 
@@ -107,4 +107,8 @@ def get_global_id(axis):
 class GetGlobalId(ConcreteTemplate):
     cases = [signature(types.uint64, types.uint64)]
 
-add_func(get_global_id, 'get_global_id')
+@register_func('get_global_id', get_global_id)
+def get_global_id_impl(builder, axis):
+    if isinstance(axis, int) or is_int(axis):
+        res = 0
+        return builder.external_call('get_global_id', axis, res)

--- a/numba_dpcomp/mlir/kernel_impl.py
+++ b/numba_dpcomp/mlir/kernel_impl.py
@@ -1,0 +1,110 @@
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+
+from numba import prange
+from numba.core import types
+from numba.core.typing.templates import ConcreteTemplate, signature, infer_global
+from numba_dpcomp.mlir.func_registry import add_func
+
+from ..decorators import njit
+
+def _raise_error(desc):
+    raise ValueError(desc)
+
+def _process_dims(dims):
+    if isinstance(dims, int):
+        return (dims,)
+    elif isinstance(dims, (list, tuple)):
+        n = len(dims)
+        if n > 3:
+            _raise_error(f'Invalid dimentions count: {n}')
+        return tuple(dims)
+    else:
+        _raise_error(f'Invalid dimentions type: {type(dims)}')
+
+def _kernel_body0(global_size, local_size, body, *args):
+    body(*args)
+
+def _kernel_body1(global_size, local_size, body, *args):
+    for i in prange(global_size[0]):
+        body(*args)
+
+def _kernel_body2(global_size, local_size, body, *args):
+    for i in prange(global_size[0]):
+        for j in prange(global_size[1]):
+            body(*args)
+
+def _kernel_body3(global_size, local_size, body, *args):
+    for i in prange(global_size[0]):
+        for j in prange(global_size[1]):
+            for k in prange(global_size[2]):
+                body(*args)
+
+_kernel_body_selector = [
+    _kernel_body0,
+    _kernel_body1,
+    _kernel_body2,
+    _kernel_body3,
+]
+
+class Kernel:
+    def __init__(self, func):
+        self.global_size = ()
+        self.local_size = ()
+        self.py_func = func
+
+    def copy(self):
+        return copy.copy(self)
+
+    def configure(self, global_size, local_size):
+        ret = self.copy()
+        ret.global_size = global_size
+        ret.local_size = local_size
+        return ret
+
+    def __getitem__(self, args):
+        nargs = len(args)
+        if nargs < 1 or nargs > 2:
+            _raise_error(f'Invalid kernel arguments count: {nargs}')
+
+        gs = _process_dims(args[0])
+        ls = _process_dims(args[1]) if nargs > 1 else ()
+        return self.configure(gs, ls)
+
+    def __call__(self, *args, **kwargs):
+        if kwargs:
+            _raise_error('kwargs not supported')
+
+        jit_func = njit(parallel=True, inline='always')(self.py_func)
+        jit_kern = njit(parallel=True)(_kernel_body_selector[len(self.global_size)])
+        jit_kern(self.global_size, self.local_size, jit_func, *args)
+
+
+def kernel(func):
+    return Kernel(func)
+
+def _stub_error():
+    raise NotImplementedError('This is a stub')
+
+def get_global_id(axis):
+    _stub_error()
+
+
+@infer_global(get_global_id)
+class GetGlobalId(ConcreteTemplate):
+    cases = [signature(types.uint64, types.uint64)]
+
+add_func(get_global_id, 'get_global_id')

--- a/numba_dpcomp/mlir/kernel_impl.py
+++ b/numba_dpcomp/mlir/kernel_impl.py
@@ -106,7 +106,7 @@ class Kernel:
         if kwargs:
             _raise_error('kwargs not supported')
 
-    def __getitem__(self, args):
+    def __getitem__(self, *args):
         nargs = len(args)
         if nargs < 1 or nargs > 2:
             _raise_error(f'Invalid kernel arguments count: {nargs}')
@@ -118,8 +118,8 @@ class Kernel:
     def __call__(self, *args, **kwargs):
         self.check_call_args(args, kwargs)
 
-        jit_func = njit(parallel=True, inline='always')(self.py_func)
-        jit_kern = njit(parallel=True, enable_gpu_pipeline=True)(_kernel_body_selector[len(self.global_size)])
+        jit_func = njit(inline='always')(self.py_func)
+        jit_kern = njit(enable_gpu_pipeline=True)(_kernel_body_selector[len(self.global_size)])
         jit_kern(self.global_size, self.local_size, jit_func, *args)
 
 

--- a/numba_dpcomp/mlir/kernel_impl.py
+++ b/numba_dpcomp/mlir/kernel_impl.py
@@ -116,7 +116,7 @@ class Kernel:
             _raise_error('kwargs not supported')
 
         jit_func = njit(parallel=True, inline='always')(self.py_func)
-        jit_kern = njit(parallel=True)(_kernel_body_selector[len(self.global_size)])
+        jit_kern = njit(parallel=True, enable_gpu_pipeline=True)(_kernel_body_selector[len(self.global_size)])
         jit_kern(self.global_size, self.local_size, jit_func, *args)
 
 

--- a/numba_dpcomp/mlir/kernel_sim.py
+++ b/numba_dpcomp/mlir/kernel_sim.py
@@ -1,0 +1,75 @@
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+from collections import namedtuple
+from itertools import product
+
+from .kernel_impl import Kernel as OrigKernel
+
+_execution_state = None
+
+
+_ExecutionState = namedtuple('_ExecutionState', [
+    'global_size',
+    'local_size',
+    'indices',
+    ])
+
+
+def get_global_id_proxy(index):
+    global _execution_state
+    assert _execution_state is not None
+    return _execution_state.indices[index]
+
+
+def _setup_execution_state(global_size, local_size):
+    import numba_dpcomp.mlir.kernel_impl
+    global _execution_state
+    assert _execution_state is None
+    _execution_state =_ExecutionState(
+        global_size=global_size,
+        local_size=local_size,
+        indices=[0]*len(global_size))
+    return _execution_state
+
+
+def _destroy_execution_state():
+    global _execution_state
+    _execution_state = None
+
+def _execute_kernel(global_size, local_size, func, *args):
+    func_copy = copy.copy(func)
+    func_copy.__globals__['get_global_id'] = get_global_id_proxy
+    state = _setup_execution_state(global_size, local_size)
+    try:
+        for indices in product(*(range(d) for d in global_size)):
+            state.indices[:] = indices
+            func_copy(*args)
+    finally:
+        _destroy_execution_state()
+
+
+class Kernel(OrigKernel):
+    def __init__(self, func):
+        super().__init__(func)
+
+    def __call__(self, *args, **kwargs):
+        self.check_call_args(args, kwargs)
+
+        _execute_kernel(self.global_size, self.local_size, self.py_func, *args)
+
+
+def kernel(func):
+    return Kernel(func)

--- a/numba_dpcomp/mlir/lowering.py
+++ b/numba_dpcomp/mlir/lowering.py
@@ -29,6 +29,7 @@ from numba.core.typed_passes import NoPythonBackend as orig_NoPythonBackend
 
 from .runtime import *
 from .math_runtime import *
+from .gpu_runtime import *
 
 class mlir_lower(orig_Lower):
     def lower(self):

--- a/numba_dpcomp/mlir/math_runtime.py
+++ b/numba_dpcomp/mlir/math_runtime.py
@@ -18,7 +18,6 @@ import llvmlite.binding as ll
 from .utils import load_lib, mlir_func_name
 
 runtime_lib = load_lib('dpcomp-math-runtime')
-assert not runtime_lib is None
 
 _init_func = runtime_lib.dpcomp_math_runtime_init
 _init_func()

--- a/numba_dpcomp/mlir/runtime.py
+++ b/numba_dpcomp/mlir/runtime.py
@@ -19,7 +19,6 @@ import llvmlite.binding as ll
 from .utils import load_lib
 
 runtime_lib = load_lib('dpcomp-runtime')
-assert not runtime_lib is None
 
 _init_func = runtime_lib.dpcomp_parallel_init
 _init_func.argtypes = [ctypes.c_int]

--- a/numba_dpcomp/mlir/runtime.py
+++ b/numba_dpcomp/mlir/runtime.py
@@ -27,8 +27,14 @@ _init_func(get_thread_count())
 
 _finalize_func = runtime_lib.dpcomp_parallel_finalize
 
-_parallel_for_func = runtime_lib.dpcomp_parallel_for
-ll.add_symbol('dpcomp_parallel_for', ctypes.cast(_parallel_for_func, ctypes.c_void_p).value)
+_funcs = [
+    'dpcomp_parallel_for',
+    'memrefCopy',
+]
+
+for name in _funcs:
+    func = getattr(runtime_lib, name)
+    ll.add_symbol(name, ctypes.cast(func, ctypes.c_void_p).value)
 
 @atexit.register
 def _cleanup():

--- a/numba_dpcomp/mlir/tests/test_gpu.py
+++ b/numba_dpcomp/mlir/tests/test_gpu.py
@@ -1,0 +1,56 @@
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from numpy.testing import assert_equal
+import numpy as np
+
+from numba_dpcomp.mlir.settings import _readenv
+from numba_dpcomp.mlir.kernel_impl import kernel, get_global_id
+from numba_dpcomp.mlir.kernel_sim import kernel as kernel_sim
+from numba_dpcomp.mlir.passes import print_pass_ir, get_print_buffer
+
+GPU_TESTS_ENABLED = _readenv('DPCOMP_ENABLE_GPU_TESTS', int, 0)
+
+def require_gpu(func):
+    return pytest.mark.skipif(not GPU_TESTS_ENABLED, reason='GPU tests disabled')(func)
+
+@require_gpu
+def test_simple():
+    def func(a, b, c):
+        i = get_global_id(0)
+        j = get_global_id(1)
+        k = get_global_id(2)
+        c[i, j, k] = a[i, j, k] + b[i, j, k]
+
+    sim_func = kernel_sim(func)
+    gpu_func = kernel(func)
+
+    a = np.array([[[1,2,3],[4,5,6]]], np.float32)
+    b = np.array([[[7,8,9],[10,11,12]]], np.float32)
+
+    sim_res = np.zeros(a.shape, a.dtype)
+    sim_func[a.shape](a, b, sim_res)
+
+    gpu_res = np.zeros(a.shape, a.dtype)
+
+    with print_pass_ir([],['ConvertParallelLoopToGpu']):
+        gpu_func[a.shape](a, b, gpu_res)
+        ir = get_print_buffer()
+        assert ir.count('gpu.launch blocks') == 1, ir
+
+    assert_equal(gpu_res, sim_res)
+
+

--- a/numba_dpcomp/mlir/utils.py
+++ b/numba_dpcomp/mlir/utils.py
@@ -34,16 +34,17 @@ def load_lib(name):
     elif sys.platform.startswith('win'):
         lib_name = f'{name}.dll'
     else:
-        return None
+        assert False, 'unsupported platform'
 
+    saved_errors = []
     for path in runtime_search_paths:
         lib_path = lib_name if len(path) == 0 else os.path.join(path, lib_name)
         try:
             return ctypes.CDLL(lib_path)
-        except:
-            pass
+        except Exception as e:
+            saved_errors.append(f'CDLL(\"{lib_path}\"): {str(e)}')
 
-    return None
+    raise ValueError(f'load_lib(\"{name}\") failed:\n' + '\n'.join(saved_errors))
 
 def mlir_func_name(name):
     return '_mlir_ciface_' + name

--- a/numba_dpcomp/mlir_compiler/CMakeLists.txt
+++ b/numba_dpcomp/mlir_compiler/CMakeLists.txt
@@ -101,3 +101,7 @@ target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE
 if(${DPNP_ENABLE})
     target_compile_definitions(${PROJECT_NAME} PRIVATE DPNP_ENABLE=1)
 endif()
+
+if(${GPU_ENABLE})
+    target_compile_definitions(${PROJECT_NAME} PRIVATE GPU_ENABLE=1)
+endif()

--- a/numba_dpcomp/mlir_compiler/CMakeLists.txt
+++ b/numba_dpcomp/mlir_compiler/CMakeLists.txt
@@ -87,6 +87,8 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     MLIRSCFToStandard
     MLIRSCFToGPU
     MLIRGPUToSPIRV
+    MLIRGPUToGPURuntimeTransforms
+    MLIRSPIRVTransforms
     MLIRTensorTransforms
     )
 

--- a/numba_dpcomp/mlir_compiler/CMakeLists.txt
+++ b/numba_dpcomp/mlir_compiler/CMakeLists.txt
@@ -28,6 +28,7 @@ include(HandleLLVMOptions)
 
 set(SOURCES_LIST
     src/pipelines/base_pipeline.cpp
+    src/pipelines/lower_to_gpu.cpp
     src/pipelines/lower_to_llvm.cpp
     src/pipelines/parallel_to_tbb.cpp
     src/pipelines/plier_to_linalg.cpp
@@ -43,6 +44,7 @@ set(SOURCES_LIST
     )
 set(HEADERS_LIST
     src/pipelines/base_pipeline.hpp
+    src/pipelines/lower_to_gpu.hpp
     src/pipelines/lower_to_llvm.hpp
     src/pipelines/parallel_to_tbb.hpp
     src/pipelines/plier_to_linalg.hpp
@@ -83,6 +85,8 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     MLIRLinalgToLLVM
     MLIRMathToLLVM
     MLIRSCFToStandard
+    MLIRSCFToGPU
+    MLIRGPUToSPIRV
     MLIRTensorTransforms
     )
 

--- a/numba_dpcomp/mlir_compiler/CMakeLists.txt
+++ b/numba_dpcomp/mlir_compiler/CMakeLists.txt
@@ -89,6 +89,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     MLIRGPUToSPIRV
     MLIRGPUToGPURuntimeTransforms
     MLIRSPIRVTransforms
+    MLIRSPIRVSerialization
     MLIRTensorTransforms
     )
 

--- a/numba_dpcomp/mlir_compiler/src/lowering.cpp
+++ b/numba_dpcomp/mlir_compiler/src/lowering.cpp
@@ -683,8 +683,13 @@ void create_pipeline(plier::PipelineRegistry &registry,
   registerPreLowSimpleficationsPipeline(registry);
   registerParallelToTBBPipeline(registry);
 
-  if (settings.enableGpuPipeline)
+  if (settings.enableGpuPipeline) {
+#ifdef GPU_ENABLE
     registerLowerToGPUPipeline(registry);
+#else
+    plier::report_error("DPCOMP was compiled without GPU support");
+#endif
+  }
 }
 
 struct Module {

--- a/numba_dpcomp/mlir_compiler/src/lowering.cpp
+++ b/numba_dpcomp/mlir_compiler/src/lowering.cpp
@@ -39,6 +39,7 @@
 #include "plier/utils.hpp"
 
 #include "pipelines/base_pipeline.hpp"
+#include "pipelines/lower_to_gpu.hpp"
 #include "pipelines/lower_to_llvm.hpp"
 #include "pipelines/parallel_to_tbb.hpp"
 #include "pipelines/plier_to_linalg.hpp"
@@ -672,6 +673,7 @@ py::bytes gen_ll_module(mlir::ModuleOp mod) {
 void create_pipeline(plier::PipelineRegistry &registry) {
   registerBasePipeline(registry);
   registerLowerToLLVMPipeline(registry);
+  registerLowerToGPUPipeline(registry);
   registerPlierToStdPipeline(registry);
   registerPlierToLinalgPipeline(registry);
   registerPreLowSimpleficationsPipeline(registry);

--- a/numba_dpcomp/mlir_compiler/src/lowering.hpp
+++ b/numba_dpcomp/mlir_compiler/src/lowering.hpp
@@ -24,7 +24,7 @@ class dict;
 
 void init_compiler(pybind11::dict settings);
 
-pybind11::capsule create_module();
+pybind11::capsule create_module(pybind11::dict settings);
 
 pybind11::capsule lower_function(const pybind11::object &compilation_context,
                                  const pybind11::capsule &py_mod,

--- a/numba_dpcomp/mlir_compiler/src/pipelines/lower_to_gpu.cpp
+++ b/numba_dpcomp/mlir_compiler/src/pipelines/lower_to_gpu.cpp
@@ -16,6 +16,7 @@
 
 #include <mlir/Conversion/AffineToStandard/AffineToStandard.h>
 #include <mlir/Conversion/GPUToSPIRV/GPUToSPIRVPass.h>
+#include <mlir/Conversion/GPUCommon/GPUCommonPass.h>
 #include <mlir/Conversion/SCFToGPU/SCFToGPUPass.h>
 #include <mlir/Dialect/Affine/IR/AffineOps.h>
 #include <mlir/Dialect/GPU/ParallelLoopMapper.h>
@@ -23,6 +24,9 @@
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/SCF.h>
 #include <mlir/Dialect/SPIRV/IR/TargetAndABI.h>
+#include <mlir/Dialect/SPIRV/IR/SPIRVOps.h>
+#include <mlir/Dialect/SPIRV/IR/SPIRVDialect.h>
+#include <mlir/Dialect/SPIRV/Transforms/Passes.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 #include <mlir/Transforms/Passes.h>
@@ -223,6 +227,11 @@ static void populateLowerToGPUPipeline(mlir::OpPassManager &pm) {
   pm.addNestedPass<mlir::gpu::GPUModuleOp>(std::make_unique<AbiAttrsPass>());
   pm.addPass(std::make_unique<SetSPIRVCapabilitiesPass>());
   pm.addPass(mlir::createConvertGPUToSPIRVPass());
+  pm.addPass(mlir::createCanonicalizerPass());
+  auto &modulePM = pm.nest<mlir::spirv::ModuleOp>();
+  modulePM.addPass(mlir::spirv::createLowerABIAttributesPass());
+  modulePM.addPass(mlir::spirv::createUpdateVersionCapabilityExtensionPass());
+//  pm.addPass(mlir::createGpuToLLVMConversionPass());
   pm.addPass(mlir::createCanonicalizerPass());
 }
 } // namespace

--- a/numba_dpcomp/mlir_compiler/src/pipelines/lower_to_gpu.cpp
+++ b/numba_dpcomp/mlir_compiler/src/pipelines/lower_to_gpu.cpp
@@ -594,7 +594,7 @@ struct GPUToSpirvPass
     auto target = mlir::SPIRVConversionTarget::get(targetAttr);
 
     mlir::SPIRVTypeConverter::Options options;
-    //    options.use64bitIndex = true;
+    options.use64bitIndex = true;
 
     mlir::SPIRVTypeConverter typeConverter(targetAttr, options);
     mlir::RewritePatternSet patterns(context);

--- a/numba_dpcomp/mlir_compiler/src/pipelines/lower_to_gpu.cpp
+++ b/numba_dpcomp/mlir_compiler/src/pipelines/lower_to_gpu.cpp
@@ -14,19 +14,24 @@
 
 #include "pipelines/lower_to_gpu.hpp"
 
+#include <mlir/Conversion/AffineToStandard/AffineToStandard.h>
 #include <mlir/Conversion/GPUToSPIRV/GPUToSPIRVPass.h>
 #include <mlir/Conversion/SCFToGPU/SCFToGPUPass.h>
+#include <mlir/Dialect/Affine/IR/AffineOps.h>
 #include <mlir/Dialect/GPU/ParallelLoopMapper.h>
 #include <mlir/Dialect/GPU/Passes.h>
+#include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/SCF.h>
 #include <mlir/Dialect/SPIRV/IR/TargetAndABI.h>
 #include <mlir/Pass/PassManager.h>
+#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 #include <mlir/Transforms/Passes.h>
 
 #include "base_pipeline.hpp"
 #include "pipelines/lower_to_llvm.hpp"
 
 #include "plier/compiler/pipeline_registry.hpp"
+#include "plier/dialect.hpp"
 
 namespace {
 struct ParallelLoopGPUMappingPass
@@ -38,6 +43,126 @@ struct ParallelLoopGPUMappingPass
 
   void runOnFunction() override {
     mlir::greedilyMapParallelSCFToGPU(getFunction().getBody());
+  }
+};
+
+static void setInsertionPointToStart(mlir::OpBuilder &builder,
+                                     mlir::Value val) {
+  if (auto parentOp = val.getDefiningOp()) {
+    builder.setInsertionPointAfter(parentOp);
+  } else {
+    builder.setInsertionPointToStart(val.getParentBlock());
+  }
+}
+
+static mlir::Value getFlatIndex(mlir::OpBuilder &builder, mlir::Location loc,
+                                mlir::Value memref, mlir::ValueRange indices) {
+  auto memrefType = memref.getType().cast<mlir::MemRefType>();
+  auto rank = static_cast<unsigned>(memrefType.getRank());
+  assert(memrefType.getAffineMaps().size() <= 1);
+  auto affineMap =
+      memrefType.getAffineMaps().empty()
+          ? mlir::AffineMap::getMultiDimIdentityMap(rank, builder.getContext())
+          : memrefType.getAffineMaps()[0];
+  assert(indices.size() == rank);
+  llvm::SmallVector<mlir::Value> applyOperands(rank * 2 + 1);
+  {
+    mlir::OpBuilder::InsertionGuard g(builder);
+    setInsertionPointToStart(builder, memref);
+    llvm::copy(indices, applyOperands.begin());
+    applyOperands[rank] =
+        builder.createOrFold<plier::ExtractMemrefMetadataOp>(loc, memref);
+    auto strides =
+        llvm::MutableArrayRef<mlir::Value>(applyOperands).drop_front(rank + 1);
+    for (auto i : llvm::seq(0u, rank)) {
+      strides[i] =
+          builder.createOrFold<plier::ExtractMemrefMetadataOp>(loc, memref, i);
+    }
+  }
+  return builder.createOrFold<mlir::AffineApplyOp>(loc, affineMap,
+                                                   applyOperands);
+}
+
+static mlir::Value getFlatMemref(mlir::OpBuilder &builder, mlir::Location loc,
+                                 mlir::Value memref) {
+  auto memrefType = memref.getType().cast<mlir::MemRefType>();
+  auto resultType = mlir::MemRefType::get(mlir::ShapedType::kDynamicSize,
+                                          memrefType.getElementType());
+  mlir::OpBuilder::InsertionGuard g(builder);
+  setInsertionPointToStart(builder, memref);
+  mlir::OpFoldResult offset = builder.getIndexAttr(0);
+  mlir::OpFoldResult size =
+      builder.createOrFold<plier::UndefOp>(loc, builder.getIndexType());
+  mlir::OpFoldResult stride = builder.getIndexAttr(1);
+  return builder.createOrFold<mlir::memref::ReinterpretCastOp>(
+      loc, resultType, memref, offset, size, stride);
+}
+
+static bool needFlatten(mlir::Value val) {
+  auto type = val.getType().cast<mlir::MemRefType>();
+  return !type.getAffineMaps().empty() ||
+         (type.getRank() > 1 && !type.hasStaticShape());
+}
+
+struct FlattenLoad : public mlir::OpRewritePattern<mlir::memref::LoadOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::memref::LoadOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (!op->getParentOfType<mlir::gpu::LaunchOp>())
+      return mlir::failure();
+
+    auto memref = op.memref();
+    if (!needFlatten(memref))
+      return mlir::failure();
+
+    auto loc = op.getLoc();
+    auto flatIndex = getFlatIndex(rewriter, loc, memref, op.indices());
+    auto flatMemref = getFlatMemref(rewriter, loc, memref);
+    rewriter.replaceOpWithNewOp<mlir::memref::LoadOp>(op, flatMemref,
+                                                      flatIndex);
+    return mlir::success();
+  }
+};
+
+struct FlattenStore : public mlir::OpRewritePattern<mlir::memref::StoreOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::memref::StoreOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (!op->getParentOfType<mlir::gpu::LaunchOp>())
+      return mlir::failure();
+
+    auto memref = op.memref();
+    if (!needFlatten(memref))
+      return mlir::failure();
+
+    auto loc = op.getLoc();
+    auto flatIndex = getFlatIndex(rewriter, loc, memref, op.indices());
+    auto flatMemref = getFlatMemref(rewriter, loc, memref);
+    rewriter.replaceOpWithNewOp<mlir::memref::StoreOp>(op, op.value(),
+                                                       flatMemref, flatIndex);
+    return mlir::success();
+  }
+};
+
+struct UnstrideMemrefsPass
+    : public mlir::PassWrapper<UnstrideMemrefsPass, mlir::FunctionPass> {
+  virtual void
+  getDependentDialects(mlir::DialectRegistry &registry) const override {
+    registry.insert<mlir::memref::MemRefDialect>();
+    registry.insert<mlir::gpu::GPUDialect>();
+  }
+
+  void runOnFunction() override {
+    mlir::OwningRewritePatternList patterns(&getContext());
+
+    patterns.insert<FlattenLoad, FlattenStore>(&getContext());
+
+    (void)mlir::applyPatternsAndFoldGreedily(getFunction(),
+                                             std::move(patterns));
   }
 };
 
@@ -65,14 +190,38 @@ struct AbiAttrsPass
   }
 };
 
+struct SetSPIRVCapabilitiesPass
+    : public mlir::PassWrapper<SetSPIRVCapabilitiesPass,
+                               mlir::OperationPass<mlir::ModuleOp>> {
+  void runOnOperation() override {
+    namespace spirv = mlir::spirv;
+    auto context = &getContext();
+    auto caps = {spirv::Capability::Shader};
+    auto exts = {spirv::Extension::SPV_KHR_storage_buffer_storage_class};
+    auto triple =
+        spirv::VerCapExtAttr::get(spirv::Version::V_1_0, caps, exts, context);
+    auto attr = spirv::TargetEnvAttr::get(
+        triple, spirv::Vendor::Unknown, spirv::DeviceType::Unknown,
+        spirv::TargetEnvAttr::kUnknownDeviceID,
+        spirv::getDefaultResourceLimits(context));
+    auto module = getOperation();
+    module->setAttr(spirv::getTargetEnvAttrName(), attr);
+  }
+};
+
 static void populateLowerToGPUPipeline(mlir::OpPassManager &pm) {
   pm.addNestedPass<mlir::FuncOp>(
       std::make_unique<ParallelLoopGPUMappingPass>());
   pm.addNestedPass<mlir::FuncOp>(mlir::createParallelLoopToGpuPass());
   pm.addNestedPass<mlir::FuncOp>(mlir::createCanonicalizerPass());
+  pm.addNestedPass<mlir::FuncOp>(std::make_unique<UnstrideMemrefsPass>());
+  pm.addNestedPass<mlir::FuncOp>(mlir::createLowerAffinePass());
+  pm.addNestedPass<mlir::FuncOp>(mlir::createCanonicalizerPass());
+  pm.addPass(mlir::createCSEPass());
   pm.addPass(mlir::createGpuKernelOutliningPass());
   pm.addPass(mlir::createCanonicalizerPass());
   pm.addNestedPass<mlir::gpu::GPUModuleOp>(std::make_unique<AbiAttrsPass>());
+  pm.addPass(std::make_unique<SetSPIRVCapabilitiesPass>());
   pm.addPass(mlir::createConvertGPUToSPIRVPass());
   pm.addPass(mlir::createCanonicalizerPass());
 }

--- a/numba_dpcomp/mlir_compiler/src/pipelines/lower_to_gpu.cpp
+++ b/numba_dpcomp/mlir_compiler/src/pipelines/lower_to_gpu.cpp
@@ -1032,7 +1032,7 @@ private:
                   mlir::ConversionPatternRewriter &rewriter) const override {
     plier::GetGpuKernelOp::Adaptor adaptor(operands);
     auto loc = op.getLoc();
-    llvm::SmallString<64> name = op.kernel().getLeafReference();
+    llvm::SmallString<64> name = op.kernel().getLeafReference().getValue();
 
     auto varName = llvm::formatv("{0}_kernel_name", name).str();
     name.push_back('\0');

--- a/numba_dpcomp/mlir_compiler/src/pipelines/lower_to_gpu.cpp
+++ b/numba_dpcomp/mlir_compiler/src/pipelines/lower_to_gpu.cpp
@@ -1,0 +1,90 @@
+// Copyright 2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "pipelines/lower_to_gpu.hpp"
+
+#include <mlir/Conversion/GPUToSPIRV/GPUToSPIRVPass.h>
+#include <mlir/Conversion/SCFToGPU/SCFToGPUPass.h>
+#include <mlir/Dialect/GPU/ParallelLoopMapper.h>
+#include <mlir/Dialect/GPU/Passes.h>
+#include <mlir/Dialect/SCF/SCF.h>
+#include <mlir/Dialect/SPIRV/IR/TargetAndABI.h>
+#include <mlir/Pass/PassManager.h>
+#include <mlir/Transforms/Passes.h>
+
+#include "base_pipeline.hpp"
+#include "pipelines/lower_to_llvm.hpp"
+
+#include "plier/compiler/pipeline_registry.hpp"
+
+namespace {
+struct ParallelLoopGPUMappingPass
+    : public mlir::PassWrapper<ParallelLoopGPUMappingPass, mlir::FunctionPass> {
+  virtual void
+  getDependentDialects(mlir::DialectRegistry &registry) const override {
+    registry.insert<mlir::scf::SCFDialect>();
+  }
+
+  void runOnFunction() override {
+    mlir::greedilyMapParallelSCFToGPU(getFunction().getBody());
+  }
+};
+
+struct AbiAttrsPass
+    : public mlir::PassWrapper<AbiAttrsPass,
+                               mlir::OperationPass<mlir::gpu::GPUModuleOp>> {
+  virtual void
+  getDependentDialects(mlir::DialectRegistry &registry) const override {
+    registry.insert<mlir::gpu::GPUDialect>();
+  }
+
+  void runOnOperation() override {
+    auto gpuModule = getOperation();
+    auto *context = &getContext();
+    auto attrName = mlir::spirv::getEntryPointABIAttrName();
+    const int32_t sizes[] = {1, 1, 1};
+    auto abi = mlir::spirv::getEntryPointABIAttr(sizes, context);
+    for (auto gpuFunc : gpuModule.getOps<mlir::gpu::GPUFuncOp>()) {
+      if (!mlir::gpu::GPUDialect::isKernel(gpuFunc) ||
+          gpuFunc->getAttr(attrName))
+        continue;
+
+      gpuFunc->setAttr(attrName, abi);
+    }
+  }
+};
+
+static void populateLowerToGPUPipeline(mlir::OpPassManager &pm) {
+  pm.addNestedPass<mlir::FuncOp>(
+      std::make_unique<ParallelLoopGPUMappingPass>());
+  pm.addNestedPass<mlir::FuncOp>(mlir::createParallelLoopToGpuPass());
+  pm.addNestedPass<mlir::FuncOp>(mlir::createCanonicalizerPass());
+  pm.addPass(mlir::createGpuKernelOutliningPass());
+  pm.addPass(mlir::createCanonicalizerPass());
+  pm.addNestedPass<mlir::gpu::GPUModuleOp>(std::make_unique<AbiAttrsPass>());
+  pm.addPass(mlir::createConvertGPUToSPIRVPass());
+  pm.addPass(mlir::createCanonicalizerPass());
+}
+} // namespace
+
+void registerLowerToGPUPipeline(plier::PipelineRegistry &registry) {
+  registry.register_pipeline([](auto sink) {
+    auto stage = getLowerLoweringStage();
+    sink(lowerToGPUPipelineName(), {stage.begin},
+         {stage.end, lowerToLLVMPipelineName()}, {},
+         &populateLowerToGPUPipeline);
+  });
+}
+
+llvm::StringRef lowerToGPUPipelineName() { return "lower_to_gpu"; }

--- a/numba_dpcomp/mlir_compiler/src/pipelines/lower_to_gpu.cpp
+++ b/numba_dpcomp/mlir_compiler/src/pipelines/lower_to_gpu.cpp
@@ -279,8 +279,6 @@ struct SerializeSPIRVPass
       signalPassFailure();
       return;
     }
-    spvBinary.insert(spvBinary.begin(),
-                     static_cast<uint32_t>(spvBinary.size())); // size
 
     auto spvData =
         llvm::StringRef(reinterpret_cast<const char *>(spvBinary.data()),

--- a/numba_dpcomp/mlir_compiler/src/pipelines/lower_to_gpu.cpp
+++ b/numba_dpcomp/mlir_compiler/src/pipelines/lower_to_gpu.cpp
@@ -1384,7 +1384,6 @@ static void populateLowerToGPUPipeline(mlir::OpPassManager &pm) {
   funcPM.addPass(mlir::createCanonicalizerPass());
   funcPM.addPass(std::make_unique<UnstrideMemrefsPass>());
   funcPM.addPass(mlir::createLowerAffinePass());
-  funcPM.addPass(mlir::createCanonicalizerPass());
   commonOptPasses(funcPM);
 
   pm.addPass(mlir::createGpuKernelOutliningPass());
@@ -1401,7 +1400,7 @@ static void populateLowerToGPUPipeline(mlir::OpPassManager &pm) {
   pm.addNestedPass<mlir::FuncOp>(std::make_unique<GPUExPass>());
   pm.addPass(std::make_unique<EnumerateEventsPass>());
   pm.addPass(std::make_unique<GPUToLLVMPass>());
-  pm.addPass(mlir::createCanonicalizerPass());
+  commonOptPasses(pm);
 }
 } // namespace
 

--- a/numba_dpcomp/mlir_compiler/src/pipelines/lower_to_gpu.cpp
+++ b/numba_dpcomp/mlir_compiler/src/pipelines/lower_to_gpu.cpp
@@ -457,11 +457,8 @@ struct SerializeSPIRVPass
 
     namespace gpu = mlir::gpu;
     auto gpuMod = getOp<gpu::GPUModuleOp>(mod.getRegion());
-    if (!gpuMod) {
-      mod.emitError() << "Invalid gpu module";
-      signalPassFailure();
+    if (!gpuMod)
       return;
-    }
 
     namespace spirv = mlir::spirv;
     auto spvMod = getOp<spirv::ModuleOp>(mod.getRegion());

--- a/numba_dpcomp/mlir_compiler/src/pipelines/lower_to_gpu.cpp
+++ b/numba_dpcomp/mlir_compiler/src/pipelines/lower_to_gpu.cpp
@@ -404,9 +404,8 @@ template <typename OpTy>
 class ConvertOpToGpuRuntimeCallPattern
     : public mlir::ConvertOpToLLVMPattern<OpTy> {
 public:
-  explicit ConvertOpToGpuRuntimeCallPattern(
-      mlir::LLVMTypeConverter &typeConverter)
-      : mlir::ConvertOpToLLVMPattern<OpTy>(typeConverter) {}
+  explicit ConvertOpToGpuRuntimeCallPattern(mlir::LLVMTypeConverter &converter)
+      : mlir::ConvertOpToLLVMPattern<OpTy>(converter) {}
 
 protected:
   mlir::MLIRContext *context = &this->getTypeConverter()->getContext();
@@ -586,9 +585,9 @@ private:
     plier::GetGpuKernelOp::Adaptor adaptor(operands);
     auto loc = op.getLoc();
     llvm::SmallString<64> name = op.name();
-    name.push_back('\0');
 
     auto varName = llvm::formatv("{0}_kernel_name", name).str();
+    name.push_back('\0');
     auto data = mlir::LLVM::createGlobalString(loc, rewriter, varName, name,
                                                mlir::LLVM::Linkage::Internal);
     auto res =

--- a/numba_dpcomp/mlir_compiler/src/pipelines/lower_to_gpu.cpp
+++ b/numba_dpcomp/mlir_compiler/src/pipelines/lower_to_gpu.cpp
@@ -1489,7 +1489,12 @@ struct LowerBuiltinCalls : public mlir::OpRewritePattern<mlir::CallOp> {
       return mlir::failure();
 
     rerun_std_pipeline(op);
-    rewriter.replaceOp(op, loop.getLoopBody().front().getArgument(0));
+    mlir::Value arg = loop.getLoopBody().front().getArgument(0);
+    auto resType = op.getResult(0).getType();
+    if (arg.getType() != resType)
+      arg = rewriter.createOrFold<mlir::IndexCastOp>(op.getLoc(), resType, arg);
+
+    rewriter.replaceOp(op, arg);
     return mlir::success();
   }
 };

--- a/numba_dpcomp/mlir_compiler/src/pipelines/lower_to_gpu.hpp
+++ b/numba_dpcomp/mlir_compiler/src/pipelines/lower_to_gpu.hpp
@@ -24,4 +24,5 @@ class StringRef;
 
 void registerLowerToGPUPipeline(plier::PipelineRegistry &registry);
 
-llvm::StringRef lowerToGPUPipelineName();
+llvm::StringRef lowerToGPUPipelineNameHigh();
+llvm::StringRef lowerToGPUPipelineNameLow();

--- a/numba_dpcomp/mlir_compiler/src/pipelines/lower_to_gpu.hpp
+++ b/numba_dpcomp/mlir_compiler/src/pipelines/lower_to_gpu.hpp
@@ -1,0 +1,27 @@
+// Copyright 2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace plier {
+class PipelineRegistry;
+}
+
+namespace llvm {
+class StringRef;
+}
+
+void registerLowerToGPUPipeline(plier::PipelineRegistry &registry);
+
+llvm::StringRef lowerToGPUPipelineName();

--- a/numba_dpcomp/mlir_compiler/src/pipelines/plier_to_linalg.cpp
+++ b/numba_dpcomp/mlir_compiler/src/pipelines/plier_to_linalg.cpp
@@ -2032,6 +2032,9 @@ void populate_plier_to_linalg_opt_pipeline(mlir::OpPassManager &pm) {
   pm.addPass(std::make_unique<ForceInlinePass>());
   pm.addPass(mlir::createSymbolDCEPass());
 
+  pm.addNestedPass<mlir::FuncOp>(mlir::createCanonicalizerPass());
+  pm.addNestedPass<mlir::FuncOp>(mlir::createLoopInvariantCodeMotionPass());
+
   // ToDo: This pass also tries to do some simple fusion, whic should be split
   // in separate pass
   pm.addNestedPass<mlir::FuncOp>(std::make_unique<PostLinalgOptPass>());

--- a/numba_dpcomp/mlir_compiler/src/py_linalg_resolver.cpp
+++ b/numba_dpcomp/mlir_compiler/src/py_linalg_resolver.cpp
@@ -1143,6 +1143,9 @@ py::object external_call_impl(py::capsule context, py::str func_name,
   if (results.empty())
     return py::none();
 
+  if (results.size() == 1)
+    return ctx.context.create_var(context, results.front());
+
   py::tuple ret(results.size());
   for (auto it : llvm::enumerate(results)) {
     ret[it.index()] = ctx.context.create_var(context, it.value());

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ except ImportError:
 
 
 # GPU/L0
-LEVEL_ZERO_DIR = os.environ.get('LEVEL_ZERO_DIR', None)
+LEVEL_ZERO_DIR = os.getenv('LEVEL_ZERO_DIR', None)
 if LEVEL_ZERO_DIR is None:
     print('LEVEL_ZERO_DIR is not set')
 else:

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,19 @@ try:
 except ImportError:
     print("DPNP not found")
 
+
+# GPU/L0
+LEVEL_ZERO_DIR = os.environ.get('LEVEL_ZERO_DIR', None)
+if LEVEL_ZERO_DIR is None:
+    print('LEVEL_ZERO_DIR is not set')
+else:
+    print('LEVEL_ZERO_DIR is', LEVEL_ZERO_DIR)
+    cmake_cmd += [
+                  '-DLEVEL_ZERO_DIR=' + LEVEL_ZERO_DIR,
+                  '-DGPU_ENABLE=1',
+                 ]
+
+
 try:
     os.mkdir(cmake_build_dir)
 except FileExistsError:


### PR DESCRIPTION
* Only dppy.kernel style functions are supported now (https://intelpython.github.io/numba-dppy/latest/index.html)
* No way to select specific device for now (always select first GPU device)
* Only get_global_id builtin is supported for now
* There is a kernel api simulator which will run kernel in fully interpreted mode, without any compilation (for testing purposes, see kernel_sim.py)
* SPIRV + L0 backend
    * kernel_impl.py - Python kernel api
    * gpu_runtime.cpp - L0 runtime code
    * lower_to_gpu.cpp - MLIR lowering setup and passes
