### PR TITLE
Register plier dialect as it is used as part of gpu lowering.

### DIFF
--- a/mlir/lib/Conversion/gpu_to_gpu_runtime.cpp
+++ b/mlir/lib/Conversion/gpu_to_gpu_runtime.cpp
@@ -637,6 +637,7 @@ struct UnstrideMemrefsPass
   getDependentDialects(mlir::DialectRegistry &registry) const override {
     registry.insert<mlir::memref::MemRefDialect>();
     registry.insert<mlir::gpu::GPUDialect>();
+    registry.insert<plier::PlierUtilDialect>();
   }
 
   void runOnOperation() override {


### PR DESCRIPTION
Description
plier.undef is used as part of gpu lowering (for unstride memref). plier::PlierUtilDialect needs to be registered for passes to use it.

Please review these guidelines to help with the review process:
- [] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [ ] Have you organized your commits logically and ensured each can be built by itself?
