### PR TITLE
Improve tensor optimization pass

### DIFF
--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_numpy.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_numpy.py
@@ -1144,7 +1144,7 @@ def test_matmul1(py_func, a, b, dtype):
 @pytest.mark.parametrize("a,b", [
     (np.arange(4*5).reshape(4,5), np.arange(5)),
     (np.arange(20*25).reshape(20,25), np.arange(25)),
-    # (np.arange(4000*5000).reshape(4000,5000), np.arange(5000)), TODO: too long
+    (np.arange(4000*5000).reshape(4000,5000), np.arange(5000))
     ])
 @pytest.mark.parametrize("dtype", [np.float32,np.float64])
 def test_matmul2(py_func, a, b, dtype):

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_linalg.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_linalg.cpp
@@ -2191,13 +2191,13 @@ void MakeTensorsSignlessPass::runOnOperation() {
     signalPassFailure();
 }
 
-struct TensorFusionPass
-    : public mlir::PassWrapper<TensorFusionPass,
+struct LinalgOptPass
+    : public mlir::PassWrapper<LinalgOptPass,
                                mlir::OperationPass<mlir::ModuleOp>> {
   void runOnOperation() override;
 };
 
-void TensorFusionPass::runOnOperation() {
+void LinalgOptPass::runOnOperation() {
   auto &context = getContext();
   mlir::RewritePatternSet patterns(&context);
 
@@ -2617,7 +2617,7 @@ static void populatePlierToLinalgOptPipeline(mlir::OpPassManager &pm) {
   pm.addPass(mlir::createReconcileUnrealizedCastsPass());
 
   pm.addPass(mlir::createCanonicalizerPass());
-  pm.addPass(std::make_unique<TensorFusionPass>());
+  pm.addPass(std::make_unique<LinalgOptPass>());
 
   pm.addPass(mlir::arith::createConstantBufferizePass());
   pm.addNestedPass<mlir::FuncOp>(std::make_unique<AdditionalBufferize>());

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_linalg.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_linalg.cpp
@@ -2176,8 +2176,14 @@ void TensorFusionPass::runOnOperation() {
 
   plier::populateCommonOptsPatterns(context, patterns);
 
-  patterns.insert<SimplifyExpandDims, LowerEnforceShape, InsertSliceToPad,
-                  SliceOfGeneric>(&context);
+  patterns.insert<
+      // clang-format off
+      SimplifyExpandDims,
+      LowerEnforceShape,
+//      InsertSliceToPad,
+      SliceOfGeneric
+      // clang-format on
+      >(&context);
 
   mlir::linalg::populateElementwiseOpsFusionPatterns(patterns);
 


### PR DESCRIPTION
* Propagate `ExtractSliceOp` dimensions through producer `GenericOp`s
* Fold `tensor.extract_slice(linalg.fill)` -> `linalg.fill`
* matmul test with large matrices now works reasonable time (previously it was just hangs)