### PR TITLE
Add additional canonicalization to ChangeLayoutOp

### DIFF
--- a/mlir/include/mlir-extensions/Dialect/plier_util/PlierUtilOps.td
+++ b/mlir/include/mlir-extensions/Dialect/plier_util/PlierUtilOps.td
@@ -27,6 +27,8 @@ def PlierUtil_Dialect : Dialect {
   let name = "plier_util";
   let cppNamespace = "plier";
 
+  let dependentDialects = ["::mlir::memref::MemRefDialect"];
+
   let hasCanonicalizer = 1;
   let hasConstantMaterializer = 1;
   let useDefaultTypePrinterParser = 1;
@@ -107,7 +109,9 @@ def RetainOp : PlierUtil_Op<"retain", [ViewLikeOpInterface]> {
 def ChangeLayoutOp : PlierUtil_Op<"change_layout", [ViewLikeOpInterface, NoSideEffect]> {
   let arguments = (ins AnyMemRef : $source);
 
-  let results = (outs AnyMemRef);
+  let results = (outs AnyMemRef : $dest);
+  let assemblyFormat = "$source attr-dict `:` type($source) `to` type($dest)";
+
   let hasFolder = 1;
   let hasCanonicalizer = 1;
 

--- a/mlir/lib/Dialect/plier_util/dialect.cpp
+++ b/mlir/lib/Dialect/plier_util/dialect.cpp
@@ -1041,6 +1041,56 @@ struct ChangeLayoutExpandShape
   }
 };
 
+struct ChangeLayoutSelect
+    : public mlir::OpRewritePattern<mlir::arith::SelectOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::arith::SelectOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (!op.getResult().getType().isa<mlir::MemRefType>())
+      return mlir::failure();
+
+    auto trueArg = op.getTrueValue();
+    auto falseArg = op.getFalseValue();
+    for (bool reverse : {false, true}) {
+      auto arg = reverse ? falseArg : trueArg;
+      auto cl = arg.getDefiningOp<plier::ChangeLayoutOp>();
+      if (!cl)
+        continue;
+
+      auto srcType = cl.source().getType().cast<mlir::MemRefType>();
+      auto dstType = arg.getType().cast<mlir::MemRefType>();
+
+      auto otherArg = reverse ? trueArg : falseArg;
+
+      auto otherArgType = otherArg.getType().cast<mlir::MemRefType>();
+      if (!canTransformLayoutCast(otherArgType, srcType))
+        continue;
+
+      auto loc = op->getLoc();
+      otherArg = rewriter.create<mlir::memref::CastOp>(loc, srcType, otherArg);
+      arg = cl.source();
+
+      if (reverse) {
+        trueArg = otherArg;
+        falseArg = arg;
+      } else {
+        trueArg = arg;
+        falseArg = otherArg;
+      }
+
+      auto cond = op.getCondition();
+      auto result = rewriter.create<mlir::arith::SelectOp>(loc, cond, trueArg, falseArg);
+      rewriter.replaceOpWithNewOp<plier::ChangeLayoutOp>(op, dstType, result);
+
+      return mlir::success();
+    }
+
+    return mlir::failure();
+  }
+};
+
 } // namespace
 
 void ChangeLayoutOp::getCanonicalizationPatterns(
@@ -1051,7 +1101,7 @@ void ChangeLayoutOp::getCanonicalizationPatterns(
       ChangeLayoutFromCast, ChangeLayoutLoad, ChangeLayoutStore,
       ChangeLayoutSubview, ChangeLayoutLinalgGeneric, ChangeLayoutLinalgFill,
       ChangeLayoutIf, ChangeLayout1DReshape, ChangeLayoutSliceGetItem,
-      ChangeLayoutCopy, ChangeLayoutExpandShape>(context);
+      ChangeLayoutCopy, ChangeLayoutExpandShape, ChangeLayoutSelect>(context);
 }
 
 static mlir::Value propagateCasts(mlir::Value val, mlir::Type thisType);

--- a/mlir/lib/Dialect/plier_util/dialect.cpp
+++ b/mlir/lib/Dialect/plier_util/dialect.cpp
@@ -1081,7 +1081,8 @@ struct ChangeLayoutSelect
       }
 
       auto cond = op.getCondition();
-      auto result = rewriter.create<mlir::arith::SelectOp>(loc, cond, trueArg, falseArg);
+      auto result =
+          rewriter.create<mlir::arith::SelectOp>(loc, cond, trueArg, falseArg);
       rewriter.replaceOpWithNewOp<plier::ChangeLayoutOp>(op, dstType, result);
 
       return mlir::success();

--- a/mlir/lib/Dialect/plier_util/dialect.cpp
+++ b/mlir/lib/Dialect/plier_util/dialect.cpp
@@ -1041,6 +1041,16 @@ struct ChangeLayoutExpandShape
   }
 };
 
+/// Propagates ChangeLayoutOp through SelectOp.
+///
+/// Example:
+/// %0 = plier_util.change_layout %arg1 : memref<?xi32, #map> to memref<?xi32>
+/// %res = arith.select %arg3, %0, %arg2 : memref<?xi32>
+///
+/// Becomes:
+/// %0 = memref.cast %arg2 : memref<?xi32> to memref<?xi32, #map>
+/// %1 = arith.select %arg3, %arg1, %0 : memref<?xi32, #map>
+/// %res  = plier_util.change_layout %1 : memref<?xi32, #map> to memref<?xi32>
 struct ChangeLayoutSelect
     : public mlir::OpRewritePattern<mlir::arith::SelectOp> {
   using OpRewritePattern::OpRewritePattern;

--- a/mlir/test/Dialect/plier_util/canonicalize-change-layout.mlir
+++ b/mlir/test/Dialect/plier_util/canonicalize-change-layout.mlir
@@ -1,0 +1,41 @@
+// RUN: imex-opt %s -canonicalize --split-input-file | FileCheck %s
+
+
+// CHECK-LABEL: func @test_change_layout
+//  CHECK-SAME:   (%[[ARG:.*]]: memref<?xi32>) -> memref<?xi32, #[[MAP:.*]]>
+//       CHECK:   %[[RES:.*]] = memref.cast %[[ARG]] : memref<?xi32> to memref<?xi32, #[[MAP]]>
+//       CHECK:   return %[[RES]]
+#map = affine_map<(d0)[s0, s1] -> (s0 + s1 * d0)>
+func.func @test_change_layout(%arg : memref<?xi32>) -> memref<?xi32, #map> {
+  %0 = plier_util.change_layout %arg : memref<?xi32> to memref<?xi32, #map>
+  return %0 : memref<?xi32, #map>
+}
+
+// -----
+
+// CHECK-LABEL: func @test_change_layout
+//  CHECK-SAME:   (%[[ARG:.*]]: memref<?xi32, #[[MAP:.*]]>) -> index
+//       CHECK:   %[[C:.*]] = arith.constant 0 : index
+//       CHECK:   %[[RES:.*]]  = memref.dim %[[ARG]], %[[C]] : memref<?xi32, #[[MAP:.*]]>
+//       CHECK:   return %[[RES]]
+#map = affine_map<(d0)[s0, s1] -> (s0 + s1 * d0)>
+func.func @test_change_layout(%arg : memref<?xi32, #map>) -> index {
+  %0 = plier_util.change_layout %arg : memref<?xi32, #map> to memref<?xi32>
+  %c0 = arith.constant 0 : index
+  %1 = memref.dim %0, %c0 : memref<?xi32>
+  return %1 : index
+}
+
+// -----
+
+// CHECK-LABEL: func @test_change_layout
+//  CHECK-SAME:   (%[[ARG:.*]]: memref<?xi32, #[[MAP:.*]]>) -> memref<?xi32>
+//       CHECK:   %[[CLONE:.*]]  = bufferization.clone %[[ARG]] : memref<?xi32, #[[MAP:.*]]> to memref<?xi32, #[[MAP:.*]]>
+//       CHECK:   %[[RES:.*]]  = plier_util.change_layout %[[CLONE]] : memref<?xi32, #map> to memref<?xi32>
+//       CHECK:   return %[[RES]]
+#map = affine_map<(d0)[s0, s1] -> (s0 + s1 * d0)>
+func.func @test_change_layout(%arg : memref<?xi32, #map>) -> memref<?xi32> {
+  %0 = plier_util.change_layout %arg : memref<?xi32, #map> to memref<?xi32>
+  %1 = bufferization.clone %0 : memref<?xi32> to memref<?xi32>
+  return %1 : memref<?xi32>
+}

--- a/mlir/test/Dialect/plier_util/canonicalize-change-layout.mlir
+++ b/mlir/test/Dialect/plier_util/canonicalize-change-layout.mlir
@@ -30,12 +30,42 @@ func.func @test_change_layout(%arg : memref<?xi32, #map>) -> index {
 
 // CHECK-LABEL: func @test_change_layout
 //  CHECK-SAME:   (%[[ARG:.*]]: memref<?xi32, #[[MAP:.*]]>) -> memref<?xi32>
-//       CHECK:   %[[CLONE:.*]]  = bufferization.clone %[[ARG]] : memref<?xi32, #[[MAP:.*]]> to memref<?xi32, #[[MAP:.*]]>
-//       CHECK:   %[[RES:.*]]  = plier_util.change_layout %[[CLONE]] : memref<?xi32, #map> to memref<?xi32>
+//       CHECK:   %[[CLONE:.*]]  = bufferization.clone %[[ARG]] : memref<?xi32, #[[MAP]]> to memref<?xi32, #[[MAP]]>
+//       CHECK:   %[[RES:.*]]  = plier_util.change_layout %[[CLONE]] : memref<?xi32, #[[MAP]]> to memref<?xi32>
 //       CHECK:   return %[[RES]]
 #map = affine_map<(d0)[s0, s1] -> (s0 + s1 * d0)>
 func.func @test_change_layout(%arg : memref<?xi32, #map>) -> memref<?xi32> {
   %0 = plier_util.change_layout %arg : memref<?xi32, #map> to memref<?xi32>
   %1 = bufferization.clone %0 : memref<?xi32> to memref<?xi32>
+  return %1 : memref<?xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func @test_change_layout
+//  CHECK-SAME:   (%[[ARG1:.*]]: memref<?xi32, #[[MAP:.*]]>, %[[ARG2:.*]]: memref<?xi32>, %[[ARG3:.*]]: i1) -> memref<?xi32>
+//       CHECK:   %[[CAST:.*]]  = memref.cast %[[ARG2]] : memref<?xi32> to memref<?xi32, #[[MAP]]>
+//       CHECK:   %[[SELECT:.*]]  = arith.select %[[ARG3]], %[[ARG1]], %[[CAST]] : memref<?xi32, #[[MAP]]>
+//       CHECK:   %[[RES:.*]]  = plier_util.change_layout %[[SELECT]] : memref<?xi32, #[[MAP]]> to memref<?xi32>
+//       CHECK:   return %[[RES]]
+#map = affine_map<(d0)[s0, s1] -> (s0 + s1 * d0)>
+func.func @test_change_layout(%arg1 : memref<?xi32, #map>, %arg2 : memref<?xi32>, %arg3 : i1) -> memref<?xi32> {
+  %0 = plier_util.change_layout %arg1 : memref<?xi32, #map> to memref<?xi32>
+  %1 = arith.select %arg3, %0, %arg2 : memref<?xi32>
+  return %1 : memref<?xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func @test_change_layout
+//  CHECK-SAME:   (%[[ARG1:.*]]: memref<?xi32>, %[[ARG2:.*]]: memref<?xi32, #[[MAP:.*]]>, %[[ARG3:.*]]: i1) -> memref<?xi32>
+//       CHECK:   %[[CAST:.*]]  = memref.cast %[[ARG1]] : memref<?xi32> to memref<?xi32, #[[MAP]]>
+//       CHECK:   %[[SELECT:.*]]  = arith.select %[[ARG3]], %[[CAST]], %[[ARG2]] : memref<?xi32, #[[MAP]]>
+//       CHECK:   %[[RES:.*]]  = plier_util.change_layout %[[SELECT]] : memref<?xi32, #[[MAP]]> to memref<?xi32>
+//       CHECK:   return %[[RES]]
+#map = affine_map<(d0)[s0, s1] -> (s0 + s1 * d0)>
+func.func @test_change_layout(%arg1 : memref<?xi32>, %arg2 : memref<?xi32, #map>, %arg3 : i1) -> memref<?xi32> {
+  %0 = plier_util.change_layout %arg2 : memref<?xi32, #map> to memref<?xi32>
+  %1 = arith.select %arg3, %arg1, %0 : memref<?xi32>
   return %1 : memref<?xi32>
 }

--- a/mlir/tools/imex-opt/main.cpp
+++ b/mlir/tools/imex-opt/main.cpp
@@ -17,10 +17,13 @@
 #include <mlir/InitAllPasses.h>
 #include <mlir/Tools/mlir-opt/MlirOptMain.h>
 
+#include "mlir-extensions/Dialect/plier_util/dialect.hpp"
+
 int main(int argc, char **argv) {
   mlir::registerAllPasses();
   mlir::DialectRegistry registry;
   mlir::registerAllDialects(registry);
+  registry.insert<plier::PlierUtilDialect>();
   return mlir::failed(MlirOptMain(argc, argv, "imex modular optimizer driver\n",
                                   registry,
                                   /*preloadDialectsInContext=*/false));

--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_numpy.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_numpy.py
@@ -1331,7 +1331,6 @@ def test_mean_loop(arr, parallel):
     assert_equal(py_func(arr), jit_func(arr))
 
 
-@pytest.mark.skipif(reason="Failure in propagate layout pass")
 @pytest.mark.parametrize(
     "arr",
     [


### PR DESCRIPTION
`ChangeLayoutOp` is used to 'align' memrefs layouts after bufferization. Canonicalization must propagate layout through ops (e.g 'change_layout -> op' must be transformed to 'op -> change_layout').
* Add transformation canonicalization for `arith.select`
* Add custom assembly format to `LayoutChangeOp`
* Add tests for `arith.select` and some other ops
* Reenable affected test
