### PR TITLE
Add env region canonicalizations

### DIFF
--- a/mlir/include/mlir-extensions/Dialect/imex_util/ImexUtilOps.td
+++ b/mlir/include/mlir-extensions/Dialect/imex_util/ImexUtilOps.td
@@ -251,6 +251,11 @@ def EnvironmentRegionOp : ImexUtil_Op<"env_region", [
   let assemblyFormat =
       "attr-dict $environment ($args^ `:` type($args))? (`->` type($results)^)? $region";
 
+  let extraClassDeclaration = [{
+    /// Inline op body into parent region and erase the op.
+    static void inlineIntoParent(::mlir::PatternRewriter &builder, EnvironmentRegionOp op);
+  }];
+
   let hasCanonicalizer = 1;
 }
 

--- a/mlir/include/mlir-extensions/Dialect/imex_util/ImexUtilOps.td
+++ b/mlir/include/mlir-extensions/Dialect/imex_util/ImexUtilOps.td
@@ -250,6 +250,8 @@ def EnvironmentRegionOp : ImexUtil_Op<"env_region", [
 
   let assemblyFormat =
       "attr-dict $environment ($args^ `:` type($args))? (`->` type($results)^)? $region";
+
+  let hasCanonicalizer = 1;
 }
 
 def EnvironmentRegionYieldOp : ImexUtil_Op<"env_region_yield", [

--- a/mlir/lib/Dialect/imex_util/dialect.cpp
+++ b/mlir/lib/Dialect/imex_util/dialect.cpp
@@ -1853,7 +1853,7 @@ struct CleanupRegionYieldArgs
       rewriter.replaceOpWithNewOp<EnvironmentRegionYieldOp>(term, newYieldArgs);
     }
 
-    // Contruct new result list, using mapping previously contructed.
+    // Contruct new result list, using mapping previously constructed.
     auto newResults = newOp.getResults();
     llvm::SmallVector<mlir::Value> newResultsToTeplace(count);
     for (auto i : llvm::seq(0u, count)) {
@@ -1912,7 +1912,7 @@ struct MergeAdjacentRegions
     auto nextYieldArgs = nextTerm.results();
 
     // Contruct merged yield args list, some of the results may become unused,
-    // but they will be cleaned up be other pattern.
+    // but they will be cleaned up by other pattern.
     llvm::SmallVector<mlir::Value> newYieldArgs(count + nextYieldArgs.size());
     llvm::copy(nextYieldArgs, llvm::copy(yieldArgs, newYieldArgs.begin()));
 

--- a/mlir/lib/Dialect/imex_util/dialect.cpp
+++ b/mlir/lib/Dialect/imex_util/dialect.cpp
@@ -1729,20 +1729,18 @@ struct EnvRegionPropagateOutsideValues
     auto termArgs = term.results();
     assert(oldResults.size() == termArgs.size());
 
-    bool changed = false;
     llvm::SmallVector<mlir::Value> newResults(count);
     llvm::SmallVector<mlir::Value> newYieldArgs;
     for (auto i : llvm::seq(0u, count)) {
       auto arg = termArgs[i];
       if (!op.getRegion().isAncestor(arg.getParentRegion())) {
         newResults[i] = arg;
-        changed = true;
       } else {
         newYieldArgs.emplace_back(arg);
       }
     }
 
-    if (!changed)
+    if (newYieldArgs.size() == count)
       return mlir::failure();
 
     mlir::ValueRange newYieldArgsRange(newYieldArgs);

--- a/mlir/test/Dialect/imex_util/canonicalize.mlir
+++ b/mlir/test/Dialect/imex_util/canonicalize.mlir
@@ -1,4 +1,4 @@
-// RUN: imex-opt %s -canonicalize --split-input-file | FileCheck %s
+// RUN: imex-opt %s -allow-unregistered-dialect -canonicalize --split-input-file | FileCheck %s
 
 func.func @test(%arg1: index, %arg2: i64) -> i64 {
   %0 = imex_util.build_tuple %arg1, %arg2: index, i64 -> tuple<index, i64>
@@ -32,3 +32,23 @@ func.func @empty_region_out_value(%arg1: index) -> index {
 // CHECK-LABEL: func @empty_region_out_value
 //  CHECK-SAME: (%[[ARG:.*]]: index)
 //       CHECK: return %[[ARG]] : index
+
+// -----
+
+func.func @merge_nested_region() {
+  imex_util.env_region "test" {
+    "test.test1"() : () -> ()
+    imex_util.env_region "test" {
+      "test.test2"() : () -> ()
+    }
+    "test.test3"() : () -> ()
+  }
+  return
+}
+// CHECK-LABEL: func @merge_nested_region
+//  CHECK-NEXT:   imex_util.env_region
+//  CHECK-NEXT:   "test.test1"() : () -> ()
+//  CHECK-NEXT:   "test.test2"() : () -> ()
+//  CHECK-NEXT:   "test.test3"() : () -> ()
+//  CHECK-NEXT:   }
+//  CHECK-NEXT:   return

--- a/mlir/test/Dialect/imex_util/canonicalize.mlir
+++ b/mlir/test/Dialect/imex_util/canonicalize.mlir
@@ -9,3 +9,26 @@ func.func @test(%arg1: index, %arg2: i64) -> i64 {
 // CHECK-LABEL: func @test
 //  CHECK-SAME:   (%[[ARG1:.*]]: index, %[[ARG2:.*]]: i64)
 //  CHECK-NEXT:   return %[[ARG2]] : i64
+
+// -----
+
+func.func @remove_empty_region() {
+  imex_util.env_region "test" {
+  }
+  return
+}
+// CHECK-LABEL: func @remove_empty_region
+//   CHECK-NOT:   imex_util.env_region
+//  CHECK-NEXT:   return
+
+// -----
+
+func.func @empty_region_out_value(%arg1: index) -> index {
+  %0 = imex_util.env_region "test" -> index {
+    imex_util.env_region_yield %arg1: index
+  }
+  return %0 : index
+}
+// CHECK-LABEL: func @empty_region_out_value
+//  CHECK-SAME: (%[[ARG:.*]]: index)
+//       CHECK: return %[[ARG]] : index

--- a/mlir/test/Dialect/imex_util/canonicalize.mlir
+++ b/mlir/test/Dialect/imex_util/canonicalize.mlir
@@ -52,3 +52,21 @@ func.func @merge_nested_region() {
 //  CHECK-NEXT:   "test.test3"() : () -> ()
 //  CHECK-NEXT:   }
 //  CHECK-NEXT:   return
+
+// -----
+
+func.func @nested_region_yield_args() {
+  %0:4 = imex_util.env_region "test" -> index, i32, index, i64 {
+    %1:3 = "test.test1"() : () -> (index, i32, i64)
+    imex_util.env_region_yield %1#0, %1#1, %1#0, %1#2: index, i32, index, i64
+  }
+  "test.test2"(%0#0, %0#2, %0#3) : (index, index, i64) -> ()
+  return
+}
+// CHECK-LABEL: func @nested_region_yield_args
+//  CHECK-NEXT:   %[[RES:.*]]:2 = imex_util.env_region "test" -> index, i64 {
+//  CHECK-NEXT:   %[[VAL:.*]]:3 = "test.test1"() : () -> (index, i32, i64)
+//  CHECK-NEXT:   imex_util.env_region_yield %[[VAL]]#0, %[[VAL]]#2 : index, i64
+//  CHECK-NEXT:   }
+//  CHECK-NEXT:   "test.test2"(%[[RES]]#0, %[[RES]]#0, %[[RES]]#1) : (index, index, i64) -> ()
+//  CHECK-NEXT:   return


### PR DESCRIPTION
Canonicalizations:
* Remove empty env region op (already covered by `NoSideEffect` handling, added test)
* Propagate yield values, defined outside region
* Merge nested regions with same environment and args
* Remove duplicated and unused yield args
* Merge adjacent regions with same environment and args
