### PR TITLE
Introduce tuple manipulation ops

### DIFF
--- a/mlir/include/mlir-extensions/Dialect/imex_util/ImexUtilOps.td
+++ b/mlir/include/mlir-extensions/Dialect/imex_util/ImexUtilOps.td
@@ -212,6 +212,13 @@ def TupleExtractOp : ImexUtil_Op<"tuple_extract", [NoSideEffect]> {
   let results = (outs AnyType:$result);
 
   let assemblyFormat = "attr-dict $source `:` type($source) `,` $index `->` type($result)";
+
+  let extraClassDeclaration = [{
+    /// Helper function to get the index as a simple integer if it is constant.
+    ::llvm::Optional<int64_t> getConstantIndex();
+  }];
+
+  let hasFolder = 1;
 }
 
 #endif // PLIER_UTIL_OPS

--- a/mlir/include/mlir-extensions/Dialect/imex_util/ImexUtilOps.td
+++ b/mlir/include/mlir-extensions/Dialect/imex_util/ImexUtilOps.td
@@ -188,13 +188,30 @@ def BuildTupleOp : ImexUtil_Op<"build_tuple", [NoSideEffect]> {
   let summary = "Constructs tuple from provided values";
   let description = [{
     "build_tuple" takes multiple SSA values and constructs tuple from them.
+
     Zero arguments are allowed and will result in an empty tuple.
   }];
 
   let arguments = (ins Variadic<AnyType>:$args);
-  let results = (outs AnyTuple);
+  let results = (outs AnyTuple:$result);
 
-  let assemblyFormat = "attr-dict ($args^ `:` type($args) `->`)? type(results)";
+  let assemblyFormat = "attr-dict ($args^ `:` type($args) `->`)? type($result)";
+}
+
+def TupleExtractOp : ImexUtil_Op<"tuple_extract", [NoSideEffect]> {
+  let summary = "Extracts value from tuple";
+  let description = [{
+    "tuple_extract" extracts element with specific index from tuple.
+
+    If index is out of bounds behaviour is unspecified and is left to the
+    lowering passes.
+  }];
+
+  let arguments = (ins AnyTuple:$source,
+                       Index:$index);
+  let results = (outs AnyType:$result);
+
+  let assemblyFormat = "attr-dict $source `:` type($source) `,` $index `->` type($result)";
 }
 
 #endif // PLIER_UTIL_OPS

--- a/mlir/include/mlir-extensions/Dialect/imex_util/ImexUtilOps.td
+++ b/mlir/include/mlir-extensions/Dialect/imex_util/ImexUtilOps.td
@@ -184,4 +184,17 @@ def ReleaseContextOp : ImexUtil_Op<"release_context"> {
   let arguments = (ins ImexUtil_OpaqueType:$context);
 }
 
+def BuildTupleOp : ImexUtil_Op<"build_tuple", [NoSideEffect]> {
+  let summary = "Constructs tuple from provided values";
+  let description = [{
+    "build_tuple" takes multiple SSA values and constructs tuple from them.
+    Zero arguments are allowed and will result in an empty tuple.
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$args);
+  let results = (outs AnyTuple);
+
+  let assemblyFormat = "attr-dict ($args^ `:` type($args) `->`)? type(results)";
+}
+
 #endif // PLIER_UTIL_OPS

--- a/mlir/lib/Dialect/imex_util/dialect.cpp
+++ b/mlir/lib/Dialect/imex_util/dialect.cpp
@@ -1640,6 +1640,30 @@ void TakeContextOp::build(mlir::OpBuilder &b, mlir::OperationState &result,
   build(b, result, allTypes, initFunc, releaseFunc);
 }
 
+llvm::Optional<int64_t> TupleExtractOp::getConstantIndex() {
+  if (auto constantOp = index().getDefiningOp<mlir::arith::ConstantOp>())
+    return constantOp.getValue().cast<mlir::IntegerAttr>().getInt();
+  return {};
+}
+
+mlir::OpFoldResult TupleExtractOp::fold(mlir::ArrayRef<mlir::Attribute> operands) {
+  // All forms of folding require a known index.
+  auto index = operands[1].dyn_cast_or_null<mlir::IntegerAttr>();
+  if (!index)
+    return {};
+
+  auto parent = source().getDefiningOp<BuildTupleOp>();
+  if (!parent)
+    return {};
+
+  int64_t indexVal = index.getInt();
+  mlir::ValueRange args = parent.args();
+  if (indexVal < 0 || indexVal >= static_cast<int64_t>(args.size()))
+    return {};
+
+  return args[indexVal];
+}
+
 } // namespace util
 } // namespace imex
 

--- a/mlir/test/Dialect/imex_util/canonicalize.mlir
+++ b/mlir/test/Dialect/imex_util/canonicalize.mlir
@@ -1,0 +1,11 @@
+// RUN: imex-opt %s -canonicalize --split-input-file | FileCheck %s
+
+func.func @test(%arg1: index, %arg2: i64) -> i64 {
+  %0 = imex_util.build_tuple %arg1, %arg2: index, i64 -> tuple<index, i64>
+  %cst = arith.constant 1 : index
+  %1 = imex_util.tuple_extract %0 : tuple<index, i64>, %cst -> i64
+  return %1 : i64
+}
+// CHECK-LABEL: func @test
+//  CHECK-SAME:   (%[[ARG1:.*]]: index, %[[ARG2:.*]]: i64)
+//  CHECK-NEXT:   return %[[ARG2]] : i64

--- a/mlir/test/Dialect/imex_util/ops.mlir
+++ b/mlir/test/Dialect/imex_util/ops.mlir
@@ -1,0 +1,22 @@
+// RUN: imex-opt %s -split-input-file | FileCheck %s
+// Verify the printed output can be parsed.
+// RUN: imex-opt %s -split-input-file | imex-opt | FileCheck %s
+
+func.func @test() -> tuple<> {
+  %0 = imex_util.build_tuple tuple<>
+  return %0 : tuple<>
+}
+// CHECK-LABEL: func @test
+//  CHECK-NEXT:   %[[RES:.*]] = imex_util.build_tuple tuple<>
+//  CHECK-NEXT:   return %[[RES]] : tuple<>
+
+// -----
+
+func.func @test(%arg1: index, %arg2: i64) -> tuple<index, i64> {
+  %0 = imex_util.build_tuple %arg1, %arg2: index, i64 -> tuple<index, i64>
+  return %0 : tuple<index, i64>
+}
+// CHECK-LABEL: func @test
+//  CHECK-SAME:   (%[[ARG1:.*]]: index, %[[ARG2:.*]]: i64)
+//  CHECK-NEXT:   %[[RES:.*]] = imex_util.build_tuple %[[ARG1]], %[[ARG2]] : index, i64 -> tuple<index, i64>
+//  CHECK-NEXT:   return %[[RES]] : tuple<index, i64>

--- a/mlir/test/Dialect/imex_util/ops.mlir
+++ b/mlir/test/Dialect/imex_util/ops.mlir
@@ -20,3 +20,14 @@ func.func @test(%arg1: index, %arg2: i64) -> tuple<index, i64> {
 //  CHECK-SAME:   (%[[ARG1:.*]]: index, %[[ARG2:.*]]: i64)
 //  CHECK-NEXT:   %[[RES:.*]] = imex_util.build_tuple %[[ARG1]], %[[ARG2]] : index, i64 -> tuple<index, i64>
 //  CHECK-NEXT:   return %[[RES]] : tuple<index, i64>
+
+// -----
+
+func.func @test(%arg1: tuple<index, i64>, %arg2: index) -> i64 {
+  %0 = imex_util.tuple_extract %arg1 : tuple<index, i64>, %arg2 -> i64
+  return %0 : i64
+}
+// CHECK-LABEL: func @test
+//  CHECK-SAME:   (%[[ARG1:.*]]: tuple<index, i64>, %[[ARG2:.*]]: index)
+//  CHECK-NEXT:   %[[RES:.*]] = imex_util.tuple_extract %[[ARG1]] : tuple<index, i64>, %[[ARG2]] -> i64
+//  CHECK-NEXT:   return %[[RES]] : i64


### PR DESCRIPTION
Currently we have `plier::BuildTupleOp` and `plier::GetItemOp` which used both in high-level python dialect in frontend and also  to more low level tuple manipulation later in pipeline. This is unfortunate and breaks abstraction, so introduce new ops, needed to manipulate tuples later in pipeline, separated from python dialect.

This PR introduces ops definition and some basic folding and tests.
