### PR TITLE
GPU lowering refactoring

### DIFF
--- a/mlir/include/mlir-extensions/transforms/common_opts.hpp
+++ b/mlir/include/mlir-extensions/transforms/common_opts.hpp
@@ -14,9 +14,12 @@
 
 #pragma once
 
+#include <memory>
+
 namespace mlir {
 class RewritePatternSet;
 class MLIRContext;
+class Pass;
 } // namespace mlir
 
 namespace plier {
@@ -25,4 +28,6 @@ void populateCanonicalizationPatterns(mlir::MLIRContext &context,
 
 void populateCommonOptsPatterns(mlir::MLIRContext &context,
                                 mlir::RewritePatternSet &patterns);
+
+std::unique_ptr<mlir::Pass> createCommonOptsPass();
 } // namespace plier

--- a/mlir/include/mlir-extensions/transforms/index_type_propagation.hpp
+++ b/mlir/include/mlir-extensions/transforms/index_type_propagation.hpp
@@ -20,6 +20,6 @@ class MLIRContext;
 } // namespace mlir
 
 namespace plier {
-void populate_index_propagate_patterns(mlir::MLIRContext &context,
-                                       mlir::RewritePatternSet &patterns);
+void populateIndexPropagatePatterns(mlir::MLIRContext &context,
+                                    mlir::RewritePatternSet &patterns);
 }

--- a/mlir/lib/transforms/common_opts.cpp
+++ b/mlir/lib/transforms/common_opts.cpp
@@ -155,5 +155,5 @@ void plier::populateCommonOptsPatterns(mlir::MLIRContext &context,
       // clang-format on
       >(&context);
 
-  plier::populate_index_propagate_patterns(context, patterns);
+  plier::populateIndexPropagatePatterns(context, patterns);
 }

--- a/mlir/lib/transforms/common_opts.cpp
+++ b/mlir/lib/transforms/common_opts.cpp
@@ -19,6 +19,8 @@
 #include "mlir-extensions/transforms/index_type_propagation.hpp"
 #include "mlir-extensions/transforms/loop_rewrites.hpp"
 #include "mlir-extensions/transforms/memory_rewrites.hpp"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #include <mlir/Dialect/Math/IR/Math.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
@@ -129,6 +131,20 @@ struct PowSimplify : public mlir::OpRewritePattern<mlir::math::PowFOp> {
     return mlir::failure();
   }
 };
+
+struct CommonOptsPass
+    : public mlir::PassWrapper<CommonOptsPass, mlir::OperationPass<void>> {
+
+  void runOnOperation() override {
+    auto *ctx = &getContext();
+    mlir::RewritePatternSet patterns(ctx);
+
+    plier::populateCommonOptsPatterns(*ctx, patterns);
+
+    (void)mlir::applyPatternsAndFoldGreedily(getOperation(),
+                                             std::move(patterns));
+  }
+};
 } // namespace
 
 void plier::populateCanonicalizationPatterns(
@@ -156,4 +172,8 @@ void plier::populateCommonOptsPatterns(mlir::MLIRContext &context,
       >(&context);
 
   plier::populateIndexPropagatePatterns(context, patterns);
+}
+
+std::unique_ptr<mlir::Pass> plier::createCommonOptsPass() {
+  return std::make_unique<CommonOptsPass>();
 }

--- a/mlir/lib/transforms/index_type_propagation.cpp
+++ b/mlir/lib/transforms/index_type_propagation.cpp
@@ -147,8 +147,8 @@ struct CmpIndexCastSimplify
 };
 } // namespace
 
-void plier::populate_index_propagate_patterns(
-    mlir::MLIRContext &context, mlir::RewritePatternSet &patterns) {
+void plier::populateIndexPropagatePatterns(mlir::MLIRContext &context,
+                                           mlir::RewritePatternSet &patterns) {
   patterns
       .insert<CmpIndexCastSimplify, ArithIndexCastSimplify<mlir::arith::SubIOp>,
               ArithIndexCastSimplify<mlir::arith::AddIOp>,

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
@@ -3014,8 +3014,6 @@ static void populateLowerToGPUPipelineLow(mlir::OpPassManager &pm) {
   funcPM.addPass(std::make_unique<UnstrideMemrefsPass>());
   funcPM.addPass(mlir::createLowerAffinePass());
 
-  // TODO: mlir::gpu::GPUModuleOp pass
-  pm.addNestedPass<mlir::FuncOp>(mlir::arith::createArithmeticExpandOpsPass());
   commonOptPasses(funcPM);
   funcPM.addPass(std::make_unique<KernelMemrefOpsMovementPass>());
   funcPM.addPass(std::make_unique<GpuLaunchSinkOpsPass>());

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
@@ -67,6 +67,7 @@
 #include "mlir-extensions/dialect/plier_util/dialect.hpp"
 #include "mlir-extensions/transforms/call_lowering.hpp"
 #include "mlir-extensions/transforms/cast_utils.hpp"
+#include "mlir-extensions/transforms/common_opts.hpp"
 #include "mlir-extensions/transforms/const_utils.hpp"
 #include "mlir-extensions/transforms/func_utils.hpp"
 #include "mlir-extensions/transforms/pipeline_utils.hpp"
@@ -2986,9 +2987,9 @@ public:
 };
 
 static void commonOptPasses(mlir::OpPassManager &pm) {
-  pm.addPass(mlir::createCanonicalizerPass());
+  pm.addPass(plier::createCommonOptsPass());
   pm.addPass(mlir::createCSEPass());
-  pm.addPass(mlir::createCanonicalizerPass());
+  pm.addPass(plier::createCommonOptsPass());
 }
 
 static void populateLowerToGPUPipelineHigh(mlir::OpPassManager &pm) {


### PR DESCRIPTION
* Remove no longer needed `pm.addNestedPass<mlir::FuncOp>(mlir::arith::createArithmeticExpandOpsPass());`
* Run `CommonOptsPass` instead of canonicalizer
* array `computeIndices` refac in preparation to option to disable negative indices