### PR TITLE
Always build tools and tests

### DIFF
--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -150,9 +150,7 @@ target_include_directories(${MLIR_EXTENSIONS_LIB} PUBLIC
 
 add_dependencies(${MLIR_EXTENSIONS_LIB} MLIRPlierOpsIncGen MLIRPlierUtilOpsIncGen MLIRGpuRuntimeOpsIncGen)
 
-if (IMEX_ENABLE_IGPU_DIALECT)
-    add_subdirectory(tools)
-    if(IMEX_ENABLE_TESTS)
-        add_subdirectory(test)
-    endif()
+add_subdirectory(tools)
+if(IMEX_ENABLE_TESTS)
+    add_subdirectory(test)
 endif()


### PR DESCRIPTION
As they are no longer limited to GPU-only and GPU E2E tests can be enabled/disabled separately via env var.

