### PR TITLE
Fix Python gpu tests

### DIFF
--- a/mlir/lib/Conversion/gpu_runtime_to_llvm.cpp
+++ b/mlir/lib/Conversion/gpu_runtime_to_llvm.cpp
@@ -871,10 +871,12 @@ struct GPUToLLVMPass
                                                             target);
     mlir::populateGpuToLLVMConversionPatterns(
         converter, patterns, mlir::gpu::getDefaultGpuBinaryAnnotation());
+#if defined(IMEX_ENABLE_NUMBA_HOTFIX)
     mlir::populateFunctionOpInterfaceTypeConversionPattern<mlir::func::FuncOp>(
         patterns, converter);
     mlir::populateReturnOpTypeConversionPattern(patterns, converter);
     mlir::populateCallOpTypeConversionPattern(patterns, converter);
+#endif
 
     target.addDynamicallyLegalOp<mlir::func::FuncOp>(
         [&](mlir::func::FuncOp op) -> llvm::Optional<bool> {

--- a/mlir/lib/Conversion/gpu_runtime_to_llvm.cpp
+++ b/mlir/lib/Conversion/gpu_runtime_to_llvm.cpp
@@ -871,12 +871,10 @@ struct GPUToLLVMPass
                                                             target);
     mlir::populateGpuToLLVMConversionPatterns(
         converter, patterns, mlir::gpu::getDefaultGpuBinaryAnnotation());
-#if defined(IMEX_ENABLE_NUMBA_HOTFIX)
     mlir::populateFunctionOpInterfaceTypeConversionPattern<mlir::func::FuncOp>(
         patterns, converter);
     mlir::populateReturnOpTypeConversionPattern(patterns, converter);
     mlir::populateCallOpTypeConversionPattern(patterns, converter);
-#endif
 
     target.addDynamicallyLegalOp<mlir::func::FuncOp>(
         [&](mlir::func::FuncOp op) -> llvm::Optional<bool> {

--- a/mlir/lib/Conversion/gpu_to_gpu_runtime.cpp
+++ b/mlir/lib/Conversion/gpu_to_gpu_runtime.cpp
@@ -829,7 +829,10 @@ static mlir::Value lowerFloatSubAtomic(mlir::OpBuilder &builder,
 
 class ConvertAtomicOps : public mlir::OpConversionPattern<mlir::func::CallOp> {
 public:
-  using OpConversionPattern::OpConversionPattern;
+  ConvertAtomicOps(mlir::TypeConverter &typeConverter,
+                   mlir::MLIRContext *context)
+      : mlir::OpConversionPattern<mlir::func::CallOp>(typeConverter, context,
+                                                      /*benefit*/ 10) {}
 
   mlir::LogicalResult
   matchAndRewrite(mlir::func::CallOp op, mlir::func::CallOp::Adaptor adaptor,

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_llvm.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_llvm.cpp
@@ -1560,16 +1560,31 @@ struct LowerTakeContextOp
             &func.getBody(), mlir::Region::iterator{}, ctxType, unknownLoc);
         rewriter.setInsertionPointToStart(block);
 
-        auto innerResults = rewriter
-                                .create<mlir::func::CallOp>(
-                                    unknownLoc, initFuncSym, results.getTypes())
-                                ->getResults();
+        auto initFunc = mod.lookupSymbol<mlir::func::FuncOp>(initFuncSym);
+        assert(initFunc && "Invalid init func");
+        auto initFuncType = initFunc.getFunctionType();
+        assert(initFuncType.getNumResults() == resultsCount);
+
+        auto innerResults =
+            rewriter
+                .create<mlir::func::CallOp>(unknownLoc, initFuncSym,
+                                            initFuncType.getResults())
+                ->getResults();
 
         mlir::Value ctxStruct =
             rewriter.create<mlir::LLVM::UndefOp>(unknownLoc, ctxStructType);
         for (auto i : llvm::seq(0u, resultsCount)) {
           auto pos = rewriter.getI64ArrayAttr(i);
-          auto val = rewriter.getRemappedValue(innerResults[i]);
+          auto srcType = initFuncType.getResult(i);
+          auto convertedType = converter->convertType(srcType);
+          assert(convertedType && "Invalid init func result type");
+
+          mlir::Value val = innerResults[i];
+          if (convertedType != srcType)
+            val = converter->materializeSourceConversion(rewriter, unknownLoc,
+                                                         convertedType, val);
+          assert(val && "Invalid init func result type");
+
           ctxStruct = rewriter.create<mlir::LLVM::InsertValueOp>(
               unknownLoc, ctxStruct, val, pos);
         }
@@ -1603,17 +1618,20 @@ struct LowerTakeContextOp
         auto ctxStruct =
             rewriter.create<mlir::LLVM::LoadOp>(unknownLoc, ctxStructType, ptr);
 
+        auto deinitFunc = mod.lookupSymbol<mlir::func::FuncOp>(deinitFuncSym);
+        assert(deinitFunc && "Invalid deinit func");
+        auto deinitFuncType = deinitFunc.getFunctionType();
+        assert(deinitFuncType.getNumInputs() == resultsCount);
+
         llvm::SmallVector<mlir::Value> args(resultsCount);
         for (auto i : llvm::seq(0u, resultsCount)) {
           auto pos = rewriter.getI64ArrayAttr(i);
           mlir::Value val = rewriter.create<mlir::LLVM::ExtractValueOp>(
               unknownLoc, resultTypes[i], ctxStruct, pos);
-          auto resType = results[i].getType();
-          if (val.getType() != resType)
-            val = rewriter
-                      .create<mlir::UnrealizedConversionCastOp>(unknownLoc,
-                                                                resType, val)
-                      .getResult(0);
+          auto resType = deinitFuncType.getInput(i);
+          if (resultTypes[i] != resType)
+            val = converter->materializeTargetConversion(rewriter, unknownLoc,
+                                                         resType, val);
 
           args[i] = val;
         }
@@ -1756,12 +1774,12 @@ struct LowerReleaseContextOp
 };
 
 /// Convert operations from the plier_util dialect to the LLVM dialect.
-struct PierUtilToLLVMPass
-    : public mlir::PassWrapper<PierUtilToLLVMPass,
+struct PlierUtilToLLVMPass
+    : public mlir::PassWrapper<PlierUtilToLLVMPass,
                                mlir::OperationPass<mlir::ModuleOp>> {
-  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PierUtilToLLVMPass)
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PlierUtilToLLVMPass)
 
-  PierUtilToLLVMPass() = default;
+  PlierUtilToLLVMPass() = default;
 
   void runOnOperation() override {
     mlir::Operation *op = getOperation();
@@ -1787,6 +1805,7 @@ struct PierUtilToLLVMPass
 
     mlir::LLVMConversionTarget target(context);
     target.addLegalOp<mlir::func::FuncOp>();
+    target.addLegalOp<mlir::func::CallOp>();
     target.addIllegalDialect<plier::PlierUtilDialect>();
     if (failed(applyPartialConversion(op, target, std::move(patterns))))
       signalPassFailure();
@@ -1850,7 +1869,7 @@ static void populateLowerToLlvmPipeline(mlir::OpPassManager &pm) {
   pm.addNestedPass<mlir::func::FuncOp>(std::make_unique<PreLLVMLowering>());
   pm.addNestedPass<mlir::func::FuncOp>(mlir::createConvertMathToLLVMPass());
   pm.addPass(mlir::createConvertMathToLibmPass());
-  pm.addPass(std::make_unique<PierUtilToLLVMPass>());
+  pm.addPass(std::make_unique<PlierUtilToLLVMPass>());
   pm.addPass(std::make_unique<LLVMLoweringPass>());
   pm.addNestedPass<mlir::LLVM::LLVMFuncOp>(
       std::make_unique<PostLLVMLowering>());


### PR DESCRIPTION
* `LowerTakeContextOp`: insert proper type conversion on function call boundaries
* `ConvertAtomicOps`: increase pattern benefit. We are representing gpu atomic ops as calls to functions with some magical names, but upstream recently added theirs own lowering for functions calls in spirv. Increase benefit of our pattern so it is always running first.