### PR TITLE
Attempting to fix CI by installing lit from conda-forge.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Install CMake and Ninja
         run: |
-          conda install cmake ninja
+          conda install cmake ninja conda-forge::lit
 
       - name: Checkout repo
         uses: actions/checkout@v2


### PR DESCRIPTION
The issue with failing CI is that the LLVM_EXTERNAL_LIT is not found in the build directory. In any case, that is an anti pattern. It is recommended to use a system `lit` to run tests.

The PR is attempting to fix the issue by installing lit into the conda environment. 
