### PR TITLE
Fix memory leak in _compile_isolated and cleanup some imports

### DIFF
--- a/numba_dpcomp/decorators.py
+++ b/numba_dpcomp/decorators.py
@@ -50,6 +50,7 @@ if USE_MLIR:
             del kws['forceobj']
         kws.update({'nopython': True})
         return jit(*args, **kws)
+
     vectorize = mlir_vectorize
 else:
     jit = orig_jit

--- a/numba_dpcomp/mlir/inner_compiler.py
+++ b/numba_dpcomp/mlir/inner_compiler.py
@@ -16,6 +16,7 @@ from numba.core.untyped_passes import ReconstructSSA
 from numba.core.typed_passes import NopythonTypeInference, AnnotateTypes
 from numba.core.compiler import CompilerBase, DefaultPassBuilder, DEFAULT_FLAGS, compile_extra
 from numba.core.compiler_machinery import PassManager
+from numba.core.registry import cpu_target
 from numba.core import typing, cpu
 
 from numba_dpcomp.mlir.passes import MlirBackendInner, get_mlir_func
@@ -38,7 +39,6 @@ class MlirTempCompiler(CompilerBase): # custom compiler extends from CompilerBas
 
 def _compile_isolated(func, args, return_type=None, flags=DEFAULT_FLAGS,
                      locals={}):
-    from numba.core.registry import cpu_target
     typingctx = cpu_target.typing_context
     targetctx = cpu_target.target_context
     # typingctx = typing.Context()

--- a/numba_dpcomp/mlir/inner_compiler.py
+++ b/numba_dpcomp/mlir/inner_compiler.py
@@ -39,12 +39,13 @@ class MlirTempCompiler(CompilerBase): # custom compiler extends from CompilerBas
 def _compile_isolated(func, args, return_type=None, flags=DEFAULT_FLAGS,
                      locals={}):
     from numba.core.registry import cpu_target
-    typingctx = typing.Context()
-    targetctx = cpu.CPUContext(typingctx)
-    # Register the contexts in case for nested @jit or @overload calls
-    with cpu_target.nested_context(typingctx, targetctx):
-        return compile_extra(typingctx, targetctx, func, args, return_type,
-                             flags, locals, pipeline_class=MlirTempCompiler)
+    typingctx = cpu_target.typing_context
+    targetctx = cpu_target.target_context
+    # typingctx = typing.Context()
+    # targetctx = cpu.CPUContext(typingctx)
+    # with cpu_target.nested_context(typingctx, targetctx):
+    return compile_extra(typingctx, targetctx, func, args, return_type,
+                         flags, locals, pipeline_class=MlirTempCompiler)
 
 def compile_func(func, args, flags=DEFAULT_FLAGS):
     _compile_isolated(func, args, flags=flags)

--- a/numba_dpcomp/mlir/linalg_builder.py
+++ b/numba_dpcomp/mlir/linalg_builder.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from .func_registry import add_func
+from .inner_compiler import compile_func
 
 class Var:
     def __init__(self, context, ssa_val):
@@ -97,10 +98,6 @@ class Builder:
 
     def array_type(self, dims, dtype):
         return self._array_type(self._context, dims, dtype)
-
-def compile_func(*args, **kwargs):
-    import numba_dpcomp.mlir.inner_compiler
-    return numba_dpcomp.mlir.inner_compiler.compile_func(*args, **kwargs)
 
 class FuncRegistry:
     def __init__(self):

--- a/numba_dpcomp/mlir/lowering.py
+++ b/numba_dpcomp/mlir/lowering.py
@@ -31,6 +31,8 @@ from .runtime import *
 from .math_runtime import *
 from .gpu_runtime import *
 
+import llvmlite.binding as llvm
+
 class mlir_lower(orig_Lower):
     def lower(self):
         if USE_MLIR:
@@ -44,8 +46,8 @@ class mlir_lower(orig_Lower):
     def lower_normal_function(self, fndesc):
         if USE_MLIR:
             mod_ir = self.metadata['mlir_blob']
-            import llvmlite.binding as llvm
             mod = llvm.parse_bitcode(mod_ir)
+            self.metadata.pop('mlir_blob')
             self.setup_function(fndesc)
             self.library.add_llvm_module(mod);
         else:


### PR DESCRIPTION
`typingctx = typing.Context()` was causing ~3000 calls to `install_registry` and `OverloadSelector` leak