### PR TITLE
[imex-opt] port serializespirvpass from main branch

### DIFF
--- a/docs/Transforms/SerializeSPIRV.md
+++ b/docs/Transforms/SerializeSPIRV.md
@@ -1,0 +1,76 @@
+# SerializeSPIRV Pass (serialize-spirv)
+
+The SerializeSPIRV pass utilizes the upstream spirv::serialize() function to serialize MLIR SPIR-V module to SPIR-V binary and attaches the binary as a string attribute to the gpuModule(attributes {gpu.binary}).
+This pass works like the upstream SerializeToCubin and SerializeToHsaco, only that the other two passes translate llvm dialect to llvm IR and then translate to ISA binary.
+
+## Example
+
+```
+// -----// IR Dump Before SerializeSPIRV //----- //
+module attributes {gpu.container_module, spv.target_env = #spv.target_env<#spv.vce<v1.0, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume]>, #spv.resource_limits<>>} {
+  spv.module @__spv__addt_kernel Physical64 OpenCL requires #spv.vce<v1.0, [Int64, Addresses, Kernel], []> {
+    spv.GlobalVariable @__builtin_var_WorkgroupId__ built_in("WorkgroupId") : !spv.ptr<vector<3xi64>, Input>
+    spv.func @addt_kernel(%arg0: !spv.ptr<f32, CrossWorkgroup>, %arg1: !spv.ptr<f32, CrossWorkgroup>, %arg2: !spv.ptr<f32, CrossWorkgroup>) "None" attributes {spv.entry_point_abi = #spv.entry_point_abi<>, workgroup_attributions = 0 : i64} {
+      %cst5_i64 = spv.Constant 5 : i64
+      %__builtin_var_WorkgroupId___addr = spv.mlir.addressof @__builtin_var_WorkgroupId__ : !spv.ptr<vector<3xi64>, Input>
+      %0 = spv.Load "Input" %__builtin_var_WorkgroupId___addr : vector<3xi64>
+      %1 = spv.CompositeExtract %0[0 : i32] : vector<3xi64>
+      %__builtin_var_WorkgroupId___addr_0 = spv.mlir.addressof @__builtin_var_WorkgroupId__ : !spv.ptr<vector<3xi64>, Input>
+      .
+      .
+      .
+      %13 = spv.IMul %1, %cst5_i64 : i64
+      %14 = spv.IAdd %13, %3 : i64
+      %15 = spv.InBoundsPtrAccessChain %arg2[%14] : !spv.ptr<f32, CrossWorkgroup>, i64
+      spv.Store "CrossWorkgroup" %15, %12 ["Aligned", 4] : f32
+      spv.Return
+    }
+    spv.EntryPoint "Kernel" @addt_kernel, @__builtin_var_WorkgroupId__
+  }
+  gpu.module @addt_kernel {
+    gpu.func @addt_kernel(%arg0: memref<?xf32>, %arg1: memref<?xf32>, %arg2: memref<?xf32>) kernel attributes {spv.entry_point_abi = #spv.entry_point_abi<>} {
+      %c5 = arith.constant 5 : index
+      %0 = gpu.block_id  x
+      %1 = gpu.block_id  y
+      .
+      .
+      .
+      %9 = arith.muli %0, %c5 : index
+      %10 = arith.addi %9, %1 : index
+      memref.store %8, %arg2[%10] : memref<?xf32>
+      gpu.return
+    }
+  }
+}
+
+```
+
+The Pass will change the IR to:
+
+```
+// -----// IR Dump After SerializeSPIRV //----- //
+module attributes {gpu.container_module, spv.target_env = #spv.target_env<#spv.vce<v1.0, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Ve    ctor16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume]>, #spv.re    source_limits<>>} {
+  gpu.module @addt_kernel attributes {gpu.binary = "\03\02#\07\00\00\01\00 ... \00"} {
+    gpu.func @addt_kernel(%arg0: memref<?xf32>, %arg1: memref<?xf32>, %arg2: memref<?xf32>) kernel attributes {spv.entry_point_abi = #spv.entry_point_abi<>    } {
+      %c5 = arith.constant 5 : index
+      %0 = gpu.block_id  x
+      %1 = gpu.block_id  y
+      .
+      .
+      .
+      %9 = arith.muli %0, %c5 : index
+      %10 = arith.addi %9, %1 : index
+      memref.store %8, %arg2[%10] : memref<?xf32>
+      gpu.return
+    }
+  }
+}
+
+```
+
+As shown in the example above, the spv module op was serialized to spv binary and attached to the gpu module op as a "gpu.binary" attribute
+
+
+## Reason for this Custom Pass:
+
+Upstream does not have a standalone pass which wraps this function. We can upstream this if it proves this is a common flow needed.

--- a/include/imex/InitIMEXPasses.h
+++ b/include/imex/InitIMEXPasses.h
@@ -19,6 +19,7 @@
 // #include <imex/Transforms/IMEXPasses.h>
 #include <imex/Dialect/Dist/Transforms/Passes.h>
 // #include <imex/Dialect/*/Transforms/Passes.h>
+#include "imex/Transforms/Passes.h"
 
 #include <cstdlib>
 
@@ -33,7 +34,7 @@ namespace imex {
 /// The global registry is interesting to interact with the command-line tools.
 inline void registerAllPasses() {
   // General passes
-  // registerTransformsPasses();
+  registerTransformsPasses();
 
   // Conversion passes
   registerConversionPasses();

--- a/include/imex/Transforms/CMakeLists.txt
+++ b/include/imex/Transforms/CMakeLists.txt
@@ -4,4 +4,4 @@ mlir_tablegen(Transforms.capi.h.inc -gen-pass-capi-header --prefix Transforms)
 mlir_tablegen(Transforms.capi.cpp.inc -gen-pass-capi-impl --prefix Transforms)
 add_public_tablegen_target(IMEXTransformsPassIncGen)
 
-add_mlir_doc(Passes GeneralPasses ./ -gen-pass-doc)
+add_mlir_doc(Passes IMEXGeneralPasses ./ -gen-pass-doc)

--- a/include/imex/Transforms/Passes.h
+++ b/include/imex/Transforms/Passes.h
@@ -1,0 +1,33 @@
+//===- Passes.h - Pass Entrypoints ------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This header file defines prototypes for IMEX transformation passes
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef IMEX_TRANSFORMS_PASSES_H_
+#define IMEX_TRANSFORMS_PASSES_H_
+
+#include "mlir/Pass/Pass.h"
+
+namespace imex {
+//===----------------------------------------------------------------------===//
+// Passes
+//===----------------------------------------------------------------------===//
+std::unique_ptr<mlir::Pass> createSerializeSPIRVPass();
+
+//===----------------------------------------------------------------------===//
+// Registration
+//===----------------------------------------------------------------------===//
+
+/// Generate the code for registering passes.
+#define GEN_PASS_REGISTRATION
+#include "imex/Transforms/Passes.h.inc"
+} // namespace imex
+
+#endif // IMEX_TRANSFORMS_PASSES_H_

--- a/include/imex/Transforms/Passes.h
+++ b/include/imex/Transforms/Passes.h
@@ -1,6 +1,7 @@
 //===- Passes.h - Pass Entrypoints ------------------------------*- C++ -*-===//
 //
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// Copyright 2022 Intel Corporation
+// Part of the IMEX Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //

--- a/include/imex/Transforms/Passes.td
+++ b/include/imex/Transforms/Passes.td
@@ -19,6 +19,11 @@ include "mlir/Pass/PassBase.td"
 
 def SerializeSPIRVPass : Pass<"serialize-spirv", "::mlir::ModuleOp"> {
   let summary = "serialize MLIR SPIR-V module to SPIR-V binary";
+  let description = [{
+    This pass iterates all the SPIR-V modules in the top module and serializes
+    each SPIR-V module to SPIR-V binary and then attachs the binary blob as a
+    string attribute to the corresponding gpu module.
+  }];
   let constructor = "imex::createSerializeSPIRVPass()";
   let dependentDialects = [
     "mlir::gpu::GPUDialect",

--- a/include/imex/Transforms/Passes.td
+++ b/include/imex/Transforms/Passes.td
@@ -17,4 +17,13 @@
 
 include "mlir/Pass/PassBase.td"
 
+def SerializeSPIRVPass : Pass<"serialize-spirv", "::mlir::ModuleOp"> {
+  let summary = "serialize MLIR SPIR-V module to SPIR-V binary";
+  let constructor = "imex::createSerializeSPIRVPass()";
+  let dependentDialects = [
+    "mlir::gpu::GPUDialect",
+    "mlir::spirv::SPIRVDialect"
+    ];
+}
+
 #endif // _IMEX_TRANSFORMS_PASSES_TD_INCLUDED_

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(Dialect)
 add_subdirectory(Conversion)
+add_subdirectory(Transforms)

--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_mlir_library(IMEXTransforms
+  SerializeSPIRV.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/imex/Transforms
+
+  LINK_LIBS PUBLIC
+  MLIRGPUOps
+  MLIRSPIRVDialect
+  MLIRFuncDialect
+  MLIRPass
+  MLIRSupport
+  MLIRTransformUtils
+
+  DEPENDS
+  IMEXTransformsPassIncGen
+)

--- a/lib/Transforms/PassDetail.h
+++ b/lib/Transforms/PassDetail.h
@@ -1,6 +1,7 @@
 //===- PassDetail.h - Transforms Pass class details -------------*- C++ -*-===//
 //
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// Copyright 2022 Intel Corporation
+// Part of the IMEX Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //

--- a/lib/Transforms/PassDetail.h
+++ b/lib/Transforms/PassDetail.h
@@ -1,0 +1,37 @@
+//===- PassDetail.h - Transforms Pass class details -------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TRANSFORMS_PASSDETAIL_H_
+#define TRANSFORMS_PASSDETAIL_H_
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/DialectRegistry.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/Passes.h"
+
+namespace mlir {
+// Forward declaration from Dialect.h
+template <typename ConcreteDialect>
+void registerDialect(DialectRegistry &registry);
+
+namespace gpu {
+class GPUDialect;
+}
+namespace spirv {
+class SPIRVDialect;
+}
+
+} // end namespace mlir
+
+namespace imex {
+#define GEN_PASS_CLASSES
+#include "imex/Transforms/Passes.h.inc"
+
+} // namespace imex
+
+#endif // TRANSFORMS_PASSDETAIL_H

--- a/lib/Transforms/SerializeSPIRV.cpp
+++ b/lib/Transforms/SerializeSPIRV.cpp
@@ -1,13 +1,17 @@
 //===- SerializeSPIRV.cpp - SPIR-V serialize pass --------------*- C++ -*-===//
 //
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// Copyright 2022 Intel Corporation
+// Part of the IMEX Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
-// serialize MLIR SPIR-V module to SPIR-V binary
-//
+///
+/// \file
+/// This pass iterates all the SPIR-V modules in the top module and serializes
+/// each SPIR-V module to SPIR-V binary and then attachs the binary blob as a
+/// string attribute to the corresponding gpu module.
+///
 //===----------------------------------------------------------------------===//
 
 #include "PassDetail.h"
@@ -28,6 +32,8 @@ public:
     llvm::SmallVector<uint32_t, 0> spvBinary;
     for (auto gpuMod : mod.getOps<gpu::GPUModuleOp>()) {
       auto name = gpuMod.getName();
+      // check that the spv module has the same name with gpu module except the
+      // prefix "__spv__"
       auto isSameMod = [&](spirv::ModuleOp spvMod) -> bool {
         auto spvModName = spvMod.getName();
         return spvModName->consume_front("__spv__") && spvModName == name;
@@ -42,12 +48,14 @@ public:
       auto spvMod = *it;
 
       spvBinary.clear();
+      // serialize the spv module to spv binary
       if (mlir::failed(spirv::serialize(spvMod, spvBinary))) {
         spvMod.emitError() << "Failed to serialize SPIR-V module";
         signalPassFailure();
         return;
       }
 
+      // attach the spv binary to the gpu module
       auto spvData =
           llvm::StringRef(reinterpret_cast<const char *>(spvBinary.data()),
                           spvBinary.size() * sizeof(uint32_t));

--- a/lib/Transforms/SerializeSPIRV.cpp
+++ b/lib/Transforms/SerializeSPIRV.cpp
@@ -1,0 +1,66 @@
+//===- SerializeSPIRV.cpp - SPIR-V serialize pass --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// serialize MLIR SPIR-V module to SPIR-V binary
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/GPU/Transforms/Passes.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVDialect.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVOps.h"
+#include "mlir/Target/SPIRV/Serialization.h"
+
+using namespace mlir;
+using namespace imex;
+
+namespace {
+struct SerializeSPIRVPass : public SerializeSPIRVPassBase<SerializeSPIRVPass> {
+public:
+  void runOnOperation() override {
+    auto mod = getOperation();
+    llvm::SmallVector<uint32_t, 0> spvBinary;
+    for (auto gpuMod : mod.getOps<gpu::GPUModuleOp>()) {
+      auto name = gpuMod.getName();
+      auto isSameMod = [&](spirv::ModuleOp spvMod) -> bool {
+        auto spvModName = spvMod.getName();
+        return spvModName->consume_front("__spv__") && spvModName == name;
+      };
+      auto spvMods = mod.getOps<spirv::ModuleOp>();
+      auto it = llvm::find_if(spvMods, isSameMod);
+      if (it == spvMods.end()) {
+        gpuMod.emitError() << "Unable to find corresponding SPIR-V module";
+        signalPassFailure();
+        return;
+      }
+      auto spvMod = *it;
+
+      spvBinary.clear();
+      if (mlir::failed(spirv::serialize(spvMod, spvBinary))) {
+        spvMod.emitError() << "Failed to serialize SPIR-V module";
+        signalPassFailure();
+        return;
+      }
+
+      auto spvData =
+          llvm::StringRef(reinterpret_cast<const char *>(spvBinary.data()),
+                          spvBinary.size() * sizeof(uint32_t));
+      auto spvAttr = mlir::StringAttr::get(&getContext(), spvData);
+      gpuMod->setAttr(gpu::getDefaultGpuBinaryAnnotation(), spvAttr);
+      spvMod->erase();
+    }
+  }
+};
+} // namespace
+
+namespace imex {
+std::unique_ptr<mlir::Pass> createSerializeSPIRVPass() {
+  return std::make_unique<SerializeSPIRVPass>();
+}
+} // namespace imex

--- a/test/Transforms/serialize-spirv.mlir
+++ b/test/Transforms/serialize-spirv.mlir
@@ -1,0 +1,53 @@
+// RUN: imex-opt -serialize-spirv %s | FileCheck %s
+module attributes {gpu.container_module, spv.target_env = #spv.target_env<#spv.vce<v1.0, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume]>, #spv.resource_limits<>>} {
+  // CHECK:         gpu.module @addt_kernel attributes {gpu.binary =
+  spv.module @__spv__addt_kernel Physical64 OpenCL requires #spv.vce<v1.0, [Int64, Addresses, Kernel], []> {
+    spv.GlobalVariable @__builtin_var_WorkgroupId__ built_in("WorkgroupId") : !spv.ptr<vector<3xi64>, Input>
+    spv.func @addt_kernel(%arg0: !spv.ptr<f32, CrossWorkgroup>, %arg1: !spv.ptr<f32, CrossWorkgroup>, %arg2: !spv.ptr<f32, CrossWorkgroup>) "None" attributes {spv.entry_point_abi = #spv.entry_point_abi<>, workgroup_attributions = 0 : i64} {
+      %cst5_i64 = spv.Constant 5 : i64
+      %__builtin_var_WorkgroupId___addr = spv.mlir.addressof @__builtin_var_WorkgroupId__ : !spv.ptr<vector<3xi64>, Input>
+      %0 = spv.Load "Input" %__builtin_var_WorkgroupId___addr : vector<3xi64>
+      %1 = spv.CompositeExtract %0[0 : i32] : vector<3xi64>
+      %__builtin_var_WorkgroupId___addr_0 = spv.mlir.addressof @__builtin_var_WorkgroupId__ : !spv.ptr<vector<3xi64>, Input>
+      %2 = spv.Load "Input" %__builtin_var_WorkgroupId___addr_0 : vector<3xi64>
+      %3 = spv.CompositeExtract %2[1 : i32] : vector<3xi64>
+      spv.Branch ^bb1
+    ^bb1:  // pred: ^bb0
+      %4 = spv.IMul %1, %cst5_i64 : i64
+      %5 = spv.IAdd %4, %3 : i64
+      %6 = spv.InBoundsPtrAccessChain %arg0[%5] : !spv.ptr<f32, CrossWorkgroup>, i64
+      %7 = spv.Load "CrossWorkgroup" %6 ["Aligned", 4] : f32
+      %8 = spv.IMul %1, %cst5_i64 : i64
+      %9 = spv.IAdd %8, %3 : i64
+      %10 = spv.InBoundsPtrAccessChain %arg1[%9] : !spv.ptr<f32, CrossWorkgroup>, i64
+      %11 = spv.Load "CrossWorkgroup" %10 ["Aligned", 4] : f32
+      %12 = spv.FAdd %7, %11 : f32
+      %13 = spv.IMul %1, %cst5_i64 : i64
+      %14 = spv.IAdd %13, %3 : i64
+      %15 = spv.InBoundsPtrAccessChain %arg2[%14] : !spv.ptr<f32, CrossWorkgroup>, i64
+      spv.Store "CrossWorkgroup" %15, %12 ["Aligned", 4] : f32
+      spv.Return
+    }
+    spv.EntryPoint "Kernel" @addt_kernel, @__builtin_var_WorkgroupId__
+  }
+  gpu.module @addt_kernel {
+    gpu.func @addt_kernel(%arg0: memref<?xf32>, %arg1: memref<?xf32>, %arg2: memref<?xf32>) kernel attributes {spv.entry_point_abi = #spv.entry_point_abi<>} {
+      %c5 = arith.constant 5 : index
+      %0 = gpu.block_id  x
+      %1 = gpu.block_id  y
+      cf.br ^bb1
+    ^bb1:  // pred: ^bb0
+      %2 = arith.muli %0, %c5 : index
+      %3 = arith.addi %2, %1 : index
+      %4 = memref.load %arg0[%3] : memref<?xf32>
+      %5 = arith.muli %0, %c5 : index
+      %6 = arith.addi %5, %1 : index
+      %7 = memref.load %arg1[%6] : memref<?xf32>
+      %8 = arith.addf %4, %7 : f32
+      %9 = arith.muli %0, %c5 : index
+      %10 = arith.addi %9, %1 : index
+      memref.store %8, %arg2[%10] : memref<?xf32>
+      gpu.return
+    }
+  }
+}

--- a/tools/imex-opt/CMakeLists.txt
+++ b/tools/imex-opt/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LIBS
         ${dialect_libs}
         ${conversion_libs}
 	MLIROptLib
+        IMEXTransforms
         )
 add_llvm_executable(imex-opt imex-opt.cpp)
 


### PR DESCRIPTION
Porting the serializespirv pass from main branch to refactor branch and put the pass in the newly created transform directory

this pass utilizes the upstream spirv::serialize() function to serialize MLIR SPIR-V module to SPIR-V binary and attaches the binary as a string attribute to the gpuModule. 
this pass works like the upstream SerializeToCubin and SerializeToHsaco, only that the other two passes translate llvm dialect to llvm IR and then translate to ISA binary.


Please review these guidelines to help with the review process:
- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
- [x] Have you organized your commits logically and ensured each can be built by itself?
