### PR TITLE
Rework numpy arrays lowering

### DIFF
--- a/dpcomp/lib/transforms/cast_utils.cpp
+++ b/dpcomp/lib/transforms/cast_utils.cpp
@@ -54,15 +54,15 @@ mlir::Value plier::index_cast(mlir::OpBuilder &builder, mlir::Location loc,
 }
 
 mlir::Type plier::makeSignlessType(mlir::Type type) {
-  if (auto intType = type.dyn_cast<mlir::IntegerType>()) {
+  if (auto intType = type.dyn_cast<mlir::IntegerType>())
     return makeSignlessType(intType);
-  }
+
   return type;
 }
 
 mlir::IntegerType plier::makeSignlessType(mlir::IntegerType type) {
-  if (!type.isSignless()) {
+  if (!type.isSignless())
     return mlir::IntegerType::get(type.getContext(), type.getWidth());
-  }
+
   return type;
 }

--- a/numba_dpcomp/mlir/numpy/funcs.py
+++ b/numba_dpcomp/mlir/numpy/funcs.py
@@ -455,8 +455,9 @@ def reshape_impl(builder, arg, new_shape):
 # @register_attr('array.flat')
 @register_func('array.flatten')
 def flatten_impl(builder, arg):
+    # TODO: fast path for 1D
     size = size_impl(builder, arg)
-    return builder.reshape(arg, [size])
+    return builder.reshape(arg, (size))
 
 @register_func('array.__getitem__')
 def getitem_impl(builder, arr, index):

--- a/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_linalg.cpp
+++ b/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_linalg.cpp
@@ -1031,7 +1031,7 @@ struct SetitemOpLowering : public mlir::OpConversionPattern<plier::SetItemOp> {
                                                           dst);
       } else {
         rewriter.replaceOpWithNewOp<mlir::linalg::FillOp>(op, castElem(value),
-                                                          dst);
+                                                          castView(dst));
       }
     } else {
       // Is single element

--- a/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_linalg.cpp
+++ b/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_linalg.cpp
@@ -1030,8 +1030,9 @@ struct SetitemOpLowering : public mlir::OpConversionPattern<plier::SetItemOp> {
         rewriter.replaceOpWithNewOp<mlir::linalg::CopyOp>(op, castView(value),
                                                           dst);
       } else {
-        rewriter.replaceOpWithNewOp<mlir::linalg::FillOp>(op, castElem(value),
-                                                          castView(dst));
+        auto elem = castElem(value);
+        auto view = castView(dst);
+        rewriter.replaceOpWithNewOp<mlir::linalg::FillOp>(op, elem, view);
       }
     } else {
       // Is single element

--- a/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_linalg.cpp
+++ b/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_linalg.cpp
@@ -1027,8 +1027,9 @@ struct SetitemOpLowering : public mlir::OpConversionPattern<plier::SetItemOp> {
         rewriter.replaceOpWithNewOp<mlir::linalg::CopyOp>(op, castView(src),
                                                           dst);
       } else if (valType.isa<mlir::MemRefType>()) {
-        rewriter.replaceOpWithNewOp<mlir::linalg::CopyOp>(op, castView(value),
-                                                          dst);
+        auto srcView = castView(value);
+        auto dstView = castView(dst);
+        rewriter.replaceOpWithNewOp<mlir::linalg::CopyOp>(op, srcView, dstView);
       } else {
         auto elem = castElem(value);
         auto view = castView(dst);

--- a/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_linalg.cpp
+++ b/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_linalg.cpp
@@ -1734,7 +1734,7 @@ struct ConvertAlloc : public mlir::OpConversionPattern<Op> {
   mlir::LogicalResult
   matchAndRewrite(Op op, typename Op::Adaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    auto converter = getTypeConverter();
+    auto converter = this->getTypeConverter();
     assert(converter);
     auto oldResType = op.getType();
     auto newResType = converter->convertType(oldResType)

--- a/numba_dpcomp/mlir_compiler/lib/py_linalg_resolver.cpp
+++ b/numba_dpcomp/mlir_compiler/lib/py_linalg_resolver.cpp
@@ -564,6 +564,8 @@ static mlir::Value broadcastDim(mlir::OpBuilder &builder, mlir::Location loc,
 static mlir::Value expandDim(mlir::OpBuilder &builder, mlir::Location loc,
                              mlir::Value initial, mlir::Value src, unsigned dim,
                              mlir::ValueRange targetShape) {
+  assert(initial.getType().isa<mlir::RankedTensorType>());
+  assert(src.getType().isa<mlir::RankedTensorType>());
   auto context = builder.getContext();
   auto srcType = src.getType().cast<mlir::ShapedType>();
   auto numDims = static_cast<unsigned>(srcType.getRank());
@@ -656,7 +658,8 @@ static py::object broadcastImpl(py::capsule context, py::tuple args,
 
   llvm::SmallVector<mlir::Value> mlirArgs(args.size());
   for (auto it : llvm::enumerate(args)) {
-    auto val = ctx.context.unwrapVal(loc, builder, it.value());
+    auto val =
+        toTensor(loc, builder, ctx.context.unwrapVal(loc, builder, it.value()));
     mlirArgs[it.index()] = val;
   }
   using shape_t = llvm::SmallVector<mlir::Value>;

--- a/numba_dpcomp/mlir_compiler/lib/py_linalg_resolver.cpp
+++ b/numba_dpcomp/mlir_compiler/lib/py_linalg_resolver.cpp
@@ -1045,7 +1045,7 @@ static py::object reshapeImpl(py::capsule context, py::handle src,
       }
       return ret;
     }
-    auto dims = unwrapDim(newDims);
+    auto dims = unwrapVal(newDims);
     if (auto tupleType = dims.getType().dyn_cast<mlir::TupleType>()) {
       auto dimsCount = tupleType.size();
       ret.resize(dimsCount);


### PR DESCRIPTION
Previously, arrays were lowered to mlir tensor types with some hacks to make setitem work.
Instead of that, lower them directly to memrefs
-- BUT --
Numpy functions are still lowering to tensor ops. We are ending with already partially bufferized result. There are some potential UBs as we not inserting copies on tensor/memref boundaries atm, but I will leave it as is for now until I find example where I can reproduce this UB.