### PR TITLE
Break dependency between gpu lowering passes and util dialect

### DIFF
--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -43,6 +43,7 @@ set(SOURCES_LIST
     lib/Conversion/cfg_to_scf.cpp
     lib/Conversion/gpu_runtime_to_llvm.cpp
     lib/Conversion/gpu_to_gpu_runtime.cpp
+    lib/Conversion/util_conversion.cpp
     lib/Conversion/util_to_llvm.cpp
     lib/Dialect/gpu_runtime/IR/gpu_runtime_ops.cpp
     lib/Dialect/imex_util/dialect.cpp
@@ -78,6 +79,7 @@ set(HEADERS_LIST
     include/mlir-extensions/Conversion/cfg_to_scf.hpp
     include/mlir-extensions/Conversion/gpu_runtime_to_llvm.hpp
     include/mlir-extensions/Conversion/gpu_to_gpu_runtime.hpp
+    include/mlir-extensions/Conversion/util_conversion.hpp
     include/mlir-extensions/Conversion/util_to_llvm.hpp
     include/mlir-extensions/Dialect/gpu_runtime/IR/gpu_runtime_ops.hpp
     include/mlir-extensions/Dialect/imex_util/dialect.hpp

--- a/mlir/include/mlir-extensions/Conversion/gpu_runtime_to_llvm.hpp
+++ b/mlir/include/mlir-extensions/Conversion/gpu_runtime_to_llvm.hpp
@@ -17,6 +17,7 @@
 #include <memory>
 
 namespace mlir {
+class ConversionTarget;
 class LLVMTypeConverter;
 class Pass;
 class RewritePatternSet;
@@ -28,8 +29,9 @@ std::unique_ptr<mlir::Pass> createEnumerateEventsPass();
 
 /// Populates the given list with patterns that convert from gpu_runtime to
 /// LLVM.
-void populateGpuToLLVMPatterns(mlir::LLVMTypeConverter &converter,
-                               mlir::RewritePatternSet &patterns);
+void populateGpuToLLVMPatternsAndLegality(mlir::LLVMTypeConverter &converter,
+                                          mlir::RewritePatternSet &patterns,
+                                          mlir::ConversionTarget &target);
 
 std::unique_ptr<mlir::Pass> createGPUToLLVMPass();
 

--- a/mlir/include/mlir-extensions/Conversion/gpu_runtime_to_llvm.hpp
+++ b/mlir/include/mlir-extensions/Conversion/gpu_runtime_to_llvm.hpp
@@ -17,12 +17,20 @@
 #include <memory>
 
 namespace mlir {
+class LLVMTypeConverter;
 class Pass;
-}
+class RewritePatternSet;
+} // namespace mlir
 
 namespace gpu_runtime {
 
 std::unique_ptr<mlir::Pass> createEnumerateEventsPass();
+
+/// Populates the given list with patterns that convert from gpu_runtime to
+/// LLVM.
+void populateGpuToLLVMPatterns(mlir::LLVMTypeConverter &converter,
+                               mlir::RewritePatternSet &patterns);
+
 std::unique_ptr<mlir::Pass> createGPUToLLVMPass();
 
 } // namespace gpu_runtime

--- a/mlir/include/mlir-extensions/Conversion/util_conversion.hpp
+++ b/mlir/include/mlir-extensions/Conversion/util_conversion.hpp
@@ -1,0 +1,30 @@
+// Copyright 2022 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace mlir {
+class ConversionTarget;
+class MLIRContext;
+class RewritePatternSet;
+class TypeConverter;
+} // namespace mlir
+
+namespace imex {
+/// Convert util ops according to provided type converter.
+void populateUtilConversionPatterns(mlir::MLIRContext &context,
+                                    mlir::TypeConverter &converter,
+                                    mlir::RewritePatternSet &patterns,
+                                    mlir::ConversionTarget &target);
+} // namespace imex

--- a/mlir/lib/Conversion/gpu_runtime_to_llvm.cpp
+++ b/mlir/lib/Conversion/gpu_runtime_to_llvm.cpp
@@ -811,21 +811,16 @@ struct GPUToLLVMPass
 
     target.addDynamicallyLegalOp<mlir::func::ReturnOp, mlir::func::CallOp>(
         [&](mlir::Operation *op) -> llvm::Optional<bool> {
-          for (auto range : {mlir::TypeRange(op->getOperandTypes()),
-                             mlir::TypeRange(op->getResultTypes())})
-            for (auto type : range)
-              if (converter.isLegal(type))
-                return true;
+          if (converter.isLegal(op))
+            return true;
 
           return llvm::None;
         });
     target.addDynamicallyLegalOp<mlir::func::FuncOp>(
         [&](mlir::func::FuncOp op) -> llvm::Optional<bool> {
-          auto type = op.getFunctionType();
-          for (auto range : {type.getInputs(), type.getResults()})
-            for (auto type : range)
-              if (converter.isLegal(type))
-                return true;
+          if (converter.isSignatureLegal(op.getFunctionType()) &&
+              converter.isLegal(&op.getBody()))
+            return true;
 
           return llvm::None;
         });

--- a/mlir/lib/Conversion/gpu_runtime_to_llvm.cpp
+++ b/mlir/lib/Conversion/gpu_runtime_to_llvm.cpp
@@ -805,8 +805,8 @@ struct GPUToLLVMPass
     mlir::populateGpuToLLVMConversionPatterns(
         converter, patterns, mlir::gpu::getDefaultGpuBinaryAnnotation());
 
-    plier::populateControlFlowTypeConversionRewritesAndTarget(converter,
-                                                              patterns, target);
+    imex::populateControlFlowTypeConversionRewritesAndTarget(converter,
+                                                             patterns, target);
 
     gpu_runtime::populateGpuToLLVMPatternsAndLegality(converter, patterns,
                                                       target);

--- a/mlir/lib/Conversion/gpu_runtime_to_llvm.cpp
+++ b/mlir/lib/Conversion/gpu_runtime_to_llvm.cpp
@@ -825,15 +825,6 @@ struct GPUToLLVMPass
     mlir::populateReturnOpTypeConversionPattern(patterns, converter);
     mlir::populateCallOpTypeConversionPattern(patterns, converter);
 
-    target.addDynamicallyLegalOp<mlir::func::FuncOp>(
-        [&](mlir::func::FuncOp op) -> llvm::Optional<bool> {
-          if (converter.isSignatureLegal(op.getFunctionType()) &&
-              converter.isLegal(&op.getBody()))
-            return true;
-
-          return llvm::None;
-        });
-
     target.addDynamicallyLegalOp<mlir::func::ReturnOp, mlir::func::CallOp>(
         [&](mlir::Operation *op) -> llvm::Optional<bool> {
           for (auto range : {mlir::TypeRange(op->getOperandTypes()),

--- a/mlir/lib/Conversion/gpu_runtime_to_llvm.cpp
+++ b/mlir/lib/Conversion/gpu_runtime_to_llvm.cpp
@@ -14,7 +14,6 @@
 
 #include "mlir-extensions/Conversion/gpu_runtime_to_llvm.hpp"
 
-#include "mlir-extensions/Conversion/util_conversion.hpp"
 #include "mlir-extensions/Dialect/gpu_runtime/IR/gpu_runtime_ops.hpp"
 #include "mlir-extensions/Transforms/func_utils.hpp"
 #include "mlir-extensions/Transforms/type_conversion.hpp"
@@ -811,7 +810,6 @@ struct GPUToLLVMPass
 
     gpu_runtime::populateGpuToLLVMPatternsAndLegality(converter, patterns,
                                                       target);
-    imex::populateUtilConversionPatterns(context, converter, patterns, target);
 
     auto mod = getOperation();
     if (mlir::failed(

--- a/mlir/lib/Conversion/util_conversion.cpp
+++ b/mlir/lib/Conversion/util_conversion.cpp
@@ -1,0 +1,66 @@
+// Copyright 2022 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mlir/Conversion/Passes.h>
+
+#include "mlir-extensions/Dialect/plier_util/dialect.hpp"
+
+#include "mlir-extensions/Conversion/util_conversion.hpp"
+
+namespace {
+struct ConvertTakeContext
+    : public mlir::OpConversionPattern<plier::TakeContextOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(plier::TakeContextOp op,
+                  plier::TakeContextOp::Adaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto srcTypes = op.getResultTypes();
+    auto count = static_cast<unsigned>(srcTypes.size());
+    llvm::SmallVector<mlir::Type> newTypes(count);
+    auto converter = getTypeConverter();
+    assert(converter);
+    for (auto i : llvm::seq(0u, count)) {
+      auto oldType = srcTypes[i];
+      auto newType = converter->convertType(oldType);
+      newTypes[i] = (newType ? newType : oldType);
+    }
+
+    auto initFunc = adaptor.initFunc().value_or(mlir::SymbolRefAttr());
+    auto releaseFunc = adaptor.releaseFunc().value_or(mlir::SymbolRefAttr());
+    rewriter.replaceOpWithNewOp<plier::TakeContextOp>(op, newTypes, initFunc,
+                                                      releaseFunc);
+    return mlir::success();
+  }
+};
+} // namespace
+
+void imex::populateUtilConversionPatterns(mlir::MLIRContext &context,
+                                          mlir::TypeConverter &converter,
+                                          mlir::RewritePatternSet &patterns,
+                                          mlir::ConversionTarget &target) {
+  patterns.insert<ConvertTakeContext>(converter, &context);
+
+  target.addDynamicallyLegalOp<plier::TakeContextOp>(
+      [&](mlir::Operation *op) -> llvm::Optional<bool> {
+        for (auto range : {mlir::TypeRange(op->getOperandTypes()),
+                           mlir::TypeRange(op->getResultTypes())})
+          for (auto type : range)
+            if (converter.isLegal(type))
+              return true;
+
+        return llvm::None;
+      });
+}

--- a/mlir/lib/Conversion/util_conversion.cpp
+++ b/mlir/lib/Conversion/util_conversion.cpp
@@ -14,18 +14,18 @@
 
 #include <mlir/Conversion/Passes.h>
 
-#include "mlir-extensions/Dialect/plier_util/dialect.hpp"
+#include "mlir-extensions/Dialect/imex_util/dialect.hpp"
 
 #include "mlir-extensions/Conversion/util_conversion.hpp"
 
 namespace {
 struct ConvertTakeContext
-    : public mlir::OpConversionPattern<plier::TakeContextOp> {
+    : public mlir::OpConversionPattern<imex::util::TakeContextOp> {
   using OpConversionPattern::OpConversionPattern;
 
   mlir::LogicalResult
-  matchAndRewrite(plier::TakeContextOp op,
-                  plier::TakeContextOp::Adaptor adaptor,
+  matchAndRewrite(imex::util::TakeContextOp op,
+                  imex::util::TakeContextOp::Adaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     auto srcTypes = op.getResultTypes();
     auto count = static_cast<unsigned>(srcTypes.size());
@@ -40,8 +40,8 @@ struct ConvertTakeContext
 
     auto initFunc = adaptor.initFunc().value_or(mlir::SymbolRefAttr());
     auto releaseFunc = adaptor.releaseFunc().value_or(mlir::SymbolRefAttr());
-    rewriter.replaceOpWithNewOp<plier::TakeContextOp>(op, newTypes, initFunc,
-                                                      releaseFunc);
+    rewriter.replaceOpWithNewOp<imex::util::TakeContextOp>(
+        op, newTypes, initFunc, releaseFunc);
     return mlir::success();
   }
 };
@@ -53,7 +53,7 @@ void imex::populateUtilConversionPatterns(mlir::MLIRContext &context,
                                           mlir::ConversionTarget &target) {
   patterns.insert<ConvertTakeContext>(converter, &context);
 
-  target.addDynamicallyLegalOp<plier::TakeContextOp>(
+  target.addDynamicallyLegalOp<imex::util::TakeContextOp>(
       [&](mlir::Operation *op) -> llvm::Optional<bool> {
         for (auto range : {mlir::TypeRange(op->getOperandTypes()),
                            mlir::TypeRange(op->getResultTypes())})

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
@@ -1427,8 +1427,8 @@ struct GPUToLLVMPass
     mlir::populateGpuToLLVMConversionPatterns(
         converter, patterns, mlir::gpu::getDefaultGpuBinaryAnnotation());
 
-    plier::populateControlFlowTypeConversionRewritesAndTarget(converter,
-                                                              patterns, target);
+    imex::populateControlFlowTypeConversionRewritesAndTarget(converter,
+                                                             patterns, target);
 
     gpu_runtime::populateGpuToLLVMPatternsAndLegality(converter, patterns,
                                                       target);

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
@@ -15,6 +15,10 @@
 #include "pipelines/lower_to_gpu.hpp"
 
 #include <mlir/Conversion/AffineToStandard/AffineToStandard.h>
+#include <mlir/Conversion/AsyncToLLVM/AsyncToLLVM.h>
+#include <mlir/Conversion/GPUCommon/GPUCommonPass.h>
+#include <mlir/Conversion/LLVMCommon/ConversionTarget.h>
+#include <mlir/Conversion/LLVMCommon/TypeConverter.h>
 #include <mlir/Conversion/SCFToGPU/SCFToGPUPass.h>
 #include <mlir/Dialect/Affine/IR/AffineOps.h>
 #include <mlir/Dialect/Arithmetic/Transforms/Passes.h>
@@ -42,6 +46,7 @@
 
 #include "mlir-extensions/Conversion/gpu_runtime_to_llvm.hpp"
 #include "mlir-extensions/Conversion/gpu_to_gpu_runtime.hpp"
+#include "mlir-extensions/Conversion/util_conversion.hpp"
 #include "mlir-extensions/Dialect/gpu_runtime/IR/gpu_runtime_ops.hpp"
 #include "mlir-extensions/Dialect/imex_util/dialect.hpp"
 #include "mlir-extensions/Transforms/call_lowering.hpp"
@@ -1406,6 +1411,36 @@ struct SinkGpuDims : public mlir::OpRewritePattern<mlir::gpu::LaunchOp> {
 struct SinkGpuDimsPass : public imex::RewriteWrapperPass<SinkGpuDimsPass, void,
                                                          void, SinkGpuDims> {};
 
+struct GPUToLLVMPass
+    : public mlir::PassWrapper<GPUToLLVMPass,
+                               mlir::OperationPass<mlir::ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(GPUToLLVMPass)
+
+  void runOnOperation() override {
+    mlir::MLIRContext &context = getContext();
+    mlir::LLVMTypeConverter converter(&context);
+    mlir::RewritePatternSet patterns(&context);
+    mlir::LLVMConversionTarget target(context);
+
+    mlir::populateAsyncStructuralTypeConversionsAndLegality(converter, patterns,
+                                                            target);
+    mlir::populateGpuToLLVMConversionPatterns(
+        converter, patterns, mlir::gpu::getDefaultGpuBinaryAnnotation());
+
+    plier::populateControlFlowTypeConversionRewritesAndTarget(converter,
+                                                              patterns, target);
+
+    gpu_runtime::populateGpuToLLVMPatternsAndLegality(converter, patterns,
+                                                      target);
+    imex::populateUtilConversionPatterns(context, converter, patterns, target);
+
+    auto mod = getOperation();
+    if (mlir::failed(
+            mlir::applyPartialConversion(mod, target, std::move(patterns))))
+      signalPassFailure();
+  }
+};
+
 static void commonOptPasses(mlir::OpPassManager &pm) {
   pm.addPass(imex::createCommonOptsPass());
   pm.addPass(mlir::createCSEPass());
@@ -1473,7 +1508,7 @@ static void populateLowerToGPUPipelineLow(mlir::OpPassManager &pm) {
   pm.addNestedPass<mlir::func::FuncOp>(
       std::make_unique<GenerateOutlineContextPass>());
   pm.addPass(gpu_runtime::createEnumerateEventsPass());
-  pm.addPass(gpu_runtime::createGPUToLLVMPass());
+  pm.addPass(std::make_unique<GPUToLLVMPass>());
   commonOptPasses(pm);
 }
 } // namespace


### PR DESCRIPTION
* Move `ConvertTakeContext` to separate file and expose it via `populateUtilConversionPatterns`
* Do not invoke `util` dialect conversion as part of gpu lowering pass
* Adapt and use `populateControlFlowTypeConversionRewritesAndTarget` in gpu lowering pass instead of copypaste
* Do custom gpu lowering pass in python pipeline, which includes `populateUtilConversionPatterns`