### PR TITLE
Add `copy`, `subview`, `load`, `store` and `create` ops to `ntensor` dialect

### DIFF
--- a/mlir/include/imex/Dialect/ntensor/IR/NTensorOps.hpp
+++ b/mlir/include/imex/Dialect/ntensor/IR/NTensorOps.hpp
@@ -20,7 +20,19 @@
 #include <mlir/IR/OpImplementation.h>
 #include <mlir/IR/Region.h>
 #include <mlir/Interfaces/CopyOpInterface.h>
+#include <mlir/Interfaces/InferTypeOpInterface.h>
 #include <mlir/Interfaces/SideEffectInterfaces.h>
+#include <mlir/Interfaces/ViewLikeInterface.h>
+
+namespace mlir {
+
+/// Return the list of Range (i.e. offset, size, stride). Each Range
+/// entry contains either the dynamic value or a ConstantIndexOp constructed
+/// with `b` at location `loc`.
+SmallVector<Range, 8> getOrCreateRanges(OffsetSizeAndStrideOpInterface op,
+                                        OpBuilder &b, Location loc);
+
+} // namespace mlir
 
 namespace imex {
 namespace ntensor {
@@ -31,12 +43,6 @@ class SliceType;
 
 #include "imex/Dialect/ntensor/IR/NTensorOpsDialect.h.inc"
 #include "imex/Dialect/ntensor/IR/NTensorOpsEnums.h.inc"
-
-#define GET_ATTRDEF_CLASSES
-#include "imex/Dialect/ntensor/IR/NTensorOpsAttributes.h.inc"
-
-#define GET_OP_CLASSES
-#include "imex/Dialect/ntensor/IR/NTensorOps.h.inc"
 
 namespace imex {
 namespace ntensor {
@@ -74,3 +80,9 @@ public:
 
 #define GET_TYPEDEF_CLASSES
 #include "imex/Dialect/ntensor/IR/NTensorOpsTypes.h.inc"
+
+#define GET_ATTRDEF_CLASSES
+#include "imex/Dialect/ntensor/IR/NTensorOpsAttributes.h.inc"
+
+#define GET_OP_CLASSES
+#include "imex/Dialect/ntensor/IR/NTensorOps.h.inc"

--- a/mlir/include/imex/Dialect/ntensor/IR/NTensorOps.hpp
+++ b/mlir/include/imex/Dialect/ntensor/IR/NTensorOps.hpp
@@ -19,6 +19,7 @@
 #include <mlir/IR/OpDefinition.h>
 #include <mlir/IR/OpImplementation.h>
 #include <mlir/IR/Region.h>
+#include <mlir/Interfaces/CopyOpInterface.h>
 #include <mlir/Interfaces/SideEffectInterfaces.h>
 
 namespace imex {

--- a/mlir/include/imex/Dialect/ntensor/IR/NTensorOps.td
+++ b/mlir/include/imex/Dialect/ntensor/IR/NTensorOps.td
@@ -286,4 +286,22 @@ def PrimitiveOp : NTensor_OpBase<"primitive", [NoSideEffect]> {
   let assemblyFormat = "$op ` ` attr-dict `(` $args `)` (`:` type($args)^)? (`->` type($results)^)?";
 }
 
+def CreateArrayOp : NTensor_OpBase<"create", [AttrSizedOperandSegments, NoSideEffect]> {
+  let summary = "Array creation operation.";
+  let description = [{
+    Creates new array from provided shape;
+
+    Follows memref.alloc conventions.
+
+    If `initValue` is provided resulting array wull be initialized with it,
+    otherwise it contents is undefined.
+  }];
+
+  let arguments = (ins Variadic<Index>:$dynamicSizes, Optional<AnyType>:$initValue);
+
+  let results = (outs NTensor_Tensor:$result);
+
+  let assemblyFormat = "`(`$dynamicSizes`)` (`=` `(` $initValue^ `:` type($initValue) `)`)? attr-dict `:` qualified(type($result))";
+}
+
 #endif // NTENSOR_OPS

--- a/mlir/include/imex/Dialect/ntensor/IR/NTensorOps.td
+++ b/mlir/include/imex/Dialect/ntensor/IR/NTensorOps.td
@@ -15,6 +15,7 @@
 #ifndef NTENSOR_OPS
 #define NTENSOR_OPS
 
+include "mlir/Interfaces/CopyOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/BuiltinTypeInterfaces.td"
@@ -161,6 +162,26 @@ def GetitemOp : NTensor_OpBase<"getitem", [NoSideEffect]> {
   let results = (outs AnyType:$result);
 
   let assemblyFormat = "attr-dict `(` $source `:` type($source) `)` `[` $index `:` type($index) `]` `->` type($result)";
+}
+
+def CopyOp : NTensor_OpBase<"copy",
+    [CopyOpInterface, SameOperandsElementType, SameOperandsShape]> {
+
+  let description = [{
+    Copies the data from the source to the destination arrau.
+
+    Source and destination are expected to have the same element type and shape.
+    Otherwise, the result is undefined.
+  }];
+
+  let arguments = (ins Arg<NTensor_Tensor, "the array to copy from",
+                           [MemRead]>:$source,
+                       Arg<NTensor_Tensor, "the array to copy to",
+                           [MemWrite]>:$target);
+
+  let assemblyFormat = [{
+    $source `,` $target attr-dict `:` qualified(type($source)) `to` qualified(type($target))
+  }];
 }
 
 def BuildSliceOp : NTensor_OpBase<"build_slice", [

--- a/mlir/include/imex/Dialect/ntensor/IR/NTensorOps.td
+++ b/mlir/include/imex/Dialect/ntensor/IR/NTensorOps.td
@@ -366,6 +366,31 @@ def LoadOp : NTensor_OpBase<"load",
   let assemblyFormat = "$array `[` $indices `]` attr-dict `:` qualified(type($array))";
 }
 
+def StoreOp : NTensor_OpBase<"store",
+     [TypesMatchWith<"type of 'value' matches element type of 'array'",
+                     "array", "value",
+                     "$_self.cast<NTensorType>().getElementType()">]> {
+  let summary = "array element store operation";
+  let description = [{
+    Store a value to a array location given by indices. The value stored should
+    have the same type as the elemental type of the array. The number of
+    arguments provided within brackets need to match the rank of the array.
+  }];
+
+  let arguments = (ins AnyType:$value,
+                       Arg<NTensor_Tensor, "the reference to store to",
+                           [MemWrite]>:$array,
+                       Variadic<Index>:$indices);
+
+  let builders = [
+    OpBuilder<(ins "::mlir::Value":$valueToStore, "::mlir::Value":$array), [{
+      $_state.addOperands(valueToStore);
+      $_state.addOperands(array);
+    }]>];
+
+  let assemblyFormat = "$value `,` $array `[` $indices `]` attr-dict `:` qualified(type($array))";
+}
+
 def BuildSliceOp : NTensor_OpBase<"build_slice", [
     AttrSizedOperandSegments, NoSideEffect]> {
   let summary = "Slice creation operation.";

--- a/mlir/include/imex/Dialect/ntensor/IR/NTensorOps.td
+++ b/mlir/include/imex/Dialect/ntensor/IR/NTensorOps.td
@@ -337,6 +337,35 @@ def SubviewOp : NTensor_OpWithOffsetSizesAndStrides<"subview", [
   }];
 }
 
+def LoadOp : NTensor_OpBase<"load",
+     [TypesMatchWith<"result type matches element type of 'array'",
+                     "array", "result",
+                     "$_self.cast<NTensorType>().getElementType()">]> {
+  let summary = "array element load operation";
+  let description = [{
+    The `load` op reads an element from a array specified by an index list. The
+    output of load is a new value with the same type as the elements of the
+    array. The arity of indices is the rank of the array (i.e., if the array
+    loaded from is of rank 3, then 3 indices are required for the load following
+    the array identifier).
+  }];
+
+  let arguments = (ins Arg<NTensor_Tensor, "the reference to load from",
+                           [MemRead]>:$array,
+                       Variadic<Index>:$indices);
+  let results = (outs AnyType:$result);
+
+  let builders = [
+    OpBuilder<(ins "::mlir::Value":$array, CArg<"::mlir::ValueRange", "{}">:$indices), [{
+      auto arrayType = array.getType().cast<NTensorType>();
+      $_state.addOperands(array);
+      $_state.addOperands(indices);
+      $_state.types.push_back(arrayType.getElementType());
+    }]>];
+
+  let assemblyFormat = "$array `[` $indices `]` attr-dict `:` qualified(type($array))";
+}
+
 def BuildSliceOp : NTensor_OpBase<"build_slice", [
     AttrSizedOperandSegments, NoSideEffect]> {
   let summary = "Slice creation operation.";

--- a/mlir/include/imex/Dialect/ntensor/IR/NTensorOps.td
+++ b/mlir/include/imex/Dialect/ntensor/IR/NTensorOps.td
@@ -16,7 +16,9 @@
 #define NTENSOR_OPS
 
 include "mlir/Interfaces/CopyOpInterface.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Interfaces/ViewLikeInterface.td"
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/BuiltinTypeInterfaces.td"
 include "mlir/IR/EnumAttr.td"
@@ -181,6 +183,157 @@ def CopyOp : NTensor_OpBase<"copy",
 
   let assemblyFormat = [{
     $source `,` $target attr-dict `:` qualified(type($source)) `to` qualified(type($target))
+  }];
+}
+
+// Base class for ops with static/dynamic offset, sizes and strides
+// attributes/arguments.
+class NTensor_OpWithOffsetSizesAndStrides<string mnemonic,
+                                          list<Trait> traits = []>
+    : NTensor_OpBase<mnemonic, traits> {
+  code extraBaseClassDeclaration = [{
+    /// Returns the dynamic sizes for this subview operation if specified.
+    ::mlir::Operation::operand_range getDynamicSizes() { return getSizes(); }
+
+    /// Return the list of Range (i.e. offset, size, stride). Each
+    /// Range entry contains either the dynamic value or a ConstantIndexOp
+    /// constructed with `b` at location `loc`.
+    ::mlir::SmallVector<::mlir::Range, 8> getOrCreateRanges(
+        ::mlir::OpBuilder &b, ::mlir::Location loc) {
+      return ::mlir::getOrCreateRanges(*this, b, loc);
+    }
+  }];
+}
+
+def SubviewOp : NTensor_OpWithOffsetSizesAndStrides<"subview", [
+    NoSideEffect, AttrSizedOperandSegments,
+    DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
+    OffsetSizeAndStrideOpInterface
+  ]> {
+  let summary = "array subview operation";
+  let description = [{
+    The "subview" operation converts a array type to another array type
+    which represents a reduced-size view of the original array as specified by
+    the operation's offsets, sizes and strides arguments.
+  }];
+
+  let arguments = (ins
+    NTensor_Tensor:$source,
+    Variadic<Index>:$offsets,
+    Variadic<Index>:$sizes,
+    Variadic<Index>:$strides,
+    I64ArrayAttr:$static_offsets,
+    I64ArrayAttr:$static_sizes,
+    I64ArrayAttr:$static_strides
+  );
+  let results = (outs NTensor_Tensor:$result);
+
+  let assemblyFormat = [{
+    $source ``
+    custom<DynamicIndexList>($offsets, $static_offsets,
+                             "::mlir::ShapedType::kDynamicStrideOrOffset")
+    custom<DynamicIndexList>($sizes, $static_sizes,
+                             "::mlir::ShapedType::kDynamicSize")
+    custom<DynamicIndexList>($strides, $static_strides,
+                             "::mlir::ShapedType::kDynamicStrideOrOffset")
+    attr-dict `:` qualified(type($source)) `to` qualified(type($result))
+  }];
+
+  let builders = [
+    // Build an ExtractSliceOp with mixed static and dynamic entries and
+    // inferred result type.
+    OpBuilder<(ins "::mlir::Value":$source, "::mlir::ArrayRef<::mlir::OpFoldResult>":$offsets,
+      "::mlir::ArrayRef<::mlir::OpFoldResult>":$sizes, "::mlir::ArrayRef<::mlir::OpFoldResult>":$strides,
+      CArg<"::mlir::ArrayRef<::mlir::NamedAttribute>", "{}">:$attrs)>,
+    // Build an ExtractSliceOp with mixed static and dynamic entries and custom
+    // result type. If the type passed is nullptr, it is inferred.
+    OpBuilder<(ins "NTensorType":$resultType, "::mlir::Value":$source,
+      "::mlir::ArrayRef<::mlir::OpFoldResult>":$offsets, "::mlir::ArrayRef<::mlir::OpFoldResult>":$sizes,
+      "::mlir::ArrayRef<::mlir::OpFoldResult>":$strides,
+      CArg<"::mlir::ArrayRef<::mlir::NamedAttribute>", "{}">:$attrs)>,
+    // Build an ExtractSliceOp with dynamic entries and custom result type. If
+    // the type passed is nullptr, it is inferred.
+    OpBuilder<(ins "::mlir::Value":$source, "::mlir::ValueRange":$offsets,
+      "::mlir::ValueRange":$sizes, "::mlir::ValueRange":$strides,
+      CArg<"::mlir::ArrayRef<::mlir::NamedAttribute>", "{}">:$attrs)>,
+    // Build an ExtractSliceOp with dynamic entries and inferred result type.
+    OpBuilder<(ins "NTensorType":$resultType, "::mlir::Value":$source,
+      "::mlir::ValueRange":$offsets, "::mlir::ValueRange":$sizes, "::mlir::ValueRange":$strides,
+      CArg<"::mlir::ArrayRef<::mlir::NamedAttribute>", "{}">:$attrs)>,
+    // Build an ExtractSliceOp with mixed static and dynamic entries packed in
+    // a Range vector.
+    OpBuilder<(ins "::mlir::Value":$source, "::mlir::ArrayRef<::mlir::Range>":$ranges,
+      CArg<"::mlir::ArrayRef<::mlir::NamedAttribute>", "{}">:$attrs)>,
+  ];
+
+  let extraClassDeclaration = extraBaseClassDeclaration # [{
+    /// Returns the type of the base tensor operand.
+    NTensorType getSourceType() {
+      return getSource().getType().cast<NTensorType>();
+    }
+
+    /// The result of an extract_slice is always a tensor.
+    NTensorType getType() {
+      return getResult().getType().cast<NTensorType>();
+    }
+
+    /// Compute the rank-reduction mask that can be applied to map the source
+    /// tensor type to the result tensor type by dropping unit dims.
+    llvm::Optional<llvm::SmallDenseSet<unsigned>>
+    computeRankReductionMask() {
+      return ::mlir::computeRankReductionMask(getSourceType().getShape(),
+                                              getType().getShape());
+    };
+
+    /// An extract_slice result type can be inferred, when it is not
+    /// rank-reduced, from the source type and the static representation of
+    /// offsets, sizes and strides. Special sentinels encode the dynamic case.
+    static NTensorType inferResultType(
+      ::mlir::ShapedType sourceShapedTensorType,
+      ::mlir::ArrayRef<int64_t> staticOffsets,
+      ::mlir::ArrayRef<int64_t> staticSizes,
+      ::mlir::ArrayRef<int64_t> staticStrides);
+    static NTensorType inferResultType(
+      ::mlir::ShapedType sourceShapedTensorType,
+      ::mlir::ArrayRef<::mlir::OpFoldResult> staticOffsets,
+      ::mlir::ArrayRef<::mlir::OpFoldResult> staticSizes,
+      ::mlir::ArrayRef<::mlir::OpFoldResult> staticStrides);
+
+    /// If the rank is reduced (i.e. the desiredResultRank is smaller than the
+    /// number of sizes), drop as many size 1 as needed to produce an inferred type
+    /// with the desired rank.
+    ///
+    /// Note that there may be multiple ways to compute this rank-reduced type:
+    ///   e.g. 1x6x1 can rank-reduce to either 1x6 or 6x1 2-D tensors.
+    ///
+    /// To disambiguate, this function always drops the first 1 sizes occurrences.
+    static NTensorType inferCanonicalRankReducedResultType(
+      unsigned resultRank,
+      NTensorType sourceRankedTensorType,
+      ::mlir::ArrayRef<int64_t> staticOffsets,
+      ::mlir::ArrayRef<int64_t> staticSizes,
+      ::mlir::ArrayRef<int64_t> staticStrides);
+    static NTensorType inferCanonicalRankReducedResultType(
+      unsigned resultRank,
+      NTensorType sourceRankedTensorType,
+      ::mlir::ArrayRef<::mlir::OpFoldResult> staticOffsets,
+      ::mlir::ArrayRef<::mlir::OpFoldResult> staticSizes,
+      ::mlir::ArrayRef<::mlir::OpFoldResult> staticStrides);
+
+    /// Return the expected rank of each of the`static_offsets`, `static_sizes`
+    /// and `static_strides` attributes.
+    std::array<unsigned, 3> getArrayAttrMaxRanks() {
+      unsigned rank = getSourceType().getRank();
+      return {rank, rank, rank};
+    }
+
+    /// Return the number of leading operands before the `offsets`, `sizes` and
+    /// and `strides` operands.
+    static unsigned getOffsetSizeAndStrideStartOperandIndex() { return 1; }
+
+    /// Return the dimensions of the source that are dropped in the
+    /// result when the result is rank-reduced.
+    llvm::SmallBitVector getDroppedDims();
   }];
 }
 

--- a/mlir/test/Dialect/ntensor/ops.mlir
+++ b/mlir/test/Dialect/ntensor/ops.mlir
@@ -254,3 +254,14 @@ func.func @test(%arg1: index, %arg2: index) -> index {
 //  CHECK-SAME:   (%[[ARG1:.*]]: index, %[[ARG2:.*]]: index)
 //  CHECK-NEXT:   %[[RES:.*]] = ntensor.resolve_index %[[ARG1]], %[[ARG2]]
 //  CHECK-NEXT:   return %[[RES]] : index
+
+// -----
+
+func.func @test(%arg1: !ntensor.ntensor<?xf32, "test1">, %arg2: !ntensor.ntensor<?xf32, "test2">) {
+  ntensor.copy %arg1, %arg2 : !ntensor.ntensor<?xf32, "test1"> to !ntensor.ntensor<?xf32, "test2">
+  return
+}
+// CHECK-LABEL: func @test
+//  CHECK-SAME:   (%[[ARG1:.*]]: !ntensor.ntensor<?xf32, "test1">, %[[ARG2:.*]]: !ntensor.ntensor<?xf32, "test2">)
+//  CHECK-NEXT:   ntensor.copy %[[ARG1]], %[[ARG2]] : !ntensor.ntensor<?xf32, "test1"> to !ntensor.ntensor<?xf32, "test2">
+//  CHECK-NEXT:   return

--- a/mlir/test/Dialect/ntensor/ops.mlir
+++ b/mlir/test/Dialect/ntensor/ops.mlir
@@ -333,3 +333,16 @@ func.func @test(%arg1: !ntensor.ntensor<?xf32>) -> f32 {
 //  CHECK-NEXT:   %[[IND:.*]] = arith.constant 0 : index
 //  CHECK-NEXT:   %[[RES:.*]] = ntensor.load %[[ARG]][%[[IND]]] : !ntensor.ntensor<?xf32>
 //  CHECK-NEXT:   return %[[RES]] : f32
+
+// -----
+
+func.func @test(%arg1: !ntensor.ntensor<?xf32>, %arg2: f32) {
+  %0 = arith.constant 0 : index
+  ntensor.store %arg2, %arg1[%0] : !ntensor.ntensor<?xf32>
+  return
+}
+// CHECK-LABEL: func @test
+//  CHECK-SAME:   (%[[ARG1:.*]]: !ntensor.ntensor<?xf32>, %[[ARG2:.*]]: f32)
+//  CHECK-NEXT:   %[[IND:.*]] = arith.constant 0 : index
+//  CHECK-NEXT:   ntensor.store %[[ARG2]], %[[ARG1]][%[[IND]]] : !ntensor.ntensor<?xf32>
+//  CHECK-NEXT:   return

--- a/mlir/test/Dialect/ntensor/ops.mlir
+++ b/mlir/test/Dialect/ntensor/ops.mlir
@@ -320,3 +320,16 @@ func.func @test(%t: !ntensor.ntensor<8x16x4xf32>, %idx : index) {
 
   return
 }
+
+// -----
+
+func.func @test(%arg1: !ntensor.ntensor<?xf32>) -> f32 {
+  %0 = arith.constant 0 : index
+  %1 = ntensor.load %arg1[%0] : !ntensor.ntensor<?xf32>
+  return %1 : f32
+}
+// CHECK-LABEL: func @test
+//  CHECK-SAME:   (%[[ARG:.*]]: !ntensor.ntensor<?xf32>)
+//  CHECK-NEXT:   %[[IND:.*]] = arith.constant 0 : index
+//  CHECK-NEXT:   %[[RES:.*]] = ntensor.load %[[ARG]][%[[IND]]] : !ntensor.ntensor<?xf32>
+//  CHECK-NEXT:   return %[[RES]] : f32

--- a/mlir/test/Dialect/ntensor/ops.mlir
+++ b/mlir/test/Dialect/ntensor/ops.mlir
@@ -295,3 +295,28 @@ func.func @test() -> !ntensor.ntensor<?x?xi32> {
 //  CHECK-NEXT:   %[[VAL:.*]] = arith.constant 5 : i32
 //  CHECK-NEXT:   %[[RES:.*]] = ntensor.create(%[[D1]], %[[D2]]) = (%[[VAL]] : i32) : !ntensor.ntensor<?x?xi32>
 //  CHECK-NEXT:   return %[[RES]]
+
+// -----
+
+// CHECK-LABEL: func @test({{.*}}) {
+func.func @test(%t: !ntensor.ntensor<8x16x4xf32>, %idx : index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+
+  // CHECK: ntensor.subview
+  // CHECK-SAME: !ntensor.ntensor<8x16x4xf32> to !ntensor.ntensor<?x?x?xf32>
+  %1 = ntensor.subview %t[%c0, %c0, %c0][%idx, %idx, %idx][%c1, %c1, %c1]
+    : !ntensor.ntensor<8x16x4xf32> to !ntensor.ntensor<?x?x?xf32>
+
+  // CHECK: ntensor.subview
+  // CHECK-SAME: !ntensor.ntensor<8x16x4xf32> to !ntensor.ntensor<4x4x4xf32>
+  %2 = ntensor.subview %t[0, 2, 0][4, 4, 4][1, 1, 1]
+    : !ntensor.ntensor<8x16x4xf32> to !ntensor.ntensor<4x4x4xf32>
+
+  // CHECK: ntensor.subview
+  // CHECK-SAME: !ntensor.ntensor<8x16x4xf32> to !ntensor.ntensor<4x4xf32>
+  %3 = ntensor.subview %t[0, 2, 0][4, 1, 4][1, 1, 1]
+    : !ntensor.ntensor<8x16x4xf32> to !ntensor.ntensor<4x4xf32>
+
+  return
+}

--- a/mlir/test/Dialect/ntensor/ops.mlir
+++ b/mlir/test/Dialect/ntensor/ops.mlir
@@ -265,3 +265,33 @@ func.func @test(%arg1: !ntensor.ntensor<?xf32, "test1">, %arg2: !ntensor.ntensor
 //  CHECK-SAME:   (%[[ARG1:.*]]: !ntensor.ntensor<?xf32, "test1">, %[[ARG2:.*]]: !ntensor.ntensor<?xf32, "test2">)
 //  CHECK-NEXT:   ntensor.copy %[[ARG1]], %[[ARG2]] : !ntensor.ntensor<?xf32, "test1"> to !ntensor.ntensor<?xf32, "test2">
 //  CHECK-NEXT:   return
+
+// -----
+
+func.func @test() -> !ntensor.ntensor<?x?xf32> {
+  %0 = arith.constant 2 : index
+  %1 = arith.constant 3 : index
+  %3 = ntensor.create(%0, %1) : !ntensor.ntensor<?x?xf32>
+  return %3 : !ntensor.ntensor<?x?xf32>
+}
+// CHECK-LABEL: func @test
+//  CHECK-NEXT:   %[[D1:.*]] = arith.constant 2 : index
+//  CHECK-NEXT:   %[[D2:.*]] = arith.constant 3 : index
+//  CHECK-NEXT:   %[[RES:.*]] = ntensor.create(%[[D1]], %[[D2]]) : !ntensor.ntensor<?x?xf32>
+//  CHECK-NEXT:   return %[[RES]]
+
+// -----
+
+func.func @test() -> !ntensor.ntensor<?x?xi32> {
+  %0 = arith.constant 2 : index
+  %1 = arith.constant 3 : index
+  %2 = arith.constant 5 : i32
+  %3 = ntensor.create(%0, %1) = (%2 : i32) : !ntensor.ntensor<?x?xi32>
+  return %3 : !ntensor.ntensor<?x?xi32>
+}
+// CHECK-LABEL: func @test
+//  CHECK-NEXT:   %[[D1:.*]] = arith.constant 2 : index
+//  CHECK-NEXT:   %[[D2:.*]] = arith.constant 3 : index
+//  CHECK-NEXT:   %[[VAL:.*]] = arith.constant 5 : i32
+//  CHECK-NEXT:   %[[RES:.*]] = ntensor.create(%[[D1]], %[[D2]]) = (%[[VAL]] : i32) : !ntensor.ntensor<?x?xi32>
+//  CHECK-NEXT:   return %[[RES]]


### PR DESCRIPTION
They are more low level than `getitem`/`setitem` and supposed to be generated from them.
