### PR TITLE
Python pipeline refactoring and cleanup

### DIFF
--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_llvm.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_llvm.cpp
@@ -1755,6 +1755,7 @@ struct LowerReleaseContextOp
   }
 };
 
+// Convert operations from the plier_util dialect to the LLVM dialect.
 struct PierUtilToLLVMPass
     : public mlir::PassWrapper<PierUtilToLLVMPass,
                                mlir::OperationPass<mlir::ModuleOp>> {

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_llvm.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_llvm.cpp
@@ -1787,7 +1787,7 @@ struct PierUtilToLLVMPass
 
     mlir::LLVMConversionTarget target(context);
     target.addLegalOp<mlir::func::FuncOp>();
-    target.addIllegalOp<plier::TakeContextOp, plier::ReleaseContextOp>();
+    target.addIllegalDialect<plier::PlierUtilDialect>();
     if (failed(applyPartialConversion(op, target, std::move(patterns))))
       signalPassFailure();
   }

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_llvm.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_llvm.cpp
@@ -1755,7 +1755,7 @@ struct LowerReleaseContextOp
   }
 };
 
-// Convert operations from the plier_util dialect to the LLVM dialect.
+/// Convert operations from the plier_util dialect to the LLVM dialect.
 struct PierUtilToLLVMPass
     : public mlir::PassWrapper<PierUtilToLLVMPass,
                                mlir::OperationPass<mlir::ModuleOp>> {

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_scf.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_scf.cpp
@@ -595,6 +595,9 @@ struct CondBranchSameTargetRewrite
   }
 };
 
+// Convert plier::ArgOp into direct function argument access. ArgOp is just an
+// artifact of Numba IR conversion and doens't really have any functional
+// meaning so we can get rid of ot early.
 struct LowerArgOps
     : public plier::RewriteWrapperPass<
           LowerArgOps, void, plier::DependentDialectsList<plier::PlierDialect>,

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_scf.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_scf.cpp
@@ -597,7 +597,7 @@ struct CondBranchSameTargetRewrite
 
 /// Convert plier::ArgOp into direct function argument access. ArgOp is just an
 /// artifact of Numba IR conversion and doesn't really have any functional
-/// meaning so we can get rid of of it early.
+/// meaning so we can get rid of it early.
 struct LowerArgOps
     : public plier::RewriteWrapperPass<
           LowerArgOps, void, plier::DependentDialectsList<plier::PlierDialect>,

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_scf.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_scf.cpp
@@ -595,9 +595,9 @@ struct CondBranchSameTargetRewrite
   }
 };
 
-// Convert plier::ArgOp into direct function argument access. ArgOp is just an
-// artifact of Numba IR conversion and doens't really have any functional
-// meaning so we can get rid of ot early.
+/// Convert plier::ArgOp into direct function argument access. ArgOp is just an
+/// artifact of Numba IR conversion and doesn't really have any functional
+/// meaning so we can get rid of of it early.
 struct LowerArgOps
     : public plier::RewriteWrapperPass<
           LowerArgOps, void, plier::DependentDialectsList<plier::PlierDialect>,

--- a/tools/FileCheck/CMakeLists.txt
+++ b/tools/FileCheck/CMakeLists.txt
@@ -14,6 +14,11 @@
 
 find_package(LLVM REQUIRED CONFIG)
 
+if (TARGET FileCheck)
+  message(STATUS "FileCheck already exists, skipping local")
+  return()
+endif()
+
 list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
 include(AddLLVM)
 include(HandleLLVMOptions)


### PR DESCRIPTION
* Do not build local FileCheck if external is present (it will fail due to target name conflict)
* Extract `LowerArgOps` pattern from `PlierToScfPass` into separate pass, `PlierToScfPass` no longer uses any python ops (it is still uses `UndefOp` though)
* Separate utils ops llvm lowering  from python specific lowering so it can be later used outside python pipeline (required by gpu pipeline, will be done in separate PR)