### PR TITLE
py_linalg_resolver refactoring

### DIFF
--- a/numba_dpcomp/mlir/kernel_impl.py
+++ b/numba_dpcomp/mlir/kernel_impl.py
@@ -18,7 +18,8 @@ from numba import prange
 from numba.core import types
 from numba.core.typing.templates import ConcreteTemplate, signature, infer_global
 
-from .linalg_builder import register_func, is_int
+from .linalg_builder import is_int
+from .numpy.funcs import register_func
 from numba_dpcomp.mlir.func_registry import add_func
 
 from ..decorators import njit

--- a/numba_dpcomp/mlir/numpy/funcs.py
+++ b/numba_dpcomp/mlir/numpy/funcs.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..linalg_builder import FuncRegistry, is_literal, broadcast_type, eltwise, convert_array, asarray, is_int, is_float
+from ..linalg_builder import FuncRegistry, is_literal, broadcast_type, eltwise, convert_array, asarray, is_int, is_float, DYNAMIC_DIM
 
 import numpy
 import math
@@ -345,9 +345,10 @@ def _prepare_cov_input(builder, m, y, rowvar):
 
         return dtype, _prepare_cov_input_impl
     dtype, func = get_func()
+    array_type = builder.array_type([DYNAMIC_DIM, DYNAMIC_DIM], dtype)
     if is_int(dtype, builder):
         dtype = builder.float64
-    res = builder.inline_func(func, m, y, rowvar)
+    res = builder.inline_func(func, array_type, m, y, rowvar)
     return convert_array(builder, res, dtype)
 
 def _cov_scalar_result_expected(mandatory_input, optional_input):
@@ -364,8 +365,9 @@ def cov_impl(builder, m, y=None, rowvar=True, bias=False, ddof=None):
     if not y is None:
         y = asarray(builder, y)
     X = _prepare_cov_input(builder, m, y, rowvar)
-    ddof = builder.inline_func(_cov_get_ddof_func(ddof is None), bias, ddof)
-    res = builder.inline_func(_cov_impl_inner, X, ddof)
+    ddof = builder.inline_func(_cov_get_ddof_func(ddof is None), builder.int64, bias, ddof)
+    array_type = builder.array_type([DYNAMIC_DIM, DYNAMIC_DIM], X.dtype)
+    res = builder.inline_func(_cov_impl_inner, array_type, X, ddof)
     if _cov_scalar_result_expected(m, y):
         res = res[0, 0]
     return res

--- a/numba_dpcomp/mlir/numpy/funcs.py
+++ b/numba_dpcomp/mlir/numpy/funcs.py
@@ -12,14 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..linalg_builder import register_func, register_attr, is_literal, broadcast_type, eltwise, convert_array, asarray, is_int
+from ..linalg_builder import FuncRegistry, is_literal, broadcast_type, eltwise, convert_array, asarray, is_int, is_float
 
 import numpy
 import math
 from numba import prange
 
-def is_float(t, b):
-    return t == b.float16 or t == b.float32 or t == b.float64
+registry = FuncRegistry()
+
+def register_func(name, orig_func=None):
+    global registry
+    return registry.register_func(name, orig_func)
+
+def register_attr(name):
+    global registry
+    return registry.register_attr(name)
 
 def promote_int(t, b):
     if is_int(t, b):

--- a/numba_dpcomp/mlir/vectorize.py
+++ b/numba_dpcomp/mlir/vectorize.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import inspect
-from .linalg_builder import register_func, eltwise
+from .linalg_builder import eltwise
+from .numpy.funcs import register_func
 from numba.core.typing.templates import infer_global, CallableTemplate
 from numba.core import types
 import sys

--- a/numba_dpcomp/mlir_compiler/src/pipelines/plier_to_linalg.cpp
+++ b/numba_dpcomp/mlir_compiler/src/pipelines/plier_to_linalg.cpp
@@ -227,6 +227,9 @@ lowerPrange(plier::PyCallOp op, llvm::ArrayRef<mlir::Value> operands,
 }
 
 struct CallLowerer {
+  CallLowerer()
+      : linalg_resolver("numba_dpcomp.mlir.numpy.funcs", "registry") {}
+
   using args_t = llvm::ArrayRef<mlir::Value>;
   using kwargs_t = llvm::ArrayRef<std::pair<llvm::StringRef, mlir::Value>>;
   mlir::LogicalResult operator()(plier::PyCallOp op, llvm::StringRef name,

--- a/numba_dpcomp/mlir_compiler/src/pipelines/plier_to_linalg.cpp
+++ b/numba_dpcomp/mlir_compiler/src/pipelines/plier_to_linalg.cpp
@@ -1513,29 +1513,29 @@ struct CastToSignCastRewrite : public mlir::OpRewritePattern<plier::CastOp> {
   matchAndRewrite(plier::CastOp op,
                   mlir::PatternRewriter &rewriter) const override {
     auto srcType = op.value().getType().dyn_cast<mlir::RankedTensorType>();
-    if (!srcType) {
+    if (!srcType)
       return mlir::failure();
-    }
+
     auto dstType = op.getType().dyn_cast<mlir::RankedTensorType>();
-    if (!dstType) {
+    if (!dstType)
       return mlir::failure();
-    }
+
     if (srcType.getShape() != dstType.getShape() ||
-        srcType.getEncoding() != dstType.getEncoding()) {
+        srcType.getEncoding() != dstType.getEncoding())
       return mlir::failure();
-    }
-    auto srcElemType = srcType.getElementType().cast<mlir::IntegerType>();
-    if (!srcElemType) {
+
+    auto srcElemType = srcType.getElementType().dyn_cast<mlir::IntegerType>();
+    if (!srcElemType)
       return mlir::failure();
-    }
-    auto dstElemType = dstType.getElementType().cast<mlir::IntegerType>();
-    if (!dstElemType) {
+
+    auto dstElemType = dstType.getElementType().dyn_cast<mlir::IntegerType>();
+    if (!dstElemType)
       return mlir::failure();
-    }
+
     if (srcElemType.getWidth() != dstElemType.getWidth() ||
-        srcElemType.getSignedness() == dstElemType.getSignedness()) {
+        srcElemType.getSignedness() == dstElemType.getSignedness())
       return mlir::failure();
-    }
+
     rewriter.replaceOpWithNewOp<plier::SignCastOp>(op, dstType, op.value());
     return mlir::success();
   }

--- a/numba_dpcomp/mlir_compiler/src/py_linalg_resolver.hpp
+++ b/numba_dpcomp/mlir_compiler/src/py_linalg_resolver.hpp
@@ -34,7 +34,7 @@ class Location;
 
 class PyLinalgResolver {
 public:
-  PyLinalgResolver();
+  PyLinalgResolver(const char *modName, const char *regName);
   ~PyLinalgResolver();
 
   using Values = llvm::SmallVector<mlir::Value, 8>;


### PR DESCRIPTION
* Add ability to create multiple independent function registries
* Get rid of TypeConverter usage inside of resolver