### PR TITLE
Add ResolveIndexOp

### DIFF
--- a/mlir/include/imex/Dialect/ntensor/IR/NTensorOps.td
+++ b/mlir/include/imex/Dialect/ntensor/IR/NTensorOps.td
@@ -193,6 +193,22 @@ def ResolveSliceOp : NTensor_OpBase<"resolve_slice", [NoSideEffect]> {
   let assemblyFormat = "attr-dict $slice `,` $size";
 }
 
+def ResolveIndexOp : NTensor_OpBase<"resolve_index", [NoSideEffect]> {
+  let summary = "Index resolving operation.";
+  let description = [{
+    Resolves index into array using specified size.
+
+    Properly negative arguments and translates them into offset within array
+    bounds.
+  }];
+
+  let arguments = (ins Index:$index, Index:$size);
+
+  let results = (outs Index:$result);
+
+  let assemblyFormat = "attr-dict $index `,` $size";
+}
+
 def DimOp : NTensor_OpBase<"dim", [NoSideEffect]> {
   let summary = "dimension index operation";
   let description = [{

--- a/mlir/include/imex/Dialect/ntensor/IR/NTensorOps.td
+++ b/mlir/include/imex/Dialect/ntensor/IR/NTensorOps.td
@@ -196,10 +196,10 @@ def ResolveSliceOp : NTensor_OpBase<"resolve_slice", [NoSideEffect]> {
 def ResolveIndexOp : NTensor_OpBase<"resolve_index", [NoSideEffect]> {
   let summary = "Index resolving operation.";
   let description = [{
-    Resolves index into array using specified size.
+    Resolves index into array using specified array size.
 
-    Properly negative arguments and translates them into offset within array
-    bounds.
+    Properly handles negative arguments and translates them into offset within
+    array bounds.
   }];
 
   let arguments = (ins Index:$index, Index:$size);

--- a/mlir/test/Dialect/ntensor/ops.mlir
+++ b/mlir/test/Dialect/ntensor/ops.mlir
@@ -243,3 +243,14 @@ func.func @test(%arg1: index, %arg2: !ntensor.slice) -> (index, index, index) {
 //  CHECK-SAME:   (%[[ARG1:.*]]: index, %[[ARG2:.*]]: !ntensor.slice)
 //  CHECK-NEXT:   %[[BEGIN:.*]], %[[END:.*]], %[[STEP:.*]] = ntensor.resolve_slice %[[ARG2]], %[[ARG1]]
 //  CHECK-NEXT:   return %[[BEGIN]], %[[END]], %[[STEP]] : index, index, index
+
+// -----
+
+func.func @test(%arg1: index, %arg2: index) -> index {
+  %0 = ntensor.resolve_index %arg1, %arg2
+  return %0 : index
+}
+// CHECK-LABEL: func @test
+//  CHECK-SAME:   (%[[ARG1:.*]]: index, %[[ARG2:.*]]: index)
+//  CHECK-NEXT:   %[[RES:.*]] = ntensor.resolve_index %[[ARG1]], %[[ARG2]]
+//  CHECK-NEXT:   return %[[RES]] : index


### PR DESCRIPTION
Similar to `ResolveSliceOp` but operates on single index. Needed in case of single array element access.
