### PR TITLE
Refactor python tuple lowering

### DIFF
--- a/mlir/include/mlir-extensions/Dialect/plier/PlierOps.td
+++ b/mlir/include/mlir-extensions/Dialect/plier/PlierOps.td
@@ -136,7 +136,6 @@ def GetItemOp : Plier_Op<"getitem", [NoSideEffect]> {
   let arguments = (ins AnyType : $value, AnyType : $index);
 
   let results = (outs AnyType);
-  let hasFolder = 1;
 
   let builders = [OpBuilder<(ins "::mlir::Value"
                              : $value, "::mlir::Value"

--- a/mlir/lib/Conversion/util_to_llvm.cpp
+++ b/mlir/lib/Conversion/util_to_llvm.cpp
@@ -20,7 +20,6 @@
 #include <mlir/Pass/Pass.h>
 
 #include "mlir-extensions/Dialect/imex_util/dialect.hpp"
-#include "mlir-extensions/Dialect/plier/dialect.hpp"
 
 #include "mlir-extensions/Conversion/util_to_llvm.hpp"
 
@@ -155,11 +154,12 @@ struct LowerExtractMemrefMetadataOp
 };
 
 struct LowerBuildTuple
-    : public mlir::ConvertOpToLLVMPattern<plier::BuildTupleOp> {
+    : public mlir::ConvertOpToLLVMPattern<imex::util::BuildTupleOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   mlir::LogicalResult
-  matchAndRewrite(plier::BuildTupleOp op, plier::BuildTupleOp::Adaptor adaptor,
+  matchAndRewrite(imex::util::BuildTupleOp op,
+                  imex::util::BuildTupleOp::Adaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     auto converter = getTypeConverter();
     auto type = converter->convertType(op.getType());

--- a/mlir/lib/Dialect/plier/dialect.cpp
+++ b/mlir/lib/Dialect/plier/dialect.cpp
@@ -32,8 +32,6 @@
 
 #include <llvm/ADT/TypeSwitch.h>
 
-#include "mlir-extensions/Transforms/const_utils.hpp"
-
 namespace MemoryEffects = ::mlir::MemoryEffects;
 
 namespace {
@@ -328,51 +326,10 @@ void BuildTupleOp::build(mlir::OpBuilder &builder, mlir::OperationState &state,
                       args);
 }
 
-static mlir::Value
-foldBuildTupleGetitem(mlir::Value val, mlir::Type type,
-                      llvm::ArrayRef<mlir::Attribute> operands) {
-  auto getCastArg = [](mlir::Value arg) -> mlir::Value {
-    if (auto cast = arg.getDefiningOp<plier::CastOp>())
-      return cast.value();
-
-    if (auto cast = arg.getDefiningOp<mlir::UnrealizedConversionCastOp>()) {
-      auto inputs = cast.getInputs();
-      if (inputs.size() == 1)
-        return inputs.front();
-    }
-
-    return {};
-  };
-
-  while (auto arg = getCastArg(val))
-    val = arg;
-
-  auto buildTuple = val.getDefiningOp<plier::BuildTupleOp>();
-  if (buildTuple) {
-    if (auto val = operands[1].dyn_cast_or_null<mlir::IntegerAttr>()) {
-      auto index = val.getInt();
-      auto numArgs = static_cast<unsigned>(buildTuple.args().size());
-      if (index >= 0 && index < numArgs) {
-        auto op = buildTuple.args()[static_cast<unsigned>(index)];
-        if (op.getType() == type)
-          return op;
-      }
-    }
-  }
-  return {};
-}
-
 void GetItemOp::build(mlir::OpBuilder &builder, mlir::OperationState &state,
                       ::mlir::Value value, ::mlir::Value index) {
   GetItemOp::build(builder, state, PyType::getUndefined(state.getContext()),
                    value, index);
-}
-
-mlir::OpFoldResult GetItemOp::fold(llvm::ArrayRef<mlir::Attribute> operands) {
-  if (auto val = foldBuildTupleGetitem(value(), getType(), operands))
-    return val;
-
-  return nullptr;
 }
 
 void GetiterOp::build(mlir::OpBuilder &builder, mlir::OperationState &state,

--- a/mlir/lib/Transforms/call_lowering.cpp
+++ b/mlir/lib/Transforms/call_lowering.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "mlir-extensions/Transforms/call_lowering.hpp"
+#include "mlir-extensions/Dialect/imex_util/dialect.hpp"
 
 #include <mlir/Dialect/Arithmetic/IR/Arithmetic.h>
 
@@ -58,7 +59,7 @@ mlir::LogicalResult imex::ExpandCallVarargs::matchAndRewrite(
     auto index = rewriter.create<mlir::arith::ConstantIndexOp>(
         loc, static_cast<int64_t>(i));
     args[argsCount + i] =
-        rewriter.create<plier::GetItemOp>(loc, type, vararg, index);
+        rewriter.create<imex::util::TupleExtractOp>(loc, type, vararg, index);
   }
 
   auto resType = op.getType();

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_llvm.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_llvm.cpp
@@ -56,7 +56,6 @@
 #include "mlir-extensions/Dialect/imex_util/dialect.hpp"
 #include "mlir-extensions/Dialect/plier/dialect.hpp"
 #include "mlir-extensions/Transforms/func_utils.hpp"
-#include "mlir-extensions/Transforms/type_conversion.hpp"
 #include "mlir-extensions/compiler/pipeline_registry.hpp"
 #include "mlir-extensions/utils.hpp"
 

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_std.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_std.cpp
@@ -1378,7 +1378,7 @@ struct GetItemTupleConversionPattern
     if (!retType)
       return mlir::failure();
 
-    auto index = adaptor.index();
+    auto index = imex::indexCast(rewriter, op->getLoc(), adaptor.index());
 
     rewriter.replaceOpWithNewOp<imex::util::TupleExtractOp>(op, retType,
                                                             container, index);

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_std.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_std.cpp
@@ -1375,7 +1375,7 @@ struct GetItemTupleConversionPattern
     auto &converter = *getTypeConverter();
 
     auto retType = converter.convertType(op.getType());
-    if (retType)
+    if (!retType)
       return mlir::failure();
 
     auto index = adaptor.index();

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/pre_low_simplifications.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/pre_low_simplifications.cpp
@@ -18,6 +18,7 @@
 
 #include "mlir-extensions/Dialect/imex_util/dialect.hpp"
 #include "mlir-extensions/Dialect/plier/dialect.hpp"
+#include "mlir-extensions/Transforms/expand_tuple.hpp"
 #include "mlir-extensions/Transforms/type_conversion.hpp"
 #include "mlir-extensions/compiler/pipeline_registry.hpp"
 
@@ -29,111 +30,6 @@
 #include <mlir/Transforms/Passes.h>
 
 namespace {
-
-static void flattenTuple(mlir::OpBuilder &builder, mlir::Location loc,
-                         mlir::ValueRange values,
-                         llvm::SmallVectorImpl<mlir::Value> &ret) {
-  for (auto arg : values) {
-    if (auto tupleType = arg.getType().dyn_cast<mlir::TupleType>()) {
-      for (auto it : llvm::enumerate(tupleType.getTypes())) {
-        auto i = it.index();
-        auto argType = it.value();
-        auto ind = builder.createOrFold<mlir::arith::ConstantIndexOp>(loc, i);
-        auto res =
-            builder.createOrFold<plier::GetItemOp>(loc, argType, arg, ind);
-        flattenTuple(builder, loc, res, ret);
-      }
-    } else {
-      ret.emplace_back(arg);
-    }
-  }
-}
-
-struct UntupleReturn : public mlir::OpConversionPattern<mlir::func::ReturnOp> {
-  using OpConversionPattern::OpConversionPattern;
-
-  mlir::LogicalResult
-  matchAndRewrite(mlir::func::ReturnOp op,
-                  mlir::func::ReturnOp::Adaptor adaptor,
-                  mlir::ConversionPatternRewriter &rewriter) const override {
-    llvm::SmallVector<mlir::Value> newOperands;
-    auto loc = op.getLoc();
-    flattenTuple(rewriter, loc, adaptor.operands(), newOperands);
-    auto *operation = op.getOperation();
-    rewriter.updateRootInPlace(op,
-                               [&]() { operation->setOperands(newOperands); });
-    return mlir::success();
-  }
-};
-
-static mlir::Value reconstructTuple(mlir::OpBuilder &builder,
-                                    mlir::Location loc,
-                                    mlir::TupleType tupleType,
-                                    mlir::ValueRange &values) {
-  llvm::SmallVector<mlir::Value, 4> vals(tupleType.size());
-  for (auto it : llvm::enumerate(tupleType.getTypes())) {
-    auto i = it.index();
-    auto type = it.value();
-    if (auto innerTuple = type.dyn_cast<mlir::TupleType>()) {
-      vals[i] = reconstructTuple(builder, loc, innerTuple, values);
-    } else {
-      if (values.empty())
-        return {};
-      vals[i] = values.front();
-      values = values.drop_front();
-    }
-  }
-  return builder.create<plier::BuildTupleOp>(loc, tupleType, vals);
-}
-
-struct UntuplePass
-    : public mlir::PassWrapper<UntuplePass,
-                               mlir::OperationPass<mlir::ModuleOp>> {
-  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(UntuplePass)
-
-  void runOnOperation() override {
-    auto module = getOperation();
-    auto *context = &getContext();
-
-    mlir::TypeConverter typeConverter;
-    // Convert unknown types to itself
-    typeConverter.addConversion([](mlir::Type type) { return type; });
-    typeConverter.addConversion(
-        [&typeConverter](mlir::TupleType type,
-                         llvm::SmallVectorImpl<mlir::Type> &ret)
-            -> llvm::Optional<mlir::LogicalResult> {
-          if (mlir::failed(typeConverter.convertTypes(type.getTypes(), ret)))
-            return llvm::None;
-          return mlir::success();
-        });
-
-    auto materializeTupleCast =
-        [](mlir::OpBuilder &builder, mlir::TupleType type,
-           mlir::ValueRange inputs,
-           mlir::Location loc) -> llvm::Optional<mlir::Value> {
-      if (auto ret = reconstructTuple(builder, loc, type, inputs))
-        return ret;
-
-      return llvm::None;
-    };
-    typeConverter.addArgumentMaterialization(materializeTupleCast);
-    typeConverter.addSourceMaterialization(materializeTupleCast);
-    typeConverter.addTargetMaterialization(materializeTupleCast);
-
-    mlir::RewritePatternSet patterns(context);
-    mlir::ConversionTarget target(*context);
-
-    imex::populateControlFlowTypeConversionRewritesAndTarget(typeConverter,
-                                                             patterns, target);
-    //    target.addIllegalOp<plier::GetItemOp, plier::BuildTupleOp>();
-
-    patterns.insert<UntupleReturn>(typeConverter, context);
-
-    if (failed(applyPartialConversion(module, target, std::move(patterns))))
-      signalPassFailure();
-  }
-};
-
 struct MakeSignlessPass
     : public mlir::PassWrapper<MakeSignlessPass, mlir::OperationPass<void>> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MakeSignlessPass)
@@ -183,7 +79,7 @@ struct MakeSignlessPass
 };
 
 void populateUntuplePipeline(mlir::OpPassManager &pm) {
-  pm.addPass(std::make_unique<UntuplePass>());
+  pm.addPass(imex::createExpandTuplePass());
   pm.addPass(mlir::createCanonicalizerPass());
 }
 

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/py_linalg_resolver.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/py_linalg_resolver.cpp
@@ -333,7 +333,7 @@ struct PyLinalgResolver::Context {
 
       mlir::ValueRange vr(elems);
       auto resType = mlir::TupleType::get(builder.getContext(), vr.getTypes());
-      return builder.create<plier::BuildTupleOp>(loc, resType, elems);
+      return builder.create<imex::util::BuildTupleOp>(loc, resType, elems);
     }
 
     if (py::isinstance<py::bool_>(obj)) {
@@ -398,7 +398,7 @@ private:
     if (auto literal = val.getType().dyn_cast<plier::LiteralType>())
       return getPyLiteral(literal.getValue());
 
-    if (auto buildTuple = val.getDefiningOp<plier::BuildTupleOp>()) {
+    if (auto buildTuple = val.getDefiningOp<imex::util::BuildTupleOp>()) {
       auto args = buildTuple.args();
       auto count = static_cast<unsigned>(args.size());
       py::tuple ret(count);
@@ -1621,7 +1621,7 @@ static py::object shapeImpl(py::capsule context, py::capsule ssaVal) {
     llvm::SmallVector<mlir::Type> shapeTypes(rank, builder.getIndexType());
     auto shapeType = mlir::TupleType::get(builder.getContext(), shapeTypes);
     auto shapeVar =
-        builder.create<plier::BuildTupleOp>(loc, shapeType, shapeVals);
+        builder.create<imex::util::BuildTupleOp>(loc, shapeType, shapeVals);
     return ctx.context.createVar(context, shapeVar.getResult());
   }
   return py::list();
@@ -1675,7 +1675,7 @@ static py::object getitemImpl(py::capsule context, py::capsule ssaVal,
                              ", expected [0:" + llvm::Twine(maxIndex) + ")")
                                 .str());
 
-    if (auto parentOp = value.getDefiningOp<plier::BuildTupleOp>())
+    if (auto parentOp = value.getDefiningOp<imex::util::BuildTupleOp>())
       return ctx.context.createVar(
           context, parentOp.getOperand(static_cast<unsigned>(indexVal)));
 
@@ -1862,7 +1862,8 @@ static PyLinalgResolver::Values unpackResults(PyBuilderContext &ctx,
     mlir::ValueRange vr(vals);
 
     auto tupleType = mlir::TupleType::get(builder.getContext(), vr.getTypes());
-    ret.emplace_back(builder.create<plier::BuildTupleOp>(loc, tupleType, vr));
+    ret.emplace_back(
+        builder.create<imex::util::BuildTupleOp>(loc, tupleType, vr));
   } else {
     ret.emplace_back(unwrapVal(object));
   }


### PR DESCRIPTION
Instead of directly lowering python `build_tuple` and `getitem`, convert them to `util` dialect `build_tuple` and `tuple_extract` first.

This is allows to break dependency between high-level python dialect and low level passes.
