### PR TITLE
Introduce new Execution engine and new Numba interop

### DIFF
--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -48,6 +48,7 @@ set(SOURCES_LIST
     lib/Dialect/gpu_runtime/IR/gpu_runtime_ops.cpp
     lib/Dialect/imex_util/dialect.cpp
     lib/Dialect/plier/dialect.cpp
+    lib/ExecutionEngine/execution_engine.cpp
     lib/Transforms/arg_lowering.cpp
     lib/Transforms/call_lowering.cpp
     lib/Transforms/canonicalize_reductions.cpp
@@ -85,6 +86,7 @@ set(HEADERS_LIST
     include/mlir-extensions/Dialect/gpu_runtime/IR/gpu_runtime_ops.hpp
     include/mlir-extensions/Dialect/imex_util/dialect.hpp
     include/mlir-extensions/Dialect/plier/dialect.hpp
+    include/mlir-extensions/ExecutionEngine/execution_engine.hpp
     include/mlir-extensions/Transforms/arg_lowering.hpp
     include/mlir-extensions/Transforms/call_lowering.hpp
     include/mlir-extensions/Transforms/canonicalize_reductions.hpp
@@ -132,14 +134,14 @@ endif()
 unset(__offsetof_flag)
 
 target_link_libraries(${MLIR_EXTENSIONS_LIB} PRIVATE
+    MLIRControlFlowToSPIRV
+    MLIRFuncTransforms
     MLIRIR
     MLIRLLVMDialect
-    MLIRTransforms
-    MLIRFuncTransforms
     MLIRLinalgTransforms
-    MLIRTensorTransforms
     MLIRMathToSPIRV
-    MLIRControlFlowToSPIRV
+    MLIRTensorTransforms
+    MLIRTransforms
     )
 
 target_include_directories(${MLIR_EXTENSIONS_LIB} SYSTEM PRIVATE

--- a/mlir/include/mlir-extensions/ExecutionEngine/execution_engine.hpp
+++ b/mlir/include/mlir-extensions/ExecutionEngine/execution_engine.hpp
@@ -1,0 +1,109 @@
+// Copyright 2022 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "llvm/ExecutionEngine/Orc/Core.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/Support/CodeGen.h"
+#include "llvm/Support/Error.h"
+
+#include <functional>
+#include <memory>
+
+namespace mlir {
+class ModuleOp;
+}
+
+namespace llvm {
+template <typename T> class Expected;
+class JITEventListener;
+
+namespace orc {
+class LLJIT;
+class MangleAndInterner;
+} // namespace orc
+} // namespace llvm
+
+namespace imex {
+struct ExecutionEngineOptions {
+  /// `jitCodeGenOptLevel`, when provided, is used as the optimization level for
+  /// target code generation.
+  llvm::Optional<llvm::CodeGenOpt::Level> jitCodeGenOptLevel = llvm::None;
+
+  /// If `enableObjectCache` is set, the JIT compiler will create one to store
+  /// the object generated for the given module. The contents of the cache can
+  /// be dumped to a file via the `dumpToObjectfile` method.
+  bool enableObjectCache = false;
+
+  /// If enable `enableGDBNotificationListener` is set, the JIT compiler will
+  /// notify the llvm's global GDB notification listener.
+  bool enableGDBNotificationListener = true;
+
+  /// If `enablePerfNotificationListener` is set, the JIT compiler will notify
+  /// the llvm's global Perf notification listener.
+  bool enablePerfNotificationListener = true;
+
+  /// Register symbols with this ExecutionEngine.
+  std::function<llvm::orc::SymbolMap(llvm::orc::MangleAndInterner)> symbolMap;
+};
+
+class ExecutionEngine {
+  class SimpleObjectCache;
+
+public:
+  using ModuleHandle = void *;
+
+  ExecutionEngine(const ExecutionEngineOptions &options);
+  ~ExecutionEngine();
+
+  /// Compiles given module, adds it to execution engine and run its contructors
+  /// if any.
+  llvm::Expected<ModuleHandle> loadModule(mlir::ModuleOp m);
+
+  /// Runs module desctructors and removes it from execution engine.
+  void releaseModule(ModuleHandle handle);
+
+  /// Looks up the original function with the given name and returns a
+  /// pointer to it. Propagates errors in case of failure.
+  llvm::Expected<void *> lookup(ModuleHandle handle,
+                                llvm::StringRef name) const;
+
+  /// Dump object code to output file `filename`.
+  void dumpToObjectFile(llvm::StringRef filename);
+
+private:
+  /// Ordering of llvmContext and jit is important for destruction purposes: the
+  /// jit must be destroyed before the context.
+  llvm::LLVMContext llvmContext;
+
+  /// Underlying LLJIT.
+  std::unique_ptr<llvm::orc::LLJIT> jit;
+
+  /// Underlying cache.
+  std::unique_ptr<SimpleObjectCache> cache;
+
+  /// GDB notification listener.
+  llvm::JITEventListener *gdbListener;
+
+  /// Perf notification listener.
+  llvm::JITEventListener *perfListener;
+
+  /// Callback to get additional symbol definitions.
+  std::function<llvm::orc::SymbolMap(llvm::orc::MangleAndInterner)> symbolMap;
+
+  /// Id for unique module name generation.
+  int uniqueNameCounter = 0;
+};
+} // namespace imex

--- a/mlir/include/mlir-extensions/ExecutionEngine/execution_engine.hpp
+++ b/mlir/include/mlir-extensions/ExecutionEngine/execution_engine.hpp
@@ -57,6 +57,10 @@ struct ExecutionEngineOptions {
 
   /// Register symbols with this ExecutionEngine.
   std::function<llvm::orc::SymbolMap(llvm::orc::MangleAndInterner)> symbolMap;
+
+  /// If `transformer` is provided, it will be called on the LLVM module during
+  /// JIT-compilation and can be used, e.g., for reporting or optimization.
+  std::function<llvm::Error(llvm::Module *)> transformer;
 };
 
 class ExecutionEngine {
@@ -65,7 +69,7 @@ class ExecutionEngine {
 public:
   using ModuleHandle = void *;
 
-  ExecutionEngine(const ExecutionEngineOptions &options);
+  ExecutionEngine(ExecutionEngineOptions options);
   ~ExecutionEngine();
 
   /// Compiles given module, adds it to execution engine and run its contructors
@@ -102,6 +106,10 @@ private:
 
   /// Callback to get additional symbol definitions.
   std::function<llvm::orc::SymbolMap(llvm::orc::MangleAndInterner)> symbolMap;
+
+  /// If `transformer` is provided, it will be called on the LLVM module during
+  /// JIT-compilation and can be used, e.g., for reporting or optimization.
+  std::function<llvm::Error(llvm::Module *)> transformer;
 
   /// Id for unique module name generation.
   int uniqueNameCounter = 0;

--- a/mlir/include/mlir-extensions/ExecutionEngine/execution_engine.hpp
+++ b/mlir/include/mlir-extensions/ExecutionEngine/execution_engine.hpp
@@ -60,7 +60,7 @@ struct ExecutionEngineOptions {
 
   /// If `transformer` is provided, it will be called on the LLVM module during
   /// JIT-compilation and can be used, e.g., for reporting or optimization.
-  std::function<llvm::Error(llvm::Module *)> transformer;
+  std::function<llvm::Error(llvm::Module &)> transformer;
 };
 
 class ExecutionEngine {
@@ -109,7 +109,7 @@ private:
 
   /// If `transformer` is provided, it will be called on the LLVM module during
   /// JIT-compilation and can be used, e.g., for reporting or optimization.
-  std::function<llvm::Error(llvm::Module *)> transformer;
+  std::function<llvm::Error(llvm::Module &)> transformer;
 
   /// Id for unique module name generation.
   int uniqueNameCounter = 0;

--- a/mlir/lib/ExecutionEngine/execution_engine.cpp
+++ b/mlir/lib/ExecutionEngine/execution_engine.cpp
@@ -154,27 +154,6 @@ imex::ExecutionEngine::ExecutionEngine(ExecutionEngineOptions options)
       objectLayer->setAutoClaimResponsibilityForObjectSymbols(true);
     }
 
-    // Resolve symbols from shared libraries.
-    //    for (auto libPath : options.sharedLibPaths) {
-    //      auto mb = llvm::MemoryBuffer::getFile(libPath);
-    //      if (!mb) {
-    //        llvm::errs() << "Failed to create MemoryBuffer for: " << libPath
-    //               << "\nError: " << mb.getError().message() << "\n";
-    //        continue;
-    //      }
-    //      auto &jd = session.createBareJITDylib(std::string(libPath));
-    //      auto loaded = DynamicLibrarySearchGenerator::Load(
-    //          libPath.data(), dataLayout.getGlobalPrefix());
-    //      if (!loaded) {
-    //        llvm::errs() << "Could not load " << libPath << ":\n  " <<
-    //        loaded.takeError()
-    //               << "\n";
-    //        continue;
-    //      }
-    //      jd.addGenerator(std::move(*loaded));
-    //      cantFail(objectLayer->add(jd, std::move(mb.get())));
-    //    }
-
     return objectLayer;
   };
 

--- a/mlir/lib/ExecutionEngine/execution_engine.cpp
+++ b/mlir/lib/ExecutionEngine/execution_engine.cpp
@@ -222,7 +222,7 @@ imex::ExecutionEngine::loadModule(mlir::ModuleOp m) {
   llvm::orc::ThreadSafeModule tsm(std::move(llvmModule), std::move(ctx));
   if (transformer)
     cantFail(tsm.withModuleDo(
-        [this](llvm::Module &module) { return transformer(&module); }));
+        [this](llvm::Module &module) { return transformer(module); }));
 
   llvm::orc::JITDylib *dylib;
   while (true) {

--- a/mlir/lib/ExecutionEngine/execution_engine.cpp
+++ b/mlir/lib/ExecutionEngine/execution_engine.cpp
@@ -1,0 +1,297 @@
+// Copyright 2022 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mlir-extensions/ExecutionEngine/execution_engine.hpp"
+
+#include <llvm/ExecutionEngine/JITEventListener.h>
+#include <llvm/ExecutionEngine/ObjectCache.h>
+#include <llvm/ExecutionEngine/Orc/ExecutionUtils.h>
+#include <llvm/ExecutionEngine/Orc/IRCompileLayer.h>
+#include <llvm/ExecutionEngine/Orc/IRTransformLayer.h>
+#include <llvm/ExecutionEngine/Orc/LLJIT.h>
+#include <llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h>
+#include <llvm/ExecutionEngine/SectionMemoryManager.h>
+#include <llvm/IR/Module.h>
+#include <llvm/MC/SubtargetFeature.h>
+#include <llvm/MC/TargetRegistry.h>
+#include <llvm/Support/Host.h>
+#include <llvm/Support/MemoryBuffer.h>
+#include <llvm/Support/ToolOutputFile.h>
+#include <llvm/Target/TargetMachine.h>
+
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/Support/FileUtilities.h>
+#include <mlir/Target/LLVMIR/Export.h>
+
+#define DEBUG_TYPE "execution-engine"
+
+/// A simple object cache following Lang's LLJITWithObjectCache example.
+class imex::ExecutionEngine::SimpleObjectCache : public llvm::ObjectCache {
+public:
+  void notifyObjectCompiled(const llvm::Module *m,
+                            llvm::MemoryBufferRef objBuffer) override {
+    cachedObjects[m->getModuleIdentifier()] =
+        llvm::MemoryBuffer::getMemBufferCopy(objBuffer.getBuffer(),
+                                             objBuffer.getBufferIdentifier());
+  }
+
+  std::unique_ptr<llvm::MemoryBuffer>
+  getObject(const llvm::Module *m) override {
+    auto i = cachedObjects.find(m->getModuleIdentifier());
+    if (i == cachedObjects.end()) {
+      LLVM_DEBUG(llvm::dbgs() << "No object for " << m->getModuleIdentifier()
+                              << " in cache. Compiling.\n");
+      return nullptr;
+    }
+    LLVM_DEBUG(llvm::dbgs() << "Object for " << m->getModuleIdentifier()
+                            << " loaded from cache.\n");
+    return llvm::MemoryBuffer::getMemBuffer(i->second->getMemBufferRef());
+  }
+
+  /// Dump cached object to output file `filename`.
+  void dumpToObjectFile(llvm::StringRef outputFilename) {
+    // Set up the output file.
+    std::string errorMessage;
+    auto file = mlir::openOutputFile(outputFilename, &errorMessage);
+    if (!file) {
+      llvm::errs() << errorMessage << "\n";
+      return;
+    }
+
+    // Dump the object generated for a single module to the output file.
+    assert(cachedObjects.size() == 1 && "Expected only one object entry.");
+    auto &cachedObject = cachedObjects.begin()->second;
+    file->os() << cachedObject->getBuffer();
+    file->keep();
+  }
+
+private:
+  llvm::StringMap<std::unique_ptr<llvm::MemoryBuffer>> cachedObjects;
+};
+
+/// Wrap a string into an llvm::StringError.
+static llvm::Error makeStringError(const llvm::Twine &message) {
+  return llvm::make_error<llvm::StringError>(message.str(),
+                                             llvm::inconvertibleErrorCode());
+}
+
+// Setup LLVM target triple from the current machine.
+static bool setupTargetTriple(llvm::Module *llvmModule) {
+  // Setup the machine properties from the current architecture.
+  auto targetTriple = llvm::sys::getDefaultTargetTriple();
+  std::string errorMessage;
+  const auto *target =
+      llvm::TargetRegistry::lookupTarget(targetTriple, errorMessage);
+  if (!target) {
+    llvm::errs() << "NO target: " << errorMessage << "\n";
+    return true;
+  }
+
+  std::string cpu(llvm::sys::getHostCPUName());
+  llvm::SubtargetFeatures features;
+  llvm::StringMap<bool> hostFeatures;
+
+  if (llvm::sys::getHostCPUFeatures(hostFeatures))
+    for (auto &f : hostFeatures)
+      features.AddFeature(f.first(), f.second);
+
+  std::unique_ptr<llvm::TargetMachine> machine(target->createTargetMachine(
+      targetTriple, cpu, features.getString(), {}, {}));
+  if (!machine) {
+    llvm::errs() << "Unable to create target machine\n";
+    return true;
+  }
+  llvmModule->setDataLayout(machine->createDataLayout());
+  llvmModule->setTargetTriple(targetTriple);
+  return false;
+}
+
+imex::ExecutionEngine::ExecutionEngine(const ExecutionEngineOptions &options)
+    : cache(options.enableObjectCache ? new SimpleObjectCache() : nullptr),
+      gdbListener(options.enableGDBNotificationListener
+                      ? llvm::JITEventListener::createGDBRegistrationListener()
+                      : nullptr),
+      perfListener(nullptr) {
+  if (options.enablePerfNotificationListener) {
+    if (auto *listener = llvm::JITEventListener::createPerfJITEventListener())
+      perfListener = listener;
+    else if (auto *listener =
+                 llvm::JITEventListener::createIntelJITEventListener())
+      perfListener = listener;
+  }
+
+  // Callback to create the object layer with symbol resolution to current
+  // process and dynamically linked libraries.
+  auto objectLinkingLayerCreator = [this](llvm::orc::ExecutionSession &session,
+                                          const llvm::Triple &targetTriple) {
+    auto objectLayer =
+        std::make_unique<llvm::orc::RTDyldObjectLinkingLayer>(session, []() {
+          return std::make_unique<llvm::SectionMemoryManager>();
+        });
+
+    // Register JIT event listeners if they are enabled.
+    if (gdbListener)
+      objectLayer->registerJITEventListener(*gdbListener);
+    if (perfListener)
+      objectLayer->registerJITEventListener(*perfListener);
+
+    // COFF format binaries (Windows) need special handling to deal with
+    // exported symbol visibility.
+    // cf llvm/lib/ExecutionEngine/Orc/LLJIT.cpp LLJIT::createObjectLinkingLayer
+    if (targetTriple.isOSBinFormatCOFF()) {
+      objectLayer->setOverrideObjectFlagsWithResponsibilityFlags(true);
+      objectLayer->setAutoClaimResponsibilityForObjectSymbols(true);
+    }
+
+    // Resolve symbols from shared libraries.
+    //    for (auto libPath : options.sharedLibPaths) {
+    //      auto mb = llvm::MemoryBuffer::getFile(libPath);
+    //      if (!mb) {
+    //        llvm::errs() << "Failed to create MemoryBuffer for: " << libPath
+    //               << "\nError: " << mb.getError().message() << "\n";
+    //        continue;
+    //      }
+    //      auto &jd = session.createBareJITDylib(std::string(libPath));
+    //      auto loaded = DynamicLibrarySearchGenerator::Load(
+    //          libPath.data(), dataLayout.getGlobalPrefix());
+    //      if (!loaded) {
+    //        llvm::errs() << "Could not load " << libPath << ":\n  " <<
+    //        loaded.takeError()
+    //               << "\n";
+    //        continue;
+    //      }
+    //      jd.addGenerator(std::move(*loaded));
+    //      cantFail(objectLayer->add(jd, std::move(mb.get())));
+    //    }
+
+    return objectLayer;
+  };
+
+  // Callback to inspect the cache and recompile on demand. This follows Lang's
+  // LLJITWithObjectCache example.
+  auto compileFunctionCreator = [this, jitCodeGenOptLevel =
+                                           options.jitCodeGenOptLevel](
+                                    llvm::orc::JITTargetMachineBuilder jtmb)
+      -> llvm::Expected<
+          std::unique_ptr<llvm::orc::IRCompileLayer::IRCompiler>> {
+    if (jitCodeGenOptLevel)
+      jtmb.setCodeGenOptLevel(*jitCodeGenOptLevel);
+    auto tm = jtmb.createTargetMachine();
+    if (!tm)
+      return tm.takeError();
+    return std::make_unique<llvm::orc::TMOwningSimpleCompiler>(std::move(*tm),
+                                                               cache.get());
+  };
+
+  // Create the LLJIT by calling the LLJITBuilder with 2 callbacks.
+  jit = cantFail(llvm::orc::LLJITBuilder()
+                     .setCompileFunctionCreator(compileFunctionCreator)
+                     .setObjectLinkingLayerCreator(objectLinkingLayerCreator)
+                     .create());
+
+  // Resolve symbols that are statically linked in the current process.
+  llvm::orc::JITDylib &mainJD = jit->getMainJITDylib();
+  auto dataLayout = jit->getDataLayout();
+  mainJD.addGenerator(
+      cantFail(llvm::orc::DynamicLibrarySearchGenerator::GetForCurrentProcess(
+          dataLayout.getGlobalPrefix())));
+
+  symbolMap = options.symbolMap;
+}
+
+imex::ExecutionEngine::~ExecutionEngine() {}
+
+llvm::Expected<imex::ExecutionEngine::ModuleHandle>
+imex::ExecutionEngine::loadModule(mlir::ModuleOp m) {
+  assert(m);
+
+  std::unique_ptr<llvm::LLVMContext> ctx(new llvm::LLVMContext);
+  auto llvmModule = mlir::translateModuleToLLVMIR(m, *ctx);
+  if (!llvmModule)
+    return makeStringError("could not convert to LLVM IR");
+
+  if (setupTargetTriple(llvmModule.get()))
+    return makeStringError("Failed to setup module targetTriple");
+
+  // Add a ThreadSafemodule to the engine and return.
+  llvm::orc::ThreadSafeModule tsm(std::move(llvmModule), std::move(ctx));
+
+  llvm::orc::JITDylib *dylib;
+  while (true) {
+    auto uniqueName =
+        (llvm::Twine("module") + llvm::Twine(uniqueNameCounter++)).str();
+    if (jit->getJITDylibByName(uniqueName))
+      continue;
+
+    auto res = jit->createJITDylib(std::move(uniqueName));
+    if (!res)
+      return res.takeError();
+
+    dylib = &res.get();
+    break;
+  }
+  assert(dylib);
+
+  if (symbolMap)
+    cantFail(
+        dylib->define(absoluteSymbols(symbolMap(llvm::orc::MangleAndInterner(
+            dylib->getExecutionSession(), jit->getDataLayout())))));
+
+  llvm::cantFail(jit->addIRModule(*dylib, std::move(tsm)));
+  llvm::cantFail(jit->initialize(*dylib));
+  return static_cast<ModuleHandle>(dylib);
+}
+
+void imex::ExecutionEngine::releaseModule(ModuleHandle handle) {
+  assert(handle);
+  auto dylib = static_cast<llvm::orc::JITDylib *>(handle);
+  llvm::cantFail(jit->deinitialize(*dylib));
+  dylib->Release();
+}
+
+llvm::Expected<void *>
+imex::ExecutionEngine::lookup(imex::ExecutionEngine::ModuleHandle handle,
+                              llvm::StringRef name) const {
+  assert(handle);
+  auto dylib = static_cast<llvm::orc::JITDylib *>(handle);
+  auto expectedSymbol = jit->lookup(*dylib, name);
+
+  // JIT lookup may return an Error referring to strings stored internally by
+  // the JIT. If the Error outlives the ExecutionEngine, it would want have a
+  // dangling reference, which is currently caught by an assertion inside JIT
+  // thanks to hand-rolled reference counting. Rewrap the error message into a
+  // string before returning. Alternatively, ORC JIT should consider copying
+  // the string into the error message.
+  if (!expectedSymbol) {
+    std::string errorMessage;
+    llvm::raw_string_ostream os(errorMessage);
+    llvm::handleAllErrors(expectedSymbol.takeError(),
+                          [&os](llvm::ErrorInfoBase &ei) { ei.log(os); });
+    return makeStringError(os.str());
+  }
+
+  if (void *fptr = expectedSymbol->toPtr<void *>())
+    return fptr;
+
+  return makeStringError("looked up function is null");
+}
+
+void imex::ExecutionEngine::dumpToObjectFile(llvm::StringRef filename) {
+  if (cache == nullptr) {
+    llvm::errs() << "cannot dump ExecutionEngine object code to file: "
+                    "object cache is disabled\n";
+    return;
+  }
+  cache->dumpToObjectFile(filename);
+}

--- a/mlir/lib/ExecutionEngine/execution_engine.cpp
+++ b/mlir/lib/ExecutionEngine/execution_engine.cpp
@@ -200,13 +200,6 @@ imex::ExecutionEngine::ExecutionEngine(const ExecutionEngineOptions &options)
                      .setObjectLinkingLayerCreator(objectLinkingLayerCreator)
                      .create());
 
-  // Resolve symbols that are statically linked in the current process.
-  llvm::orc::JITDylib &mainJD = jit->getMainJITDylib();
-  auto dataLayout = jit->getDataLayout();
-  mainJD.addGenerator(
-      cantFail(llvm::orc::DynamicLibrarySearchGenerator::GetForCurrentProcess(
-          dataLayout.getGlobalPrefix())));
-
   symbolMap = options.symbolMap;
 }
 
@@ -242,6 +235,11 @@ imex::ExecutionEngine::loadModule(mlir::ModuleOp m) {
     break;
   }
   assert(dylib);
+
+  auto dataLayout = jit->getDataLayout();
+  dylib->addGenerator(
+      cantFail(llvm::orc::DynamicLibrarySearchGenerator::GetForCurrentProcess(
+          dataLayout.getGlobalPrefix())));
 
   if (symbolMap)
     cantFail(

--- a/numba_dpcomp/numba_dpcomp/mlir/compiler_context.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/compiler_context.py
@@ -1,0 +1,25 @@
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .settings import DEBUG_TYPE
+from .. import mlir_compiler
+
+def _init_compiler():
+    settings = {}
+    settings["debug_type"] = DEBUG_TYPE
+    return mlir_compiler.init_compiler(settings)
+
+
+global_compiler_context = _init_compiler()
+del _init_compiler

--- a/numba_dpcomp/numba_dpcomp/mlir/compiler_context.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/compiler_context.py
@@ -15,6 +15,7 @@
 from .settings import DEBUG_TYPE
 from .. import mlir_compiler
 
+
 def _init_compiler():
     settings = {}
     settings["debug_type"] = DEBUG_TYPE

--- a/numba_dpcomp/numba_dpcomp/mlir/gpu_runtime.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/gpu_runtime.py
@@ -14,7 +14,6 @@
 
 import ctypes
 import atexit
-import llvmlite.binding as ll
 from .utils import load_lib, mlir_func_name, register_cfunc
 
 from numba.core.runtime import _nrt_python as _nrt
@@ -64,7 +63,7 @@ if IS_GPU_RUNTIME_AVAILABLE:
                 func = getattr(runtime_lib, name)
             else:
                 func = 1
-            register_cfunc(ll, name, func)
+            register_cfunc(name, func)
 
         _alloc_func = runtime_lib.dpcompGpuSetMemInfoAllocFunc
         _alloc_func.argtypes = [ctypes.c_void_p]

--- a/numba_dpcomp/numba_dpcomp/mlir/lowering.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/lowering.py
@@ -29,6 +29,7 @@ from numba.core.typed_passes import NativeLowering as orig_NativeLowering
 
 from .runtime import *
 from .math_runtime import *
+from .numba_runtime import *
 from .gpu_runtime import *
 
 import llvmlite.binding as llvm
@@ -46,10 +47,14 @@ class mlir_lower(orig_Lower):
 
     def lower_normal_function(self, fndesc):
         if USE_MLIR:
-            mod_ir = self.metadata.pop("mlir_blob")
-            mod = llvm.parse_bitcode(mod_ir)
+            # mod_ir = self.metadata.pop("mlir_blob")
+            # mod = llvm.parse_bitcode(mod_ir)
             self.setup_function(fndesc)
-            self.library.add_llvm_module(mod)
+            # self.library.add_llvm_module(mod)
+
+            func_ptr = self.metadata.pop("mlir_func_ptr")
+            func_name = self.metadata.pop("mlir_func_name")
+            llvm.add_symbol(func_name, func_ptr)
         else:
             orig_Lower.lower_normal_function(self, desc)
 

--- a/numba_dpcomp/numba_dpcomp/mlir/lowering.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/lowering.py
@@ -54,7 +54,7 @@ class mlir_lower(orig_Lower):
             func_ptr = self.metadata.pop("mlir_func_ptr")
             func_name = self.metadata.pop("mlir_func_name")
 
-            # TODO: Contruct new ir module instead of globally registering symbol
+            # TODO: Construct new ir module instead of globally registering symbol
             llvm.add_symbol(func_name, func_ptr)
         else:
             orig_Lower.lower_normal_function(self, desc)

--- a/numba_dpcomp/numba_dpcomp/mlir/lowering.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/lowering.py
@@ -52,8 +52,12 @@ class mlir_lower(orig_Lower):
             self.setup_function(fndesc)
             # self.library.add_llvm_module(mod)
 
+            # Skip check that all numba symbols defined
+            setattr(self.library, "_verify_declare_only_symbols", lambda: None)
             func_ptr = self.metadata.pop("mlir_func_ptr")
             func_name = self.metadata.pop("mlir_func_name")
+
+            # TODO: Contruct new ir module instead of globally registering symbol
             llvm.add_symbol(func_name, func_ptr)
         else:
             orig_Lower.lower_normal_function(self, desc)

--- a/numba_dpcomp/numba_dpcomp/mlir/lowering.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/lowering.py
@@ -47,10 +47,7 @@ class mlir_lower(orig_Lower):
 
     def lower_normal_function(self, fndesc):
         if USE_MLIR:
-            # mod_ir = self.metadata.pop("mlir_blob")
-            # mod = llvm.parse_bitcode(mod_ir)
             self.setup_function(fndesc)
-            # self.library.add_llvm_module(mod)
 
             # Skip check that all numba symbols defined
             setattr(self.library, "_verify_declare_only_symbols", lambda: None)

--- a/numba_dpcomp/numba_dpcomp/mlir/math_runtime.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/math_runtime.py
@@ -14,7 +14,6 @@
 
 import ctypes
 import atexit
-import llvmlite.binding as ll
 from .utils import load_lib, mlir_func_name, register_cfunc
 
 runtime_lib = load_lib("dpcomp-math-runtime")
@@ -28,7 +27,7 @@ def load_function_variants(func_name, suffixes):
         name = func_name + s
         mlir_name = mlir_func_name(name)
         func = getattr(runtime_lib, name)
-        register_cfunc(ll, mlir_name, func)
+        register_cfunc(mlir_name, func)
 
 
 load_function_variants("dpcompLinalgEig_", ["float32", "float64"])

--- a/numba_dpcomp/numba_dpcomp/mlir/numba_runtime.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/numba_runtime.py
@@ -20,6 +20,7 @@ from numba.core.runtime import _nrt_python as _nrt
 def _register_symbols():
     names = [
         'MemInfo_alloc_safe_aligned',
+        'MemInfo_call_dtor',
     ]
 
     helpers = _nrt.c_helpers

--- a/numba_dpcomp/numba_dpcomp/mlir/numba_runtime.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/numba_runtime.py
@@ -1,0 +1,33 @@
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .compiler_context import global_compiler_context
+from .. import mlir_compiler
+
+from numba.core.runtime import _nrt_python as _nrt
+
+def _register_symbols():
+    names = [
+        'MemInfo_alloc_safe_aligned',
+    ]
+
+    helpers = _nrt.c_helpers
+
+    for name in names:
+        func_name = 'NRT_' + name
+        sym = helpers[name]
+        mlir_compiler.register_symbol(global_compiler_context, func_name, sym)
+
+_register_symbols()
+del _register_symbols

--- a/numba_dpcomp/numba_dpcomp/mlir/numba_runtime.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/numba_runtime.py
@@ -17,18 +17,20 @@ from .. import mlir_compiler
 
 from numba.core.runtime import _nrt_python as _nrt
 
+
 def _register_symbols():
     names = [
-        'MemInfo_alloc_safe_aligned',
-        'MemInfo_call_dtor',
+        "MemInfo_alloc_safe_aligned",
+        "MemInfo_call_dtor",
     ]
 
     helpers = _nrt.c_helpers
 
     for name in names:
-        func_name = 'NRT_' + name
+        func_name = "NRT_" + name
         sym = helpers[name]
         mlir_compiler.register_symbol(global_compiler_context, func_name, sym)
+
 
 _register_symbols()
 del _register_symbols

--- a/numba_dpcomp/numba_dpcomp/mlir/passes.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/passes.py
@@ -189,11 +189,13 @@ class MlirBackend(MlirBackendBase):
 
             # TODO: properly handle returned module ownership
             compiled_mod = mlir_compiler.compile_module2(global_compiler_context, ctx, module)
-            func_ptr = mlir_compiler.get_function_pointer(global_compiler_context, compiled_mod, ctx["fnname"]())
+            func_name = ctx["fnname"]()
+            func_ptr = mlir_compiler.get_function_pointer(global_compiler_context, compiled_mod, func_name)
         finally:
             _mlir_active_module = old_module
         state.metadata["mlir_blob"] = mod_ir
         state.metadata["mlir_func_ptr"] = func_ptr
+        state.metadata["mlir_func_name"] = func_name
         return True
 
 

--- a/numba_dpcomp/numba_dpcomp/mlir/passes.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/passes.py
@@ -71,6 +71,7 @@ def print_pass_ir(print_before, print_after):
 _mlir_last_compiled_func = None
 _mlir_active_module = None
 
+
 class MlirBackendBase(FunctionPass):
     def __init__(self, push_func_stack):
         self._push_func_stack = push_func_stack
@@ -187,9 +188,13 @@ class MlirBackend(MlirBackendBase):
             )
 
             # TODO: properly handle returned module ownership
-            compiled_mod = mlir_compiler.compile_module(global_compiler_context, ctx, module)
+            compiled_mod = mlir_compiler.compile_module(
+                global_compiler_context, ctx, module
+            )
             func_name = ctx["fnname"]()
-            func_ptr = mlir_compiler.get_function_pointer(global_compiler_context, compiled_mod, func_name)
+            func_ptr = mlir_compiler.get_function_pointer(
+                global_compiler_context, compiled_mod, func_name
+            )
         finally:
             _mlir_active_module = old_module
         state.metadata["mlir_func_ptr"] = func_ptr

--- a/numba_dpcomp/numba_dpcomp/mlir/passes.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/passes.py
@@ -187,7 +187,7 @@ class MlirBackend(MlirBackendBase):
             )
 
             # TODO: properly handle returned module ownership
-            compiled_mod = mlir_compiler.compile_module2(global_compiler_context, ctx, module)
+            compiled_mod = mlir_compiler.compile_module(global_compiler_context, ctx, module)
             func_name = ctx["fnname"]()
             func_ptr = mlir_compiler.get_function_pointer(global_compiler_context, compiled_mod, func_name)
         finally:

--- a/numba_dpcomp/numba_dpcomp/mlir/passes.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/passes.py
@@ -185,7 +185,6 @@ class MlirBackend(MlirBackendBase):
             _mlir_last_compiled_func = mlir_compiler.lower_function(
                 ctx, module, state.func_ir
             )
-            mod_ir = mlir_compiler.compile_module(ctx, module)
 
             # TODO: properly handle returned module ownership
             compiled_mod = mlir_compiler.compile_module2(global_compiler_context, ctx, module)
@@ -193,7 +192,6 @@ class MlirBackend(MlirBackendBase):
             func_ptr = mlir_compiler.get_function_pointer(global_compiler_context, compiled_mod, func_name)
         finally:
             _mlir_active_module = old_module
-        state.metadata["mlir_blob"] = mod_ir
         state.metadata["mlir_func_ptr"] = func_ptr
         state.metadata["mlir_func_name"] = func_name
         return True

--- a/numba_dpcomp/numba_dpcomp/mlir/passes.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/passes.py
@@ -20,9 +20,10 @@ from numba.np.ufunc.parallel import get_thread_count
 import numba.core.types.functions
 from contextlib import contextmanager
 
-from .settings import DUMP_IR, DEBUG_TYPE, OPT_LEVEL, DUMP_DIAGNOSTICS
+from .settings import DUMP_IR, OPT_LEVEL, DUMP_DIAGNOSTICS
 from . import func_registry
 from .. import mlir_compiler
+from .compiler_context import global_compiler_context
 
 
 _print_before = []
@@ -69,17 +70,6 @@ def print_pass_ir(print_before, print_after):
 
 _mlir_last_compiled_func = None
 _mlir_active_module = None
-
-
-def _init_compiler():
-    settings = {}
-    settings["debug_type"] = DEBUG_TYPE
-    return mlir_compiler.init_compiler(settings)
-
-
-global_compiler_context = _init_compiler()
-del _init_compiler
-
 
 class MlirBackendBase(FunctionPass):
     def __init__(self, push_func_stack):

--- a/numba_dpcomp/numba_dpcomp/mlir/python_rt.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/python_rt.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import ctypes
-import llvmlite.binding as ll
 from numba.core.runtime import _nrt_python as _nrt
 from .utils import load_lib, register_cfunc
 
@@ -25,7 +24,7 @@ def _register_funcs():
 
     for name in _funcs:
         func = getattr(runtime_lib, name)
-        register_cfunc(ll, name, func)
+        register_cfunc(name, func)
 
     _alloc_func = runtime_lib.dpcompSetMemInfoAllocFunc
     _alloc_func.argtypes = [ctypes.c_void_p]

--- a/numba_dpcomp/numba_dpcomp/mlir/runtime.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/runtime.py
@@ -15,7 +15,6 @@
 import ctypes
 import atexit
 from numba.np.ufunc.parallel import get_thread_count
-import llvmlite.binding as ll
 from .utils import load_lib, register_cfunc
 
 runtime_lib = load_lib("dpcomp-runtime")
@@ -36,7 +35,7 @@ _funcs = [
 
 for name in _funcs:
     func = getattr(runtime_lib, name)
-    register_cfunc(ll, name, func)
+    register_cfunc(name, func)
 
 
 @atexit.register

--- a/numba_dpcomp/numba_dpcomp/mlir/utils.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/utils.py
@@ -19,7 +19,8 @@ import atexit
 import sys
 import numba_dpcomp
 import llvmlite.binding as ll
-
+from .compiler_context import global_compiler_context
+from .. import mlir_compiler
 
 def load_lib(name):
     runtime_search_paths = [os.path.dirname(numba_dpcomp.__file__)]
@@ -61,3 +62,4 @@ def register_cfunc(name, cfunc):
     ptr = ctypes.cast(cfunc, ctypes.c_void_p)
     _registered_cfuncs.append(ptr)
     ll.add_symbol(name, ptr.value)
+    mlir_compiler.register_symbol(global_compiler_context, name, ptr.value)

--- a/numba_dpcomp/numba_dpcomp/mlir/utils.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/utils.py
@@ -22,6 +22,7 @@ import llvmlite.binding as ll
 from .compiler_context import global_compiler_context
 from .. import mlir_compiler
 
+
 def load_lib(name):
     runtime_search_paths = [os.path.dirname(numba_dpcomp.__file__)]
 

--- a/numba_dpcomp/numba_dpcomp/mlir/utils.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/utils.py
@@ -18,6 +18,7 @@ import os
 import atexit
 import sys
 import numba_dpcomp
+import llvmlite.binding as ll
 
 
 def load_lib(name):
@@ -55,7 +56,7 @@ def mlir_func_name(name):
 _registered_cfuncs = []
 
 
-def register_cfunc(ll, name, cfunc):
+def register_cfunc(name, cfunc):
     global _registered_cfuncs
     ptr = ctypes.cast(cfunc, ctypes.c_void_p)
     _registered_cfuncs.append(ptr)

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/CMakeLists.txt
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/CMakeLists.txt
@@ -75,25 +75,28 @@ apply_llvm_compile_flags(${PROJECT_NAME})
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
     mlir-extensions
+
+    LLVM${LLVM_NATIVE_ARCH}AsmParser
     LLVM${LLVM_NATIVE_ARCH}CodeGen
     LLVM${LLVM_NATIVE_ARCH}Desc
+    LLVMOrcJIT
     LLVMTarget
+    MLIRFuncTransforms
+    MLIRGPUToGPURuntimeTransforms
+    MLIRGPUToSPIRV
     MLIRIR
     MLIRLLVMDialect
     MLIRLLVMToLLVMIRTranslation
-    MLIRTransforms
-    MLIRFuncTransforms
-    MLIRLinalgTransforms
     MLIRLinalgToLLVM
+    MLIRLinalgTransforms
     MLIRMathToLLVM
     MLIRMathToLibm
-    MLIRSCFToGPU
-    MLIRGPUToSPIRV
-    MLIRGPUToGPURuntimeTransforms
-    MLIRSPIRVTransforms
-    MLIRSPIRVSerialization
-    MLIRTensorTransforms
     MLIRReconcileUnrealizedCasts
+    MLIRSCFToGPU
+    MLIRSPIRVSerialization
+    MLIRSPIRVTransforms
+    MLIRTensorTransforms
+    MLIRTransforms
     )
 
 target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/lowering.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/lowering.cpp
@@ -760,7 +760,7 @@ struct GlobalCompilerContext {
   imex::ExecutionEngine executionEngine;
 
 private:
-  imex::ExecutionEngineOptions getOpts() {
+  imex::ExecutionEngineOptions getOpts() const {
     imex::ExecutionEngineOptions opts;
     opts.symbolMap =
         [this](llvm::orc::MangleAndInterner m) -> llvm::orc::SymbolMap {
@@ -773,6 +773,7 @@ private:
       }
       return ret;
     };
+    opts.jitCodeGenOptLevel = llvm::CodeGenOpt::Level::Aggressive;
 
     return opts;
   }

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/lowering.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/lowering.cpp
@@ -148,9 +148,9 @@ struct InstHandles {
 
 struct PlierLowerer final {
   PlierLowerer(mlir::MLIRContext &context) : ctx(context), builder(&ctx) {
+    ctx.loadDialect<imex::util::ImexUtilDialect>();
     ctx.loadDialect<mlir::func::FuncDialect>();
     ctx.loadDialect<plier::PlierDialect>();
-    ctx.loadDialect<imex::util::ImexUtilDialect>();
   }
 
   mlir::func::FuncOp lower(const py::object &compilationContext,

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/lowering.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/lowering.cpp
@@ -856,6 +856,7 @@ py::capsule compileModule2(const py::capsule &compiler,
   assert(mod);
 
   runCompiler(*mod, compilationContext);
+  mlir::registerLLVMDialectTranslation(*mod->module->getContext());
   auto res = context->executionEngine.loadModule(mod->module);
   if (!res)
     imex::reportError(llvm::Twine("Failed to load MLIR module:\n") +

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/lowering.hpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/lowering.hpp
@@ -31,12 +31,9 @@ pybind11::capsule lowerFunction(const pybind11::object &compilationContext,
                                 const pybind11::capsule &pyMod,
                                 const pybind11::object &funcIr);
 
-pybind11::bytes compileModule(const pybind11::object &compilationContext,
-                              const pybind11::capsule &pyMod);
-
-pybind11::capsule compileModule2(const pybind11::capsule &compiler,
-                                 const pybind11::object &compilationContext,
-                                 const pybind11::capsule &pyMod);
+pybind11::capsule compileModule(const pybind11::capsule &compiler,
+                                const pybind11::object &compilationContext,
+                                const pybind11::capsule &pyMod);
 
 void registerSymbol(const pybind11::capsule &compiler,
                     const pybind11::str &name, const pybind11::int_ &ptr);

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/lowering.hpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/lowering.hpp
@@ -38,6 +38,9 @@ pybind11::capsule compileModule2(const pybind11::capsule &compiler,
                                  const pybind11::object &compilationContext,
                                  const pybind11::capsule &pyMod);
 
+void registerSymbol(const pybind11::capsule &compiler,
+                    const pybind11::str &name, const pybind11::int_ &ptr);
+
 pybind11::int_ getFunctionPointer(const pybind11::capsule &compiler,
                                   const pybind11::capsule &module,
                                   pybind11::str funcName);

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/lowering.hpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/lowering.hpp
@@ -17,12 +17,13 @@
 namespace pybind11 {
 class bytes;
 class capsule;
+class dict;
+class int_;
 class object;
 class str;
-class dict;
 } // namespace pybind11
 
-void initCompiler(pybind11::dict settings);
+pybind11::capsule initCompiler(pybind11::dict settings);
 
 pybind11::capsule createModule(pybind11::dict settings);
 
@@ -32,5 +33,16 @@ pybind11::capsule lowerFunction(const pybind11::object &compilationContext,
 
 pybind11::bytes compileModule(const pybind11::object &compilationContext,
                               const pybind11::capsule &pyMod);
+
+pybind11::capsule compileModule2(const pybind11::capsule &compiler,
+                                 const pybind11::object &compilationContext,
+                                 const pybind11::capsule &pyMod);
+
+pybind11::int_ getFunctionPointer(const pybind11::capsule &compiler,
+                                  const pybind11::capsule &module,
+                                  pybind11::str funcName);
+
+void releaseModule(const pybind11::capsule &compiler,
+                   const pybind11::capsule &module);
 
 pybind11::str moduleStr(const pybind11::capsule &pyMod);

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_llvm.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_llvm.cpp
@@ -734,7 +734,7 @@ static mlir::Type getMeminfoType(mlir::LLVMTypeConverter &converter) {
   return mlir::LLVM::LLVMStructType::getLiteral(context, members);
 }
 
-static const bool defineMeminfoFuncs = false;
+static const bool defineMeminfoFuncs = true;
 
 struct LowerRetainOp
     : public mlir::ConvertOpToLLVMPattern<imex::util::RetainOp> {

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_llvm.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_llvm.cpp
@@ -908,17 +908,9 @@ struct DeallocOpLowering
   matchAndRewrite(mlir::memref::DeallocOp op,
                   mlir::memref::DeallocOp::Adaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    // Insert the `free` declaration if it is not already present.
-    auto freeFunc = op->getParentOfType<mlir::ModuleOp>()
-                        .lookupSymbol<mlir::LLVM::LLVMFuncOp>("NRT_decref");
-    if (!freeFunc) {
-      mlir::OpBuilder::InsertionGuard guard(rewriter);
-      rewriter.setInsertionPointToStart(
-          op->getParentOfType<mlir::ModuleOp>().getBody());
-      freeFunc = rewriter.create<mlir::LLVM::LLVMFuncOp>(
-          rewriter.getUnknownLoc(), "NRT_decref",
-          mlir::LLVM::LLVMFunctionType::get(getVoidType(), getVoidPtrType()));
-    }
+    auto mod = op->getParentOfType<mlir::ModuleOp>();
+    assert(mod);
+    auto freeFunc = getDecrefFunc(rewriter, mod);
 
     mlir::MemRefDescriptor memref(adaptor.memref());
     mlir::Value casted = rewriter.create<mlir::LLVM::BitcastOp>(
@@ -927,6 +919,78 @@ struct DeallocOpLowering
     rewriter.replaceOpWithNewOp<mlir::LLVM::CallOp>(
         op, mlir::TypeRange(), mlir::SymbolRefAttr::get(freeFunc), casted);
     return mlir::success();
+  }
+
+private:
+  mlir::LLVM::LLVMFuncOp getDecrefFunc(mlir::OpBuilder &builder,
+                                       mlir::ModuleOp mod) const {
+    llvm::StringRef funcName("NRT_decref");
+    auto func = mod.lookupSymbol<mlir::LLVM::LLVMFuncOp>(funcName);
+    if (!func) {
+      auto loc = builder.getUnknownLoc();
+      mlir::OpBuilder::InsertionGuard g(builder);
+      builder.setInsertionPointToStart(mod.getBody());
+      auto llvmVoidType = getVoidType();
+      auto llvmVoidPointerType = getVoidPtrType();
+      func = builder.create<mlir::LLVM::LLVMFuncOp>(
+          loc, funcName,
+          mlir::LLVM::LLVMFunctionType::get(llvmVoidType, llvmVoidPointerType));
+      if (defineMeminfoFuncs) {
+        func.setPrivate();
+        auto block = func.addEntryBlock();
+        auto releaseBlock = func.addBlock();
+        auto returnBlock = func.addBlock();
+
+        builder.setInsertionPointToStart(block);
+        auto arg = block->getArgument(0);
+        auto meminfoType = mlir::LLVM::LLVMPointerType::get(
+            getMeminfoType(*getTypeConverter()));
+        auto meminfo =
+            builder.create<mlir::LLVM::BitcastOp>(loc, meminfoType, arg);
+
+        auto llvmI32Type = builder.getI32Type();
+
+        auto indexType = getIndexType();
+        auto refcntType = mlir::LLVM::LLVMPointerType::get(indexType);
+        auto i32zero = builder.create<mlir::LLVM::ConstantOp>(
+            loc, llvmI32Type, builder.getI32IntegerAttr(0));
+        mlir::Value indices[] = {i32zero, i32zero};
+        auto refcntPtr = builder.create<mlir::LLVM::GEPOp>(loc, refcntType,
+                                                           meminfo, indices);
+
+        auto one = builder.create<mlir::LLVM::ConstantOp>(
+            loc, indexType, builder.getIntegerAttr(indexType, 1));
+        auto res = builder.create<mlir::LLVM::AtomicRMWOp>(
+            loc, indexType, mlir::LLVM::AtomicBinOp::sub, refcntPtr, one,
+            mlir::LLVM::AtomicOrdering::monotonic);
+
+        auto zero = builder.create<mlir::LLVM::ConstantOp>(
+            loc, indexType, builder.getIntegerAttr(indexType, 0));
+        auto isRelease = builder.create<mlir::LLVM::ICmpOp>(
+            loc, mlir::LLVM::ICmpPredicate::eq, res, zero);
+        builder.create<mlir::LLVM::CondBrOp>(loc, isRelease, releaseBlock,
+                                             returnBlock);
+
+        builder.setInsertionPointToStart(releaseBlock);
+        llvm::StringRef dtorFuncName("NRT_MemInfo_call_dtor");
+        auto dtorFunc = mod.lookupSymbol<mlir::LLVM::LLVMFuncOp>(dtorFuncName);
+        if (!dtorFunc) {
+          mlir::OpBuilder::InsertionGuard g1(builder);
+          builder.setInsertionPointToStart(mod.getBody());
+          dtorFunc = builder.create<mlir::LLVM::LLVMFuncOp>(
+              loc, dtorFuncName,
+              mlir::LLVM::LLVMFunctionType::get(llvmVoidType, meminfoType));
+        }
+        builder.create<mlir::LLVM::CallOp>(loc, mlir::TypeRange(),
+                                           mlir::SymbolRefAttr::get(dtorFunc),
+                                           meminfo.getRes());
+        builder.create<mlir::func::ReturnOp>(loc);
+
+        builder.setInsertionPointToStart(returnBlock);
+        builder.create<mlir::func::ReturnOp>(loc);
+      }
+    }
+    return func;
   }
 };
 

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_llvm.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_llvm.cpp
@@ -718,6 +718,11 @@ private:
   }
 };
 
+enum {
+  MeminfoRefcntIndex = 0,
+  MeminfoDataIndex = 3,
+};
+
 static mlir::Type getMeminfoType(mlir::LLVMTypeConverter &converter) {
   auto indexType = converter.getIndexType();
   auto *context = &converter.getContext();
@@ -794,7 +799,9 @@ private:
         auto refcntType = mlir::LLVM::LLVMPointerType::get(indexType);
         auto i32zero = builder.create<mlir::LLVM::ConstantOp>(
             loc, llvmI32Type, builder.getI32IntegerAttr(0));
-        mlir::Value indices[] = {i32zero, i32zero};
+        auto refcntOffset = builder.create<mlir::LLVM::ConstantOp>(
+            loc, llvmI32Type, builder.getI32IntegerAttr(MeminfoRefcntIndex));
+        mlir::Value indices[] = {i32zero, refcntOffset};
         auto refcntPtr = builder.create<mlir::LLVM::GEPOp>(loc, refcntType,
                                                            meminfo, indices);
 
@@ -891,9 +898,9 @@ private:
     auto llvmI32Type = rewriter.getI32Type();
     auto i32zero = rewriter.create<mlir::LLVM::ConstantOp>(
         loc, llvmI32Type, rewriter.getI32IntegerAttr(0));
-    auto i32three = rewriter.create<mlir::LLVM::ConstantOp>(
-        loc, llvmI32Type, rewriter.getI32IntegerAttr(3));
-    mlir::Value indices[] = {i32zero, i32three};
+    auto dataOffset = rewriter.create<mlir::LLVM::ConstantOp>(
+        loc, llvmI32Type, rewriter.getI32IntegerAttr(MeminfoDataIndex));
+    mlir::Value indices[] = {i32zero, dataOffset};
     auto dataPtrPtr = rewriter.create<mlir::LLVM::GEPOp>(loc, dataPtrPtrType,
                                                          meminfo, indices);
     return rewriter.create<mlir::LLVM::LoadOp>(loc, dataPtrPtr);
@@ -954,7 +961,9 @@ private:
         auto refcntType = mlir::LLVM::LLVMPointerType::get(indexType);
         auto i32zero = builder.create<mlir::LLVM::ConstantOp>(
             loc, llvmI32Type, builder.getI32IntegerAttr(0));
-        mlir::Value indices[] = {i32zero, i32zero};
+        auto refcntOffset = builder.create<mlir::LLVM::ConstantOp>(
+            loc, llvmI32Type, builder.getI32IntegerAttr(MeminfoRefcntIndex));
+        mlir::Value indices[] = {i32zero, refcntOffset};
         auto refcntPtr = builder.create<mlir::LLVM::GEPOp>(loc, refcntType,
                                                            meminfo, indices);
 

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_llvm.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_llvm.cpp
@@ -50,13 +50,11 @@
 #include <llvm/Target/TargetMachine.h>
 
 #include "base_pipeline.hpp"
-#include "pipelines/plier_to_std.hpp"
 
 #include "mlir-extensions/Conversion/util_to_llvm.hpp"
 #include "mlir-extensions/Dialect/imex_util/dialect.hpp"
 #include "mlir-extensions/Dialect/plier/dialect.hpp"
 #include "mlir-extensions/Transforms/func_utils.hpp"
-#include "mlir-extensions/Transforms/type_conversion.hpp"
 #include "mlir-extensions/compiler/pipeline_registry.hpp"
 #include "mlir-extensions/utils.hpp"
 

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/py_module.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/py_module.cpp
@@ -31,7 +31,6 @@ PYBIND11_MODULE(mlir_compiler, m) {
   m.def("create_module", &createModule, "No docs");
   m.def("lower_function", &lowerFunction, "No docs");
   m.def("compile_module", &compileModule, "No docs");
-  m.def("compile_module2", &compileModule2, "No docs");
   m.def("register_symbol", &registerSymbol, "No docs");
   m.def("get_function_pointer", &getFunctionPointer, "No docs");
   m.def("release_module", &releaseModule, "No docs");

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/py_module.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/py_module.cpp
@@ -18,21 +18,22 @@
 
 #include "lowering.hpp"
 
-namespace {
-bool is_dpnp_supported() {
+static bool is_dpnp_supported() {
 #ifdef IMEX_USE_DPNP
   return true;
 #else
   return false;
 #endif
 }
-} // namespace
 
 PYBIND11_MODULE(mlir_compiler, m) {
   m.def("init_compiler", &initCompiler, "No docs");
   m.def("create_module", &createModule, "No docs");
   m.def("lower_function", &lowerFunction, "No docs");
   m.def("compile_module", &compileModule, "No docs");
+  m.def("compile_module2", &compileModule2, "No docs");
+  m.def("get_function_pointer", &getFunctionPointer, "No docs");
+  m.def("release_module", &releaseModule, "No docs");
   m.def("module_str", &moduleStr, "No docs");
   m.def("is_dpnp_supported", &is_dpnp_supported, "No docs");
 }

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/py_module.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/py_module.cpp
@@ -32,6 +32,7 @@ PYBIND11_MODULE(mlir_compiler, m) {
   m.def("lower_function", &lowerFunction, "No docs");
   m.def("compile_module", &compileModule, "No docs");
   m.def("compile_module2", &compileModule2, "No docs");
+  m.def("register_symbol", &registerSymbol, "No docs");
   m.def("get_function_pointer", &getFunctionPointer, "No docs");
   m.def("release_module", &releaseModule, "No docs");
   m.def("module_str", &moduleStr, "No docs");


### PR DESCRIPTION
* Add `ExecutionEngine` to imex core, existing mlir one is not suitable for us:
  * Doesn't support dynamically adding and removing modules
  * Contains 'packed' stuff, which we don't need and which cannot be disabled
* Instead passing LLVM bitcode to Numba side, pass function pointer to compiled code
* Move `RetainOp` lowering back to `lower_to_llvm.cpp` as it contains Numba-specific lowering
* Define our own versions of `NRT_Incref`m `NRT_Decref` and `NRT_MemInfo_data_fast` to reduce dependency on Numba runtime
* Compiled modules are not being freed at the moment and they will leak, but they are not freed in baseline numba as well, so no regression here
