### PR TITLE
Fix parfor tests

### DIFF
--- a/mlir/lib/dialect/plier_util/dialect.cpp
+++ b/mlir/lib/dialect/plier_util/dialect.cpp
@@ -20,6 +20,7 @@
 #include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/DialectImplementation.h>
 #include <mlir/IR/Dominance.h>
+#include <mlir/IR/Matchers.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/Transforms/InliningUtils.h>
 
@@ -269,14 +270,56 @@ struct GenGlobalId : public mlir::OpRewritePattern<mlir::arith::AddIOp> {
     return mlir::failure();
   }
 };
+
+struct InvertCmpi : public mlir::OpRewritePattern<mlir::arith::CmpIOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::arith::CmpIOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+
+    if (!mlir::matchPattern(op.getLhs(), mlir::m_Constant()) ||
+        mlir::matchPattern(op.getRhs(), mlir::m_Constant()))
+      return mlir::failure();
+
+    using Pred = mlir::arith::CmpIPredicate;
+    const std::pair<Pred, Pred> inv[] = {
+        // clang-format off
+        {Pred::slt, Pred::sgt},
+        {Pred::sle, Pred::sge},
+        {Pred::ult, Pred::ugt},
+        {Pred::ule, Pred::uge},
+        {Pred::eq, Pred::eq},
+        {Pred::ne, Pred::ne},
+        // clang-format on
+    };
+
+    auto newPred = [&]() -> Pred {
+      auto oldPred = op.getPredicate();
+      for (auto it : inv) {
+        if (it.first == oldPred)
+          return it.second;
+        if (it.second == oldPred)
+          return it.first;
+      }
+
+      llvm_unreachable("Unknown predicate");
+    }();
+
+    rewriter.replaceOpWithNewOp<mlir::arith::CmpIOp>(op, newPred, op.getRhs(),
+                                                     op.getLhs());
+    ;
+    return mlir::success();
+  }
+};
 } // namespace
 
 void PlierUtilDialect::getCanonicalizationPatterns(
     mlir::RewritePatternSet &results) const {
   results.add<DimExpandShape<mlir::tensor::DimOp, mlir::tensor::ExpandShapeOp>,
               DimExpandShape<mlir::memref::DimOp, mlir::memref::ExpandShapeOp>,
-              DimInsertSlice, FillExtractSlice, SpirvInputCSE, GenGlobalId>(
-      getContext());
+              DimInsertSlice, FillExtractSlice, SpirvInputCSE, GenGlobalId,
+              InvertCmpi>(getContext());
 }
 
 OpaqueType OpaqueType::get(mlir::MLIRContext *context) {

--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_numba_parfor.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_numba_parfor.py
@@ -183,7 +183,6 @@ def _gen_tests():
     }
 
     skip_tests = {
-        "test_high_dimension1",
         "test_three_d_array_reduction",
         "test_prange26",
     }

--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_numba_parfor.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_numba_parfor.py
@@ -52,6 +52,7 @@ def _gen_tests():
     ]
 
     xfail_tests = {
+        "test_prange26",
         "test_prange03mul",
         "test_prange09",
         "test_prange03sub",
@@ -182,9 +183,7 @@ def _gen_tests():
         "test_one_d_array_reduction",
     }
 
-    skip_tests = {
-        "test_prange26",
-    }
+    skip_tests = {}
 
     def countParfors(test_func, args, **kws):
         pytest.xfail()

--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_numba_parfor.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_numba_parfor.py
@@ -183,7 +183,6 @@ def _gen_tests():
     }
 
     skip_tests = {
-        "test_three_d_array_reduction",
         "test_prange26",
     }
 

--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_numba_parfor.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_numba_parfor.py
@@ -183,7 +183,6 @@ def _gen_tests():
     }
 
     skip_tests = {
-        "test_copy_global_for_parfor",
         "test_high_dimension1",
         "test_three_d_array_reduction",
         "test_prange26",

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_linalg.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_linalg.cpp
@@ -2851,8 +2851,6 @@ static void populatePlierToLinalgOptPipeline(mlir::OpPassManager &pm) {
       mlir::bufferization::createBufferHoistingPass());
   pm.addNestedPass<mlir::FuncOp>(
       mlir::bufferization::createBufferLoopHoistingPass());
-  pm.addNestedPass<mlir::FuncOp>(
-      mlir::bufferization::createPromoteBuffersToStackPass());
 
   pm.addNestedPass<mlir::FuncOp>(std::make_unique<CloneArgsPass>());
   pm.addPass(std::make_unique<MakeStridedLayoutPass>());
@@ -2863,6 +2861,8 @@ static void populatePlierToLinalgOptPipeline(mlir::OpPassManager &pm) {
   pm.addPass(mlir::createCanonicalizerPass());
 
   pm.addNestedPass<mlir::FuncOp>(std::make_unique<LowerCloneOpsPass>());
+  pm.addNestedPass<mlir::FuncOp>(
+      mlir::bufferization::createPromoteBuffersToStackPass());
 
   pm.addPass(std::make_unique<LowerLinalgPass>());
   pm.addPass(plier::createForceInlinePass());


### PR DESCRIPTION
* Fix ScfWhileRewrite generating invalid code in some cases
* Fix `dpcompParallelFor` crash for deep nested loops
* Additional cleanup for `CmpIOp`, `EnforceShapeDim` and `ReshapeOp`
* Change relative order of `createPromoteBuffersToStackPass` and `createBufferDeallocationPass` to avoid situation when we try to deallocate stack-allocated buffer