### PR TITLE
Remove one of IMEX_ENABLE_NUMBA_HOTFIX hacks

### DIFF
--- a/mlir/lib/Conversion/gpu_runtime_to_llvm.cpp
+++ b/mlir/lib/Conversion/gpu_runtime_to_llvm.cpp
@@ -871,12 +871,10 @@ struct GPUToLLVMPass
                                                             target);
     mlir::populateGpuToLLVMConversionPatterns(
         converter, patterns, mlir::gpu::getDefaultGpuBinaryAnnotation());
-#if defined(IMEX_ENABLE_NUMBA_HOTFIX)
     mlir::populateFunctionOpInterfaceTypeConversionPattern<mlir::func::FuncOp>(
         patterns, converter);
     mlir::populateReturnOpTypeConversionPattern(patterns, converter);
     mlir::populateCallOpTypeConversionPattern(patterns, converter);
-#endif
 
     target.addDynamicallyLegalOp<mlir::func::FuncOp>(
         [&](mlir::func::FuncOp op) -> llvm::Optional<bool> {

--- a/mlir/tools/level_zero_runner/level_zero_runner.cpp
+++ b/mlir/tools/level_zero_runner/level_zero_runner.cpp
@@ -94,8 +94,8 @@ static LogicalResult runMLIRPasses(ModuleOp module) {
   // GpuRuntime -> LLVM
 
   passManager.addPass(gpu_runtime::createEnumerateEventsPass());
-  passManager.addPass(gpu_runtime::createGPUToLLVMPass());
   passManager.addPass(createConvertFuncToLLVMPass(llvmOptions));
+  passManager.addPass(gpu_runtime::createGPUToLLVMPass());
   passManager.addPass(createMemRefToLLVMPass());
   passManager.addPass(createReconcileUnrealizedCastsPass());
 


### PR DESCRIPTION
`GPUToLLVMPass` was causing failures in L0 runner tests due to specific ABI requirements in runner runtime for functions taking memrefs and generic patterns not following them.
`createConvertFuncToLLVMPass` contains required transformations for ABI compliance so run it before our pass.

Tested locally on gpu and runner tests passed.