### PR TITLE
[WIP] Changes to separate out IMEX from numba_dpcomp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,6 @@ _install
 
 # pip wheels
 *.whl
+
+# VSCode config
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ if(IMEX_ENABLE_IGPU_DIALECT)
         find_package(LevelZero 1.6 REQUIRED)
     endif()
     add_subdirectory(dpcomp_gpu_runtime)
+    install(TARGETS dpcomp-gpu-runtime)
 endif()
 
 if(IMEX_ENABLE_NUMBA_HOTFIX)
@@ -135,3 +136,5 @@ if(IMEX_ENABLE_TESTS)
     include(CTest)
     add_subdirectory(test)
 endif()
+
+install(TARGETS dpcomp-runtime)

--- a/mlir/include/mlir-extensions/Transforms/func_utils.hpp
+++ b/mlir/include/mlir-extensions/Transforms/func_utils.hpp
@@ -21,17 +21,16 @@ class ModuleOp;
 class OpBuilder;
 class FunctionType;
 class Operation;
+
+namespace func {
+class FuncOp;
+}
+
 } // namespace mlir
 
 namespace llvm {
 class StringRef;
 }
-
-namespace mlir {
-namespace func {
-class FuncOp;
-}
-} // namespace mlir
 
 namespace plier {
 mlir::func::FuncOp add_function(mlir::OpBuilder &builder, mlir::ModuleOp module,

--- a/numba_dpcomp/CMakeLists.txt
+++ b/numba_dpcomp/CMakeLists.txt
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+cmake_minimum_required(VERSION 3.20)
+project(numba-dpcomp)
+
 add_subdirectory(numba_dpcomp/python_runtime)
 add_subdirectory(numba_dpcomp/math_runtime)
 add_subdirectory(numba_dpcomp/mlir_compiler)

--- a/numba_dpcomp/numba_dpcomp/mlir/utils.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/utils.py
@@ -38,6 +38,11 @@ def load_lib(name):
         assert False, "unsupported platform"
 
     saved_errors = []
+    try:
+        return ctypes.CDLL(lib_name)
+    except Exception as e:
+        saved_errors.append(f'CDLL("{lib_name}"): {str(e)}')
+
     for path in runtime_search_paths:
         lib_path = lib_name if len(path) == 0 else os.path.join(path, lib_name)
         try:

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/CMakeLists.txt
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/CMakeLists.txt
@@ -15,7 +15,6 @@
 project(mlir_compiler LANGUAGES CXX C)
 
 find_package(pybind11 REQUIRED)
-
 find_package(LLVM REQUIRED CONFIG)
 find_package(MLIR REQUIRED CONFIG)
 
@@ -42,7 +41,7 @@ set(SOURCES_LIST
     lib/py_linalg_resolver.cpp
     lib/py_map_types.cpp
     lib/py_module.cpp
-    )
+)
 set(HEADERS_LIST
     lib/pipelines/base_pipeline.hpp
     lib/pipelines/lower_to_gpu.hpp
@@ -59,7 +58,7 @@ set(HEADERS_LIST
     lib/py_linalg_resolver.hpp
     lib/py_map_types.hpp
     lib/py_module.hpp
-    )
+)
 
 pybind11_add_module(${PROJECT_NAME} ${SOURCES_LIST} ${HEADERS_LIST})
 
@@ -71,7 +70,12 @@ if (CMAKE_SYSTEM_NAME STREQUAL Darwin)
     target_link_libraries(${PROJECT_NAME} PRIVATE "-Wl,-exported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/export_darwin.txt")
 endif()
 
-apply_llvm_compile_flags(${PROJECT_NAME})
+
+if (MSVC)
+    target_compile_options(${PROJECT_NAME} PRIVATE /EHsc)
+else()
+    target_compile_definitions(${PROJECT_NAME} PRIVATE ${LLVM_DEFINITIONS})
+endif ()
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
     mlir-extensions
@@ -94,12 +98,13 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     MLIRSPIRVSerialization
     MLIRTensorTransforms
     MLIRReconcileUnrealizedCasts
-    )
+)
 
 target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE
     ${MLIR_INCLUDE_DIRS}
     PRIVATE
-    ./lib)
+    ./lib
+)
 
 if(IMEX_USE_DPNP)
     target_compile_definitions(${PROJECT_NAME} PRIVATE IMEX_USE_DPNP=1)
@@ -113,15 +118,9 @@ set(CMAKE_INSTALL_BINDIR ./numba_dpcomp/numba_dpcomp)
 set(CMAKE_INSTALL_LIBDIR ./numba_dpcomp/numba_dpcomp)
 set(CMAKE_INSTALL_INCLUDEDIR ./numba_dpcomp/numba_dpcomp)
 
-install(TARGETS dpcomp-runtime dpcomp-math-runtime dpcomp-python-runtime mlir_compiler
+install(TARGETS dpcomp-math-runtime dpcomp-python-runtime mlir_compiler
         LIBRARY DESTINATION numba_dpcomp/numba_dpcomp
-        )
-
-if(IMEX_ENABLE_IGPU_DIALECT)
-    install(TARGETS dpcomp-gpu-runtime
-            LIBRARY DESTINATION numba_dpcomp/numba_dpcomp
-            )
-endif()
+)
 
 get_filename_component(_tmp_path1 "${CMAKE_SOURCE_DIR}" REALPATH)
 get_filename_component(_tmp_path2 "${CMAKE_INSTALL_PREFIX}" REALPATH)

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/CMakeLists.txt
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/CMakeLists.txt
@@ -77,12 +77,18 @@ else()
     target_compile_definitions(${PROJECT_NAME} PRIVATE ${LLVM_DEFINITIONS})
 endif ()
 
+target_link_directories(${PROJECT_NAME} PRIVATE
+    /localdisk/work/diptorup/devel/imex-devel/_mlir_install/lib
+    /localdisk/work/diptorup/devel/mlir-extensions/_build/mlir
+)
+
 target_link_libraries(${PROJECT_NAME} PRIVATE
     mlir-extensions
     LLVM${LLVM_NATIVE_ARCH}CodeGen
     LLVM${LLVM_NATIVE_ARCH}Desc
     LLVMTarget
     MLIRIR
+    MLIRControlFlowToSPIRV
     MLIRLLVMIR
     MLIRLLVMToLLVMIRTranslation
     MLIRTransforms
@@ -91,6 +97,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     MLIRLinalgToLLVM
     MLIRMathToLLVM
     MLIRMathToLibm
+    MLIRMathToSPIRV
     MLIRSCFToGPU
     MLIRGPUToSPIRV
     MLIRGPUToGPURuntimeTransforms
@@ -102,6 +109,8 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
 
 target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE
     ${MLIR_INCLUDE_DIRS}
+    /localdisk/work/diptorup/devel/mlir-extensions/mlir/include
+    /localdisk/work/diptorup/devel/mlir-extensions/_build/mlir/include
     PRIVATE
     ./lib
 )

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/lowering.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/lowering.cpp
@@ -524,7 +524,7 @@ private:
 
   void retvar(py::handle inst) {
     auto var = loadvar(inst);
-    auto funcType = func.getType();
+    auto funcType = func.getFunctionType();
     auto retType = funcType.getResult(0);
     auto varType = var.getType();
     if (retType != varType)

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
@@ -797,7 +797,7 @@ static void visitTypeRecursive(mlir::Type type, F &&visitor) {
 
 void MarkGpuArraysInputs::runOnOperation() {
   auto func = getOperation();
-  auto funcType = func.getType();
+  auto funcType = func.getFunctionType();
 
   mlir::OpBuilder builder(&getContext());
   auto attrStr = builder.getStringAttr(gpu_runtime::getGpuAccessibleAttrName());
@@ -816,7 +816,7 @@ void MarkGpuArraysInputs::runOnOperation() {
     needAttr = needAttr || res;
   };
 
-  for (auto type : (func.getType().getInputs()))
+  for (auto type : (func.getFunctionType().getInputs()))
     visitTypeRecursive(type, visitor);
 
   if (needAttr)
@@ -1081,7 +1081,7 @@ struct LowerBuiltinCalls : public mlir::OpRewritePattern<mlir::func::CallOp> {
         if (auto cast = mlir::dyn_cast<plier::CastOp>(op))
           return cast.value();
         if (auto cast = mlir::dyn_cast<mlir::UnrealizedConversionCastOp>(op))
-          return cast.inputs()[0];
+          return cast.getInputs()[0];
 
         return {};
       };
@@ -1311,8 +1311,7 @@ public:
               return WalkResult::interrupt();
 
             return WalkResult::advance();
-          })
-            .wasInterrupted())
+          }).wasInterrupted())
       signalPassFailure();
   }
 };

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_llvm.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_llvm.cpp
@@ -52,11 +52,11 @@
 #include "base_pipeline.hpp"
 #include "pipelines/plier_to_std.hpp"
 
-#include "mlir-extensions/compiler/pipeline_registry.hpp"
 #include "mlir-extensions/Dialect/plier/dialect.hpp"
 #include "mlir-extensions/Dialect/plier_util/dialect.hpp"
 #include "mlir-extensions/Transforms/func_utils.hpp"
 #include "mlir-extensions/Transforms/type_conversion.hpp"
+#include "mlir-extensions/compiler/pipeline_registry.hpp"
 #include "mlir-extensions/utils.hpp"
 
 namespace {
@@ -356,8 +356,8 @@ get_to_memref_conversion_func(mlir::ModuleOp module, mlir::OpBuilder &builder,
   assert(dst_type);
   auto func_name = gen_to_memref_conversion_func_name(memrefType);
   if (auto func = module.lookupSymbol<mlir::func::FuncOp>(func_name)) {
-    assert(func.getType().getNumResults() == 1);
-    assert(func.getType().getResult(0) == dst_type);
+    assert(func.getFunctionType().getNumResults() == 1);
+    assert(func.getFunctionType().getResult(0) == dst_type);
     return func;
   }
   auto func_type =
@@ -417,8 +417,8 @@ get_from_memref_conversion_func(mlir::ModuleOp module, mlir::OpBuilder &builder,
   assert(dst_type);
   auto func_name = gen_from_memref_conversion_func_name(memrefType);
   if (auto func = module.lookupSymbol<mlir::func::FuncOp>(func_name)) {
-    assert(func.getType().getNumResults() == 1);
-    assert(func.getType().getResult(0) == dst_type);
+    assert(func.getFunctionType().getNumResults() == 1);
+    assert(func.getFunctionType().getResult(0) == dst_type);
     return func;
   }
   auto func_type =
@@ -528,7 +528,7 @@ mlir::LogicalResult fixFuncSig(LLVMTypeHelper &typeHelper,
   if (func->getAttr(plier::attributes::getFastmathName()))
     func->setAttr("passthrough", get_fastmath_attrs(*func.getContext()));
 
-  auto oldType = func.getType();
+  auto oldType = func.getFunctionType();
   auto &ctx = *oldType.getContext();
   llvm::SmallVector<mlir::Type> args;
 
@@ -1040,8 +1040,7 @@ struct LowerParallel : public mlir::OpRewritePattern<plier::ParallelOp> {
               }
             }
             return mlir::WalkResult::advance();
-          })
-            .wasInterrupted()) {
+          }).wasInterrupted()) {
       return mlir::failure();
     }
 

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/parallel_to_tbb.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/parallel_to_tbb.cpp
@@ -15,6 +15,7 @@
 #include "pipelines/parallel_to_tbb.hpp"
 
 #include <mlir/Dialect/Arithmetic/IR/Arithmetic.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/SCF.h>
 #include <mlir/IR/BlockAndValueMapping.h>
@@ -25,12 +26,12 @@
 #include "pipelines/base_pipeline.hpp"
 #include "pipelines/lower_to_llvm.hpp"
 
-#include "mlir-extensions/compiler/pipeline_registry.hpp"
 #include "mlir-extensions/Dialect/plier/dialect.hpp"
 #include "mlir-extensions/Dialect/plier_util/dialect.hpp"
 #include "mlir-extensions/Transforms/const_utils.hpp"
 #include "mlir-extensions/Transforms/func_utils.hpp"
 #include "mlir-extensions/Transforms/rewrite_wrapper.hpp"
+#include "mlir-extensions/compiler/pipeline_registry.hpp"
 
 namespace {
 mlir::MemRefType getReduceType(mlir::Type type, int64_t count) {

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_std.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_std.cpp
@@ -1274,10 +1274,11 @@ protected:
     if (!externalFunc)
       return mlir::failure();
 
-    assert(externalFunc.getType().getNumResults() == op->getNumResults());
+    assert(externalFunc.getFunctionType().getNumResults() ==
+           op->getNumResults());
 
     llvm::SmallVector<mlir::Value> castedArgs(args.size());
-    auto funcTypes = externalFunc.getType().getInputs();
+    auto funcTypes = externalFunc.getFunctionType().getInputs();
     for (auto it : llvm::enumerate(args)) {
       auto arg = it.value();
       auto i = it.index();

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/py_func_resolver.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/py_func_resolver.cpp
@@ -13,12 +13,10 @@
 // limitations under the License.
 
 #include "py_func_resolver.hpp"
-
-#include <pybind11/pybind11.h>
-
-#include <mlir/IR/BuiltinOps.h>
-
 #include "py_map_types.hpp"
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/IR/BuiltinOps.h>
+#include <pybind11/pybind11.h>
 
 namespace py = pybind11;
 

--- a/numba_dpcomp/setup.py
+++ b/numba_dpcomp/setup.py
@@ -41,7 +41,7 @@ if int(os.environ.get("DPCOMP_SETUP_RUN_CMAKE", 1)):
     LLVM_PATH = os.environ["LLVM_PATH"]
     LLVM_DIR = os.path.join(LLVM_PATH, "lib", "cmake", "llvm")
     MLIR_DIR = os.path.join(LLVM_PATH, "lib", "cmake", "mlir")
-    TBB_DIR = os.path.join(os.environ["TBB_PATH"], "lib", "cmake", "tbb")
+    # TBB_DIR = os.path.join(os.environ["TBB_PATH"], "lib", "cmake", "tbb")
     CMAKE_INSTALL_PREFIX = root_dir
 
     cmake_build_dir = os.path.join(root_dir, "cmake_build")
@@ -55,15 +55,15 @@ if int(os.environ.get("DPCOMP_SETUP_RUN_CMAKE", 1)):
     NUMPY_INCLUDE_DIR = numpy.get_include()
 
     cmake_cmd += [
-        "..",
+        "../numba_dpcomp",
         "-DCMAKE_BUILD_TYPE=Release",
         "-DLLVM_DIR=" + LLVM_DIR,
         "-DMLIR_DIR=" + MLIR_DIR,
-        "-DTBB_DIR=" + TBB_DIR,
+        # "-DTBB_DIR=" + TBB_DIR,
         "-DCMAKE_INSTALL_PREFIX=" + CMAKE_INSTALL_PREFIX,
         "-DPython3_NumPy_INCLUDE_DIRS=" + NUMPY_INCLUDE_DIR,
         "-DPython3_FIND_STRATEGY=LOCATION",
-        "-DIMEX_ENABLE_NUMBA_FE=ON",
+        # "-DIMEX_ENABLE_NUMBA_FE=ON",
         "-DIMEX_ENABLE_NUMBA_HOTFIX=ON",
         "-DIMEX_ENABLE_TBB_SUPPORT=ON",
     ]
@@ -83,15 +83,15 @@ if int(os.environ.get("DPCOMP_SETUP_RUN_CMAKE", 1)):
     except ImportError:
         print("DPNP not found")
 
-    # GPU/L0
-    LEVEL_ZERO_DIR = os.getenv("LEVEL_ZERO_DIR", None)
-    if LEVEL_ZERO_DIR is None:
-        print("LEVEL_ZERO_DIR is not set")
-    else:
-        print("LEVEL_ZERO_DIR is", LEVEL_ZERO_DIR)
-        cmake_cmd += [
-            "-DIMEX_ENABLE_IGPU_DIALECT=ON",
-        ]
+    # # GPU/L0
+    # LEVEL_ZERO_DIR = os.getenv("LEVEL_ZERO_DIR", None)
+    # if LEVEL_ZERO_DIR is None:
+    #     print("LEVEL_ZERO_DIR is not set")
+    # else:
+    #     print("LEVEL_ZERO_DIR is", LEVEL_ZERO_DIR)
+    #     cmake_cmd += [
+    #         "-DIMEX_ENABLE_IGPU_DIALECT=ON",
+    #     ]
 
     try:
         os.mkdir(cmake_build_dir)

--- a/numba_dpcomp/setup.py
+++ b/numba_dpcomp/setup.py
@@ -64,8 +64,8 @@ if int(os.environ.get("DPCOMP_SETUP_RUN_CMAKE", 1)):
         "-DPython3_NumPy_INCLUDE_DIRS=" + NUMPY_INCLUDE_DIR,
         "-DPython3_FIND_STRATEGY=LOCATION",
         # "-DIMEX_ENABLE_NUMBA_FE=ON",
-        "-DIMEX_ENABLE_NUMBA_HOTFIX=ON",
-        "-DIMEX_ENABLE_TBB_SUPPORT=ON",
+        # "-DIMEX_ENABLE_NUMBA_HOTFIX=ON",
+        # "-DIMEX_ENABLE_TBB_SUPPORT=ON",
     ]
 
     # DPNP

--- a/scripts/build_locally.py
+++ b/scripts/build_locally.py
@@ -49,7 +49,7 @@ def _sha_matched(llvm_install_dir, llvm_sha):
 
     Raises:
         RuntimeError: When the SHA could not be found in the LLVM installation
-        direcotry.
+        directory.
 
     Returns:
         bool: True if the two SHAs matched, else False
@@ -84,9 +84,7 @@ def _configure_llvm_build(
     except FileExistsError:
         raise RuntimeError("Could not create build directory.")
     except FileNotFoundError:
-        raise RuntimeError(
-            f"Could not create build direcotry {llvm_build_dir}", llvm_build_dir,
-        )
+        raise RuntimeError("Could not create build directory" + llvm_build_dir)
 
     if "linux" in sys.platform:
         if c_compiler is None:
@@ -159,8 +157,8 @@ def _build_llvm(
     # Check if the LLVM source directory exists
     if not os.path.exists(llvm_src_dir):
         raise RuntimeError(
-            f"llvm_src_dir specified as {llvm_src_dir} does not exist.",
-            os.path.abspath(llvm_src_dir),
+            "llvm_src_dir specified as %s does not exist.",
+            (os.path.abspath(llvm_src_dir)),
         )
     cmake_exec = [cmake_executable if cmake_executable else "cmake"]
     mlir_install_prefix = (
@@ -189,7 +187,7 @@ def _build_llvm(
         )
     finally:
         if not save_llvm_build_dir:
-            print("Removing the llvm build direcotry")
+            print("Removing the llvm build directory")
             shutil.rmtree(llvm_build_dir)
 
     return mlir_install_prefix
@@ -198,7 +196,7 @@ def _build_llvm(
 def _get_llvm(llvm_sha=None, working_dir=None):
     """Checks out the llvm git repo.
 
-    The llvm git repo is cloned either to a sub-direcotry inside the provided
+    The llvm git repo is cloned either to a sub-directory inside the provided
     "working_dir" or into the system tmp folder. If a commit SHA is provided,
     then the commit is checked out into a new branch. The location of the cloned
     git repo is returned to caller.
@@ -207,7 +205,7 @@ def _get_llvm(llvm_sha=None, working_dir=None):
         working_dir (str, optional): Path where the LLVM repo is to be cloned.
         If None, then defaults to system temp directory.
         Defaults to None.
-        llvm_sha (str, optional): LLVM SHA that should be checkedout after
+        llvm_sha (str, optional): LLVM SHA that should be checked out after
         cloning. Defaults to None.
 
     Raises:
@@ -236,7 +234,7 @@ def _get_llvm(llvm_sha=None, working_dir=None):
             raise RuntimeError("Found existing build directory.")
         except FileNotFoundError:
             raise RuntimeError(
-                f"Could not create build direcotry {git_checkout_dir}",
+                f"Could not create build directory {git_checkout_dir}",
                 git_checkout_dir,
             )
 


### PR DESCRIPTION
The PR is working towards converting IMEX into an SDK that will make it possible to use it cleanly in out external projects. As part of the changes the following things will be completed:

- [ ] Changes to IMEX and numba_dpcomp `CMakeLists.txt` to make them independent of each otther.
- [x] Rename directories (dialect, transforms, _etc._) to match upstream conventions.
- [ ] Add `IMEXConfig.cmake` module that will help the IMEX headers and library to be discovered by other CMake projects.
- [ ] Update build_locally.py and the GithubActions CI to build `numba_dpcomp` and run its tests.
- [ ] Rename `numba_dpcomp` to `numba_mlir`. The name dpcomp is not descriptive.
- [ ] Convert IMEX to a conda package that contains IMEX and `numba_mlir` so that it can be used in other places (such as `numba_dpex`).

In addition, as `numba_dpcomp` was not updated along with IMEX when the LLVM SHA was updated the PR will contain a standalone commit to fix build problems in numba_dpcomp with current LLVM SHA.
