### PR TITLE
fixing caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           path: |
             /home/runner/work/tbb/*
-          key: ${{ runner.os }}-build-tbb-${{ env.TBBVER }}
+          key: ${{ runner.os }}-build-tbb-${{ env.TBB_VER }}
 
       - name: Cache Level-Zero
         id: cache-level-zero

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       TBB_VER: 2021.5.0
       LEVEL_ZERO_VER: v1.6.2
       TBB_URL_PREFIX: https://github.com/oneapi-src/oneTBB/releases/download/
-      LLVM_SHA: /home/runner/work/mlir-extensions/mlir-extensions/llvm-sha.txt
+      LLVM_SHA_FILE: /home/runner/work/mlir-extensions/mlir-extensions/llvm-sha.txt
 
     strategy:
       matrix:
@@ -56,13 +56,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Cache Vars
+        run: |
+          echo 'LLVM_SHA<<EOF' >> $GITHUB_ENV
+          cat $LLVM_SHA_FILE >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
       - name: Cache TBB
         id: cache-tbb
         uses: actions/cache@v3
         with:
           path: |
             /home/runner/work/tbb/*
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/home/runner/work/tbb/bundle_id.txt') }}
+          key: ${{ runner.os }}-build-tbb-${{ env.TBBVER }}
 
       - name: Cache Level-Zero
         id: cache-level-zero
@@ -70,7 +76,7 @@ jobs:
         with:
           path: |
             /home/runner/work/level-zero/**
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/home/runner/work/level-zero/bundle_id.txt') }}
+          key: ${{ runner.os }}-build-l0-${{ env.LEVEL_ZERO_VER }}
 
       - name: Cache LLLVM-MLIR
         id: cache-llvm-mlir
@@ -80,9 +86,10 @@ jobs:
         with:
           path: |
             /home/runner/work/llvm-mlir/_mlir_install/**
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.CACHE_NUMBER }}-${{ hashFiles( env.LLVM_SHA ) }}
+          key: ${{ runner.os }}-build-llvm-${{ env.CACHE_NUMBER }}-${{ env.LLVM_SHA }}
 
       - name: Download TBB
+        if: steps.cache-tbb.outputs.cache-hit != 'true'
         shell: bash -l {0}
         run: |
           cd /home/runner/work
@@ -102,6 +109,7 @@ jobs:
           popd
 
       - name: Download and Build Level-Zero
+        if: steps.cache-level-zero.outputs.cache-hit != 'true'
         shell: bash -l {0}
         run: |
           cd /home/runner/work
@@ -139,7 +147,7 @@ jobs:
           np=`nproc`
           git clone https://github.com/llvm/llvm-project || exit 1
           cd llvm-project || exit 1
-          git checkout `cat ${{ env.LLVM_SHA }}` || exit 1
+          git checkout $LLVM_SHA || exit 1
           mkdir _build || exit 1
           cd _build || exit 1
           cmake ../llvm                                                    \
@@ -149,6 +157,7 @@ jobs:
             -DLLVM_ENABLE_ASSERTIONS=ON                                    \
             -DLLVM_ENABLE_RTTI=ON                                          \
             -DLLVM_USE_LINKER=gold                                         \
+            -DLLVM_INSTALL_UTILS=ON                                        \
             -DCMAKE_INSTALL_PREFIX=/home/runner/work/llvm-mlir/_mlir_install || exit 1
           cmake --build . -j ${np} || exit 1
           cmake --install . || exit 1


### PR DESCRIPTION
Current use of sha's/hashing does not produce any values.
Fixed it by using version number for cache name (TBB, L0) or sha from file (LLVM).
This will make sure we use the same naming in main and refactor and so refactor can re-use cache from main. Otherwise eny PR against refactor will rebuild LLVM et al.

@Hardcode84 @diptorupd @nbpatel 

Please review these guidelines to help with the review process:
- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [x] Have you organized your commits logically and ensured each can be built by itself?
