### PR TITLE
Code cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,6 @@ if (CMAKE_SYSTEM_NAME STREQUAL Linux)
         "-Winit-self "
         "-Wunused-function "
         "-Wuninitialized "
-        "-Wmissing-declarations "
         "-fdiagnostics-color=auto "
         "-Wno-deprecated-declarations "
     )

--- a/dpcomp_runtime/lib/memory.cpp
+++ b/dpcomp_runtime/lib/memory.cpp
@@ -13,11 +13,9 @@
 // limitations under the License.
 
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
-#include <cstdlib>
-#if defined(__MACH__)
-#include <cstdlib>
-#else
+#if !defined(__MACH__)
 #include <malloc.h>
 #endif
 

--- a/mlir/include/mlir-extensions/Dialect/gpu_runtime/IR/GpuRuntimeOps.td
+++ b/mlir/include/mlir-extensions/Dialect/gpu_runtime/IR/GpuRuntimeOps.td
@@ -32,6 +32,7 @@ def GpuRuntime_Dialect : Dialect {
     }];
   let cppNamespace = "gpu_runtime";
   let hasConstantMaterializer = 1;
+  let useDefaultAttributePrinterParser = 1;
   let useDefaultTypePrinterParser = 1;
 }
 

--- a/mlir/lib/Conversion/gpu_runtime_to_llvm.cpp
+++ b/mlir/lib/Conversion/gpu_runtime_to_llvm.cpp
@@ -47,8 +47,8 @@ struct LowerTakeContext
       newTypes[i] = (newType ? newType : oldType);
     }
 
-    auto initFunc = adaptor.initFunc().getValueOr(mlir::SymbolRefAttr());
-    auto releaseFunc = adaptor.releaseFunc().getValueOr(mlir::SymbolRefAttr());
+    auto initFunc = adaptor.initFunc().value_or(mlir::SymbolRefAttr());
+    auto releaseFunc = adaptor.releaseFunc().value_or(mlir::SymbolRefAttr());
     rewriter.replaceOpWithNewOp<plier::TakeContextOp>(op, newTypes, initFunc,
                                                       releaseFunc);
     return mlir::success();

--- a/mlir/lib/Dialect/gpu_runtime/IR/gpu_runtime_ops.cpp
+++ b/mlir/lib/Dialect/gpu_runtime/IR/gpu_runtime_ops.cpp
@@ -194,8 +194,8 @@ void GPUSuggestBlockSizeOp::build(::mlir::OpBuilder &odsBuilder,
     kernRef = kernel.get<mlir::Attribute>().cast<mlir::SymbolRefAttr>();
 
   GPUSuggestBlockSizeOp::build(odsBuilder, odsState, resTypes,
-                               stream.getValueOr(mlir::Value{}), kernVal,
-                               kernRef, gridSize);
+                               stream.value_or(mlir::Value{}), kernVal, kernRef,
+                               gridSize);
 }
 
 mlir::StringAttr GPUSuggestBlockSizeOp::getKernelModuleName() {


### PR DESCRIPTION
* Remove `-Wmissing-declarations` which is generates too much useless noise from runtime libs and is not actually part of compiler defense BKM
* Headers cleanup
* Add missing `let useDefaultAttributePrinterParser = 1;` to GPU dialect (fix warning about unused parsers)
* Replace deprecated `Optional::getValueOr`