### PR TITLE
Initial GPU atomics support

### DIFF
--- a/dpcomp_gpu_runtime/src/kernel_api_stubs.cpp
+++ b/dpcomp_gpu_runtime/src/kernel_api_stubs.cpp
@@ -41,3 +41,21 @@ extern "C" DPCOMP_GPU_RUNTIME_EXPORT int64_t
 _mlir_ciface_get_local_size(int64_t) {
   STUB();
 }
+
+#define ATOMIC_FUNC_DECL(op, suff, dt)                                         \
+  extern "C" DPCOMP_GPU_RUNTIME_EXPORT dt _mlir_ciface_atomic_##op##_##suff(   \
+      void *, dt) {                                                            \
+    STUB();                                                                    \
+  }
+
+#define ATOMIC_FUNC_DECL2(op)                                                  \
+  ATOMIC_FUNC_DECL(op, int32, int32_t)                                         \
+  ATOMIC_FUNC_DECL(op, int64, int64_t)                                         \
+  ATOMIC_FUNC_DECL(op, float32, float)                                         \
+  ATOMIC_FUNC_DECL(op, float64, double)
+
+ATOMIC_FUNC_DECL2(add)
+ATOMIC_FUNC_DECL2(sub)
+
+#undef ATOMIC_FUNC_DECL2
+#undef ATOMIC_FUNC_DECL

--- a/numba_dpcomp/mlir/kernel_impl.py
+++ b/numba_dpcomp/mlir/kernel_impl.py
@@ -214,7 +214,7 @@ def _define_atomic_funcs():
     def get_func(func_name):
         def api_func_impl(builder, arr, idx, val):
             # TODO: idx
-            return builder.external_call(f'atomic_add_{dtype_str(builder, arr.dtype)}', (arr, val), val)
+            return builder.external_call(f'{func_name}_{dtype_str(builder, arr.dtype)}', (arr, val), val)
         return api_func_impl
 
     def get_stub_func(func_name):

--- a/numba_dpcomp/mlir/kernel_impl.py
+++ b/numba_dpcomp/mlir/kernel_impl.py
@@ -213,7 +213,8 @@ def _define_atomic_funcs():
 
     def get_func(func_name):
         def api_func_impl(builder, arr, idx, val):
-            # TODO: idx
+            if not (isinstance(idx, int) and idx == 0):
+                arr = builder.subview(arr, idx)
             return builder.external_call(f'{func_name}_{dtype_str(builder, arr.dtype)}', (arr, val), val)
         return api_func_impl
 

--- a/numba_dpcomp/mlir/kernel_impl.py
+++ b/numba_dpcomp/mlir/kernel_impl.py
@@ -19,7 +19,7 @@ from numba import prange
 from numba.core import types
 from numba.core.typing.templates import AbstractTemplate, ConcreteTemplate, signature, infer_global
 
-from .linalg_builder import is_int, FuncRegistry
+from .linalg_builder import is_int, dtype_str, FuncRegistry
 from .numpy.funcs import register_func
 from .func_registry import add_func
 
@@ -214,7 +214,7 @@ def _define_atomic_funcs():
     def get_func(func_name):
         def api_func_impl(builder, arr, idx, val):
             # TODO: idx
-            return builder.external_call('atomic_add', (arr, val), val)
+            return builder.external_call(f'atomic_add_{dtype_str(builder, arr.dtype)}', (arr, val), val)
         return api_func_impl
 
     def get_stub_func(func_name):

--- a/numba_dpcomp/mlir/kernel_sim.py
+++ b/numba_dpcomp/mlir/kernel_sim.py
@@ -16,7 +16,7 @@ from collections import namedtuple
 from itertools import product
 
 from .kernel_impl import Kernel as OrigKernel
-from .kernel_impl import get_global_id, get_global_size, get_local_size
+from .kernel_impl import get_global_id, get_global_size, get_local_size, atomic, atomic_add
 
 _ExecutionState = namedtuple('_ExecutionState', [
     'global_size',
@@ -40,6 +40,20 @@ def get_global_size_proxy(index):
 def get_local_size_proxy(index):
     return get_exec_state().local_size[index]
 
+class atomic_proxy:
+    @staticmethod
+    def add(arr, ind, val):
+        new_val = arr[ind] + val
+        arr[ind] = new_val
+        return new_val
+
+    @staticmethod
+    def add(arr, ind, val):
+        new_val = arr[ind] - val
+        arr[ind] = new_val
+        return new_val
+
+
 def _setup_execution_state(global_size, local_size):
     import numba_dpcomp.mlir.kernel_impl
     global _execution_state
@@ -59,6 +73,8 @@ _globals_to_replace = [
     ('get_global_id', get_global_id, get_global_id_proxy),
     ('get_global_size', get_global_size, get_global_size_proxy),
     ('get_local_size', get_local_size, get_local_size_proxy),
+    ('atomic', atomic, atomic_proxy),
+    ('atomic_add', atomic_add, atomic_proxy.add),
 ]
 
 def _replace_globals(src):

--- a/numba_dpcomp/mlir/kernel_sim.py
+++ b/numba_dpcomp/mlir/kernel_sim.py
@@ -16,7 +16,7 @@ from collections import namedtuple
 from itertools import product
 
 from .kernel_impl import Kernel as OrigKernel
-from .kernel_impl import get_global_id, get_global_size, get_local_size, atomic, atomic_add
+from .kernel_impl import get_global_id, get_global_size, get_local_size, atomic, atomic_add, atomic_sub
 
 _ExecutionState = namedtuple('_ExecutionState', [
     'global_size',
@@ -48,7 +48,7 @@ class atomic_proxy:
         return new_val
 
     @staticmethod
-    def add(arr, ind, val):
+    def sub(arr, ind, val):
         new_val = arr[ind] - val
         arr[ind] = new_val
         return new_val
@@ -75,6 +75,7 @@ _globals_to_replace = [
     ('get_local_size', get_local_size, get_local_size_proxy),
     ('atomic', atomic, atomic_proxy),
     ('atomic_add', atomic_add, atomic_proxy.add),
+    ('atomic_sub', atomic_sub, atomic_proxy.sub),
 ]
 
 def _replace_globals(src):

--- a/numba_dpcomp/mlir/linalg_builder.py
+++ b/numba_dpcomp/mlir/linalg_builder.py
@@ -104,6 +104,9 @@ class Builder:
     def undef(self, dtype):
         return self._undef(self._context, dtype)
 
+    def subview(self, src, offset, size=None, strides=None):
+        return self._subview(self._context, src, offset, size, strides)
+
     def array_type(self, dims, dtype):
         return self._array_type(self._context, dims, dtype)
 

--- a/numba_dpcomp/mlir/linalg_builder.py
+++ b/numba_dpcomp/mlir/linalg_builder.py
@@ -220,3 +220,17 @@ def is_int(t, b):
 
 def is_float(t, b):
     return t == b.float16 or t == b.float32 or t == b.float64
+
+def dtype_str(builder, dtype):
+    names = [
+        (builder.int8,  'int8'),
+        (builder.int16, 'int16'),
+        (builder.int32, 'int32'),
+        (builder.int64, 'int64'),
+        (builder.float32, 'float32'),
+        (builder.float64, 'float64'),
+    ]
+    for t, name in names:
+        if t == dtype:
+            return name
+    assert(False)

--- a/numba_dpcomp/mlir/numpy/funcs.py
+++ b/numba_dpcomp/mlir/numpy/funcs.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..linalg_builder import FuncRegistry, is_literal, broadcast_type, eltwise, convert_array, asarray, is_int, is_float, DYNAMIC_DIM
+from ..linalg_builder import FuncRegistry, is_literal, broadcast_type, eltwise, convert_array, asarray, is_int, is_float, dtype_str, DYNAMIC_DIM
 from ..func_registry import add_func
 
 import numpy
@@ -226,20 +226,6 @@ def reshape_impl(builder, arg, new_shape):
 def flatten_impl(builder, arg):
     size = size_impl(builder, arg)
     return builder.reshape(arg, size)
-
-def dtype_str(builder, dtype):
-    names = [
-        (builder.int8,  'int8'),
-        (builder.int16, 'int16'),
-        (builder.int32, 'int32'),
-        (builder.int64, 'int64'),
-        (builder.float32, 'float32'),
-        (builder.float64, 'float64'),
-    ]
-    for t, name in names:
-        if t == dtype:
-            return name
-    assert(False)
 
 @register_func('numpy.linalg.eig', numpy.linalg.eig)
 def eig_impl(builder, arg):

--- a/numba_dpcomp/mlir/tests/test_gpu.py
+++ b/numba_dpcomp/mlir/tests/test_gpu.py
@@ -272,7 +272,7 @@ def test_get_local_size(shape, lsize):
 
 @require_gpu
 @pytest.mark.parametrize("dtype", ['int32', 'int64']) # TODO: float
-@pytest.mark.parametrize("atomic_op", [atomic.add])
+@pytest.mark.parametrize("atomic_op", [atomic.add, atomic.sub])
 def test_atomics(dtype, atomic_op):
     def func(a, b):
         i = get_global_id(0)

--- a/numba_dpcomp/mlir/tests/test_gpu.py
+++ b/numba_dpcomp/mlir/tests/test_gpu.py
@@ -288,9 +288,9 @@ def test_atomics(dtype, atomic_op):
 
     gpu_res = np.zeros([1], dtype)
 
-    with print_pass_ir([],['ConvertParallelLoopToGpu']):
+    with print_pass_ir([],['GPUToSpirvPass']):
         gpu_func[a.shape, ()](a, gpu_res)
         ir = get_print_buffer()
-        assert ir.count('gpu.launch blocks') == 1, ir
+        assert ir.count('spv.AtomicIAdd') == 1 or ir.count('spv.AtomicISub') == 1, ir
 
     assert_equal(gpu_res, sim_res)

--- a/numba_dpcomp/mlir_compiler/src/py_linalg_resolver.cpp
+++ b/numba_dpcomp/mlir_compiler/src/py_linalg_resolver.cpp
@@ -201,9 +201,10 @@ template <typename F> void containerIterate(py::handle obj, F &&func) {
   }
 }
 
-template <typename UnwrapFunc>
+template <typename RetType = llvm::SmallVector<mlir::Value>,
+          typename UnwrapFunc>
 auto toValues(py::handle obj, UnwrapFunc &&unwrapFunc) {
-  llvm::SmallVector<mlir::Value> ret(containerSize(obj));
+  RetType ret(containerSize(obj));
   containerIterate(
       obj, [&](auto index, py::handle elem) { ret[index] = unwrapFunc(elem); });
   return ret;
@@ -1242,6 +1243,51 @@ py::object undefImpl(py::capsule context, py::handle dtype) {
   return ctx.context.createVar(context, ret);
 }
 
+py::object subviewImpl(py::capsule context, py::handle src, py::handle offsets,
+                       py::handle sizes, py::handle strides) {
+  auto &ctx = getPyContext(context);
+  auto &builder = ctx.builder;
+  auto loc = ctx.loc;
+  auto origSrcVal = ctx.context.unwrapVal(loc, builder, src);
+  auto srcVal = doSignCast(builder, loc, origSrcVal);
+
+  auto indexType = builder.getIndexType();
+  auto unwrapVal = [&](py::handle obj) {
+    return doCast(builder, loc, ctx.context.unwrapVal(loc, builder, obj),
+                  indexType);
+  };
+
+  using ValsArray = llvm::SmallVector<mlir::OpFoldResult>;
+  auto offsetVals = toValues<ValsArray>(offsets, unwrapVal);
+  auto sizeVals = [&]() -> ValsArray {
+    if (sizes.is_none()) {
+      ValsArray ret(offsetVals.size());
+      for (auto i : llvm::seq(size_t(0), ret.size())) {
+        auto dim = builder.createOrFold<mlir::tensor::DimOp>(
+            loc, origSrcVal, static_cast<int64_t>(i));
+        auto offset = offsetVals[i].get<mlir::Value>();
+        auto size = builder.createOrFold<mlir::arith::SubIOp>(loc, dim, offset);
+        ret[i] = size;
+      }
+      return ret;
+    } else {
+      return toValues<ValsArray>(sizes, unwrapVal);
+    }
+  }();
+  auto strideVals = [&]() -> ValsArray {
+    if (strides.is_none()) {
+      auto one = builder.create<mlir::arith::ConstantIndexOp>(loc, 1);
+      return ValsArray(offsetVals.size(), one.getResult());
+    } else {
+      return toValues<ValsArray>(strides, unwrapVal);
+    }
+  }();
+  auto view = builder.createOrFold<mlir::tensor::ExtractSliceOp>(
+      loc, srcVal, offsetVals, sizeVals, strideVals);
+  return ctx.context.createVar(
+      context, doSignCast(builder, loc, view, origSrcVal.getType()));
+}
+
 py::object arrayTypeImpl(py::capsule context, py::iterable dims,
                          py::handle dtype) {
   auto &ctx = getPyContext(context);
@@ -1268,6 +1314,7 @@ void setupPyBuilder(py::handle builder, mlir::OpBuilder &b,
   py::setattr(builder, "_inline_func", py::cpp_function(&inlineFuncImpl));
   py::setattr(builder, "_cast", py::cpp_function(&castImpl));
   py::setattr(builder, "_undef", py::cpp_function(&undefImpl));
+  py::setattr(builder, "_subview", py::cpp_function(&subviewImpl));
 
   py::setattr(builder, "_array_type", py::cpp_function(&arrayTypeImpl));
 


### PR DESCRIPTION
* Only integer atomics are supported for now (float atomics require some fixes in upstream MLIR first)
* Non-zero offsets not suported (need `memref.subview` spirv lowering)