### PR TITLE
FindPython3.cmake can find NumPy. No need to set include path manually.

### DIFF
--- a/numba_dpcomp/numba_dpcomp/python_runtime/CMakeLists.txt
+++ b/numba_dpcomp/numba_dpcomp/python_runtime/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 project(dpcomp-python-runtime LANGUAGES CXX C)
 
-find_package (Python3 COMPONENTS Development REQUIRED)
+find_package (Python3 COMPONENTS Development NumPy REQUIRED)
 
 include(GenerateExportHeader)
 

--- a/numba_dpcomp/setup.py
+++ b/numba_dpcomp/setup.py
@@ -52,8 +52,6 @@ if int(os.environ.get("DPCOMP_SETUP_RUN_CMAKE", 1)):
 
     cmake_cmd += ["-GNinja"]
 
-    NUMPY_INCLUDE_DIR = numpy.get_include()
-
     cmake_cmd += [
         "..",
         "-DCMAKE_BUILD_TYPE=Release",
@@ -61,7 +59,6 @@ if int(os.environ.get("DPCOMP_SETUP_RUN_CMAKE", 1)):
         "-DMLIR_DIR=" + MLIR_DIR,
         "-DTBB_DIR=" + TBB_DIR,
         "-DCMAKE_INSTALL_PREFIX=" + CMAKE_INSTALL_PREFIX,
-        "-DPython3_NumPy_INCLUDE_DIRS=" + NUMPY_INCLUDE_DIR,
         "-DPython3_FIND_STRATEGY=LOCATION",
         "-DNUMBA_ENABLE=ON",
         "-DTBB_ENABLE=ON",


### PR DESCRIPTION
Fixes the usage of the CMake FindPython3 module to properly search for NumPy. With the change, there should not be a need to manually set up the `Python3_NumPy_INCLUDE_DIRS` flag.