### PR TITLE
IMEX_BINARY_DIR differs depending on whether IMEX is built standalone vs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,9 +50,6 @@ else()
     list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
 endif()
 
-set(IMEX_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-set(IMEX_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
-
 include(TableGen)
 include(AddLLVM)
 include(AddMLIR)
@@ -65,12 +62,17 @@ endif()
 
 include_directories(${LLVM_INCLUDE_DIRS})
 include_directories(${MLIR_INCLUDE_DIRS})
-include_directories(${IMEX_SOURCE_DIR}/include)
-include_directories(${IMEX_BINARY_DIR}/include)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 link_directories(${LLVM_BUILD_LIBRARY_DIR})
 add_definitions(${LLVM_DEFINITIONS})
 
 set(LLVM_LIT_ARGS "-sv" CACHE STRING "lit default options")
+
+set(IMEX_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+# LLVM_EXTERNAL_PROJECTS build puts library, executables and tools in LLVM's CMAKE_BINARY_DIR
+set(IMEX_BINARY_DIR ${CMAKE_BINARY_DIR})
+
 include(sanitizers)
 
 add_subdirectory(include)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,3 @@
-add_custom_target(imex-runner-pps
-                  COMMAND mkdir -p imex-runner
-                  COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/imex-runner/*.pp imex-runner/)
-
 configure_lit_site_cfg(
         ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
         ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
@@ -14,7 +10,6 @@ set(IMEX_TEST_DEPENDS
         FileCheck count not
         imex-opt
         imex-runner
-        imex-runner-pps
         mlir-cpu-runner
         mlir_c_runner_utils
         mlir_runner_utils

--- a/test/imex-runner/ptensor_arange.mlir
+++ b/test/imex-runner/ptensor_arange.mlir
@@ -1,4 +1,4 @@
-// RUN: %{python_executable} %{imex_tools_dir}/imex-runner.py -i %s --pass-pipeline-file=ptensor.pp -e main -entry-point-result=void --shared-libs=%{mlir_shlib_dir}/libmlir_c_runner_utils%shlibext --shared-libs=%{mlir_shlib_dir}/libmlir_runner_utils%shlibext | FileCheck %s
+// RUN: %{python_executable} %{imex_tools_dir}/imex-runner.py -i %s --pass-pipeline-file=%p/ptensor.pp -e main -entry-point-result=void --shared-libs=%{mlir_shlib_dir}/libmlir_c_runner_utils%shlibext --shared-libs=%{mlir_shlib_dir}/libmlir_runner_utils%shlibext | FileCheck %s
 
 module {
     func.func @arange(%arg0: i64, %arg1: i64, %arg2: i64) -> !ptensor.ptensor<tensor<?xi64>, 0> {

--- a/tools/imex-runner/imex-runner.py
+++ b/tools/imex-runner/imex-runner.py
@@ -35,7 +35,7 @@ All unknown arguments will be forwarded to mlir-runner. Currently there is no
 option to forward user-provided args to imex-opt.
 
 To use this in a lit test, you can do something similar to
-`// RUN: %{python_executable} %{imex_tools_dir}/imex-runner.py -i %s --pass-pipeline-file=ptensor.pp -e main -entry-point-result=void --shared-libs=%{mlir_shlib_dir}/libmlir_c_runner_utils%shlibext --shared-libs=%{mlir_shlib_dir}/libmlir_runner_utils%shlibext | FileCheck %s`
+`// RUN: %{python_executable} %{imex_tools_dir}/imex-runner.py -i %s --pass-pipeline-file=%p/ptensor.pp -e main -entry-point-result=void --shared-libs=%{mlir_shlib_dir}/libmlir_c_runner_utils%shlibext --shared-libs=%{mlir_shlib_dir}/libmlir_runner_utils%shlibext | FileCheck %s`
 """
 
 import os, sys, re


### PR DESCRIPTION
as an LLVM_EXTERNAL_PROJECT.
pass pipeline files do not need to be copied to binary directory.

Current llvm external project build for imex has an issue with copying some files.
This PR fixes the root cause of that issue.

LLVM external project build places libraries and executables under CMAKE_BINARY_DIR and not is CMAKE_CURRENT_BINARY_DIR.
Note that MLIR tablegen generated headers are always put relative to CMAKE_CURRENT_BINARY_DIR
This PR addresses issue coming from that difference.

Supplementary files in test directory can be accessed in lit run script by using "%p" substitution variable. The variable gives path to current test directory. And can be used like the following.
// RUN: ... %p/<somefilename> ...

Please review these guidelines to help with the review process:
- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [x] Have you organized your commits logically and ensured each can be built by itself?
