### PR TITLE
GPU group reductions support

### DIFF
--- a/mlir/include/imex/Dialect/gpu_runtime/IR/GpuRuntimeOps.td
+++ b/mlir/include/imex/Dialect/gpu_runtime/IR/GpuRuntimeOps.td
@@ -197,36 +197,4 @@ def GPUMemFenceOp : GpuRuntime_Op<"mem_fence"> {
   let assemblyFormat = "$flags attr-dict";
 }
 
-def GPU_AllReduceOpAdd : I32EnumAttrCase<"ADD", 0, "add">;
-def GPU_AllReduceOpAnd : I32EnumAttrCase<"AND", 1, "and">;
-def GPU_AllReduceOpMax : I32EnumAttrCase<"MAX", 2, "max">;
-def GPU_AllReduceOpMin : I32EnumAttrCase<"MIN", 3, "min">;
-def GPU_AllReduceOpMul : I32EnumAttrCase<"MUL", 4, "mul">;
-def GPU_AllReduceOpOr  : I32EnumAttrCase<"OR",  5, "or">;
-def GPU_AllReduceOpXor : I32EnumAttrCase<"XOR", 6, "xor">;
-
-def GPU_AllReduceOperation : I32EnumAttr<"AllReduceOperation",
-    "built-in reduction operations supported by gpu.allreduce.",
-    [
-      GPU_AllReduceOpAdd,
-      GPU_AllReduceOpAnd,
-      GPU_AllReduceOpMax,
-      GPU_AllReduceOpMin,
-      GPU_AllReduceOpMul,
-      GPU_AllReduceOpOr,
-      GPU_AllReduceOpXor
-    ]>{
-  let genSpecializedAttr = 0;
-  let cppNamespace = "::gpu_runtime";
-}
-def GPU_AllReduceOperationAttr : EnumAttr<GpuRuntime_Dialect, GPU_AllReduceOperation,
-                                          "all_reduce_op">;
-
-def GPUSubGroupReduceOp : GpuRuntime_Op<"subgroup_reduce",
-    [SameOperandsAndResultType]>,
-    Arguments<(ins AnyType:$value,
-               GPU_AllReduceOperationAttr:$op)>,
-    Results<(outs AnyType)> {
-}
-
 #endif // GPURUNTIME_OPS

--- a/mlir/include/imex/Dialect/gpu_runtime/IR/GpuRuntimeOps.td
+++ b/mlir/include/imex/Dialect/gpu_runtime/IR/GpuRuntimeOps.td
@@ -197,4 +197,36 @@ def GPUMemFenceOp : GpuRuntime_Op<"mem_fence"> {
   let assemblyFormat = "$flags attr-dict";
 }
 
+def GPU_AllReduceOpAdd : I32EnumAttrCase<"ADD", 0, "add">;
+def GPU_AllReduceOpAnd : I32EnumAttrCase<"AND", 1, "and">;
+def GPU_AllReduceOpMax : I32EnumAttrCase<"MAX", 2, "max">;
+def GPU_AllReduceOpMin : I32EnumAttrCase<"MIN", 3, "min">;
+def GPU_AllReduceOpMul : I32EnumAttrCase<"MUL", 4, "mul">;
+def GPU_AllReduceOpOr  : I32EnumAttrCase<"OR",  5, "or">;
+def GPU_AllReduceOpXor : I32EnumAttrCase<"XOR", 6, "xor">;
+
+def GPU_AllReduceOperation : I32EnumAttr<"AllReduceOperation",
+    "built-in reduction operations supported by gpu.allreduce.",
+    [
+      GPU_AllReduceOpAdd,
+      GPU_AllReduceOpAnd,
+      GPU_AllReduceOpMax,
+      GPU_AllReduceOpMin,
+      GPU_AllReduceOpMul,
+      GPU_AllReduceOpOr,
+      GPU_AllReduceOpXor
+    ]>{
+  let genSpecializedAttr = 0;
+  let cppNamespace = "::gpu_runtime";
+}
+def GPU_AllReduceOperationAttr : EnumAttr<GpuRuntime_Dialect, GPU_AllReduceOperation,
+                                          "all_reduce_op">;
+
+def GPUSubGroupReduceOp : GpuRuntime_Op<"subgroup_reduce",
+    [SameOperandsAndResultType]>,
+    Arguments<(ins AnyType:$value,
+               GPU_AllReduceOperationAttr:$op)>,
+    Results<(outs AnyType)> {
+}
+
 #endif // GPURUNTIME_OPS

--- a/mlir/lib/Conversion/gpu_runtime_to_llvm.cpp
+++ b/mlir/lib/Conversion/gpu_runtime_to_llvm.cpp
@@ -455,8 +455,13 @@ private:
 
     mlir::Value one = rewriter.create<mlir::LLVM::ConstantOp>(
         loc, llvmInt32Type, rewriter.getI32IntegerAttr(1));
-    auto localMemStorageClass = gpu_runtime::StorageClassAttr::get(
-        getContext(), gpu_runtime::StorageClass::local);
+
+    // TODO: Fix storage class handling upstream
+    //    auto localMemStorageClass = gpu_runtime::StorageClassAttr::get(
+    //        getContext(), gpu_runtime::StorageClass::local);
+    auto localMemStorageClass = rewriter.getI64IntegerAttr(
+        mlir::gpu::GPUDialect::getPrivateAddressSpace());
+
     auto computeTypeSize = [&](mlir::Type type) -> mlir::Value {
       // %Size = getelementptr %T* null, int 1
       // %SizeI = ptrtoint %T* %Size to i32
@@ -584,9 +589,12 @@ private:
 
     bool isShared = op.getHostShared();
 
-    auto localstorageClass = gpu_runtime::StorageClassAttr::get(
-        getContext(), gpu_runtime::StorageClass::local);
-    bool isLocal = memrefType.getMemorySpace() == localstorageClass;
+    // TODO: Fix storage class handling upstream
+    //    auto localstorageClass = gpu_runtime::StorageClassAttr::get(
+    //        getContext(), gpu_runtime::StorageClass::local);
+    auto localMemStorageClass = rewriter.getI64IntegerAttr(
+        mlir::gpu::GPUDialect::getPrivateAddressSpace());
+    bool isLocal = memrefType.getMemorySpace() == localMemStorageClass;
 
     if (isShared && isLocal)
       return mlir::failure();

--- a/mlir/lib/Conversion/gpu_to_gpu_runtime.cpp
+++ b/mlir/lib/Conversion/gpu_to_gpu_runtime.cpp
@@ -1075,7 +1075,8 @@ static void genReduceOp(mlir::Operation *srcOp, mlir::PatternRewriter &rewriter,
   auto scope = mlir::spirv::ScopeAttr::get(ctx, mlir::spirv::Scope::Workgroup);
   auto groupOp = mlir::spirv::GroupOperationAttr::get(
       ctx, mlir::spirv::GroupOperation::Reduce);
-  rewriter.replaceOpWithNewOp<SpirvOp>(srcOp, type, scope, groupOp, arg);
+  rewriter.replaceOpWithNewOp<SpirvOp>(srcOp, type, scope, groupOp, arg,
+                                       mlir::Value{});
 }
 
 class ConvertAllReduceOp

--- a/mlir/lib/Conversion/gpu_to_gpu_runtime.cpp
+++ b/mlir/lib/Conversion/gpu_to_gpu_runtime.cpp
@@ -1128,13 +1128,13 @@ public:
 };
 
 class ConvertSubgroupReduceOp
-    : public mlir::OpConversionPattern<gpu_runtime::GPUSubGroupReduceOp> {
+    : public mlir::OpConversionPattern<mlir::gpu::SubgroupReduceOp> {
 public:
   using OpConversionPattern::OpConversionPattern;
 
   mlir::LogicalResult
-  matchAndRewrite(gpu_runtime::GPUSubGroupReduceOp op,
-                  gpu_runtime::GPUSubGroupReduceOp::Adaptor adaptor,
+  matchAndRewrite(mlir::gpu::SubgroupReduceOp op,
+                  mlir::gpu::SubgroupReduceOp::Adaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     auto reduceOp = adaptor.getOp();
     //    if (!reduceOp)
@@ -1148,7 +1148,7 @@ public:
     using funcptr_t =
         void (*)(mlir::Operation *, mlir::PatternRewriter &, mlir::Value);
 
-    using ReduceType = gpu_runtime::AllReduceOperation;
+    using ReduceType = mlir::gpu::AllReduceOperation;
     struct Handler {
       ReduceType op;
       funcptr_t floatFunc;

--- a/mlir/lib/Conversion/gpu_to_gpu_runtime.cpp
+++ b/mlir/lib/Conversion/gpu_to_gpu_runtime.cpp
@@ -1090,11 +1090,11 @@ public:
   matchAndRewrite(mlir::gpu::AllReduceOp op,
                   mlir::gpu::AllReduceOp::Adaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    auto reduceOp = adaptor.op();
+    auto reduceOp = adaptor.getOp();
     if (!reduceOp)
       return mlir::failure();
 
-    auto val = adaptor.value();
+    auto val = adaptor.getValue();
     auto valType = val.getType();
     if (!valType.isIntOrFloat())
       return mlir::failure();
@@ -1136,11 +1136,11 @@ public:
   matchAndRewrite(gpu_runtime::GPUSubGroupReduceOp op,
                   gpu_runtime::GPUSubGroupReduceOp::Adaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    auto reduceOp = adaptor.op();
+    auto reduceOp = adaptor.getOp();
     //    if (!reduceOp)
     //      return mlir::failure();
 
-    auto val = adaptor.value();
+    auto val = adaptor.getValue();
     auto valType = val.getType();
     if (!valType.isIntOrFloat())
       return mlir::failure();

--- a/mlir/test/Transforms/set-spirv-capability.mlir
+++ b/mlir/test/Transforms/set-spirv-capability.mlir
@@ -3,7 +3,7 @@
 module attributes {gpu.container_module} {
 
 // CHECK: module attributes {gpu.container_module} {
-// CHECK: gpu.module @main_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Linkage, Kernel, Vector16, Float16Buffer, Float16, Float64, Int64, Groups, Int16, GenericPointer, Int8, ExpectAssumeKHR, AtomicFloat32AddEXT], [SPV_KHR_expect_assume, SPV_EXT_shader_atomic_float_add]>, #spirv.resource_limits<>>} {
+// CHECK: gpu.module @main_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Linkage, Kernel, Vector16, Float16Buffer, Float16, Float64, Int64, Groups, Int16, GenericPointer, Int8, ExpectAssumeKHR, AtomicFloat32AddEXT], [SPV_KHR_expect_assume, SPV_EXT_shader_atomic_float_add, GroupNonUniformArithmetic]>, #spirv.resource_limits<>>} {
 
   gpu.module @main_kernel {
     gpu.func @main_kernel(%arg0: memref<8xf32>, %arg1: memref<8xf32>, %arg2: memref<8xf32>) kernel attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {

--- a/mlir/test/Transforms/set-spirv-capability.mlir
+++ b/mlir/test/Transforms/set-spirv-capability.mlir
@@ -3,7 +3,7 @@
 module attributes {gpu.container_module} {
 
 // CHECK: module attributes {gpu.container_module} {
-// CHECK: gpu.module @main_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Linkage, Kernel, Vector16, Float16Buffer, Float16, Float64, Int64, Groups, Int16, GenericPointer, Int8, ExpectAssumeKHR, AtomicFloat32AddEXT], [SPV_KHR_expect_assume, SPV_EXT_shader_atomic_float_add, GroupNonUniformArithmetic]>, #spirv.resource_limits<>>} {
+// CHECK: gpu.module @main_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Linkage, Kernel, Vector16, Float16Buffer, Float16, Float64, Int64, Groups, Int16, GenericPointer, Int8, GroupNonUniformArithmetic, ExpectAssumeKHR, AtomicFloat32AddEXT], [SPV_KHR_expect_assume, SPV_EXT_shader_atomic_float_add]>, #spirv.resource_limits<>>} {
 
   gpu.module @main_kernel {
     gpu.func @main_kernel(%arg0: memref<8xf32>, %arg1: memref<8xf32>, %arg2: memref<8xf32>) kernel attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {

--- a/numba_dpcomp/numba_dpcomp/mlir/gpu_runtime.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/gpu_runtime.py
@@ -51,12 +51,17 @@ if IS_GPU_RUNTIME_AVAILABLE:
         from itertools import product
 
         _types = ["int32", "int64", "float32", "float64"]
+
         _atomic_ops = ["add", "sub"]
         for o, t in product(_atomic_ops, _types):
             _funcs.append(mlir_func_name(f"atomic_{o}_{t}"))
 
         for n, t in product(range(8), _types):
             _funcs.append(mlir_func_name(f"local_array_{t}_{n}"))
+
+        _group_ops = ["reduce_add"]
+        for o, t in product(_group_ops, _types):
+            _funcs.append(mlir_func_name(f"group_{o}_{t}"))
 
         for name in _funcs:
             if hasattr(runtime_lib, name):

--- a/numba_dpcomp/numba_dpcomp/mlir/kernel_impl.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/kernel_impl.py
@@ -377,3 +377,32 @@ def _local_array_impl(builder, shape, dtype):
     return builder.external_call(
         func_name, inputs=shape, outputs=res, return_tensor=True
     )
+
+
+class group(Stub):
+    pass
+
+
+def group_reduce_add(shape, dtype):
+    _stub_error()
+
+
+setattr(group, "reduce_add", group_reduce_add)
+
+
+@infer_global(group_reduce_add)
+class _GroupId(AbstractTemplate):
+    def generic(self, args, kws):
+        assert not kws
+        assert len(args) == 1
+        elem_type = args[0]
+
+        return signature(elem_type, elem_type)
+
+
+@registry.register_func("group_reduce_add", group_reduce_add)
+def _group_add_impl(builder, value):
+    elem_type = value.type
+    func_name = f"group_reduce_add_{dtype_str(builder, elem_type)}"
+    res = builder.cast(0, elem_type)
+    return builder.external_call(func_name, inputs=value, outputs=res)

--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_gpu.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_gpu.py
@@ -723,8 +723,8 @@ def test_barrier_ops(op, flags, global_size, local_size):
 
 
 @require_gpu
-@pytest.mark.parametrize("global_size", [1, 2, 4, 27])
-@pytest.mark.parametrize("local_size", [1, 2, 7])
+@pytest.mark.parametrize("global_size", [1, 2, 4, 27, 67, 101])
+@pytest.mark.parametrize("local_size", [1, 2, 7, 17, 33])
 def test_barrier1(global_size, local_size):
     atomic_add = atomic.add
 

--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_gpu.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_gpu.py
@@ -33,6 +33,7 @@ from numba_dpcomp.mlir.kernel_impl import (
     CLK_LOCAL_MEM_FENCE,
     CLK_GLOBAL_MEM_FENCE,
     local,
+    group,
 )
 from numba_dpcomp.mlir.kernel_sim import kernel as kernel_sim
 from numba_dpcomp.mlir.passes import (
@@ -722,7 +723,7 @@ def test_barrier_ops(op, flags, global_size, local_size):
 
 
 @require_gpu
-@pytest.mark.parametrize("global_size", [1, 2, 27])
+@pytest.mark.parametrize("global_size", [1, 2, 4, 27])
 @pytest.mark.parametrize("local_size", [1, 2, 7])
 def test_barrier1(global_size, local_size):
     atomic_add = atomic.add
@@ -784,6 +785,35 @@ def test_local_memory(blocksize):
         assert ir.count("gpu.launch blocks") == 1, ir
 
     assert_allclose(sim_res, gpu_res)
+
+
+@require_gpu
+@pytest.mark.parametrize("group_op", [group.reduce_add])
+@pytest.mark.parametrize("global_size", [1, 2, 4, 27])
+@pytest.mark.parametrize("local_size", [1, 2, 7])
+@pytest.mark.parametrize("dtype", [np.int32, np.int64, np.float32])
+def test_group_func(group_op, global_size, local_size, dtype):
+    def func(a, b):
+        i = get_global_id(0)
+        v = group_op(a[i])
+        b[i] = v
+
+    sim_func = kernel_sim(func)
+    gpu_func = kernel_cached(func)
+
+    a = np.arange(global_size, dtype=dtype)
+
+    sim_res = np.zeros(global_size, a.dtype)
+    sim_func[global_size, local_size](a, sim_res)
+
+    gpu_res = np.zeros(global_size, a.dtype)
+
+    with print_pass_ir([], ["ConvertParallelLoopToGpu"]):
+        gpu_func[global_size, local_size](a, gpu_res)
+        ir = get_print_buffer()
+        assert ir.count("gpu.launch blocks") == 1, ir
+
+    assert_allclose(gpu_res, sim_res)
 
 
 @require_dpctl

--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_gpu.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_gpu.py
@@ -789,8 +789,8 @@ def test_local_memory(blocksize):
 
 @require_gpu
 @pytest.mark.parametrize("group_op", [group.reduce_add])
-@pytest.mark.parametrize("global_size", [1, 2, 4, 27])
-@pytest.mark.parametrize("local_size", [1, 2, 7])
+@pytest.mark.parametrize("global_size", [1, 2, 4, 27, 67, 101])
+@pytest.mark.parametrize("local_size", [1, 2, 7, 17, 33])
 @pytest.mark.parametrize("dtype", [np.int32, np.int64, np.float32])
 def test_group_func(group_op, global_size, local_size, dtype):
     def func(a, b):

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
@@ -1409,9 +1409,10 @@ public:
                                                gpu_runtime::FenceFlags::local);
 
     mlir::Value numSubgroups = [&]() {
-        mlir::OpBuilder::InsertionGuard g(rewriter);
+      mlir::OpBuilder::InsertionGuard g(rewriter);
       rewriter.setInsertionPointToStart(&launchOp.body().front());
-        return rewriter.create<mlir::gpu::NumSubgroupsOp>(rewriter.getUnknownLoc());
+      return rewriter.create<mlir::gpu::NumSubgroupsOp>(
+          rewriter.getUnknownLoc());
     }();
 
     mlir::Value zero = rewriter.create<mlir::arith::ConstantIndexOp>(loc, 0);

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
@@ -1378,8 +1378,12 @@ public:
           rewriter.create<mlir::arith::CeilDivSIOp>(loc, size, subgroupSize);
 
       auto elemType = op.getType();
-      auto storageClass = gpu_runtime::StorageClassAttr::get(
-          getContext(), gpu_runtime::StorageClass::local);
+
+      // TODO: Fix storage class handling upstream
+      //      auto storageClass = gpu_runtime::StorageClassAttr::get(
+      //          getContext(), gpu_runtime::StorageClass::local);
+      auto storageClass = rewriter.getI64IntegerAttr(
+          mlir::gpu::GPUDialect::getPrivateAddressSpace());
       auto memrefType = mlir::MemRefType::get(mlir::ShapedType::kDynamicSize,
                                               elemType, nullptr, storageClass);
       groupBuffer = rewriter
@@ -1493,6 +1497,7 @@ public:
     }
 
     auto type = mlir::MemRefType::get(shape, oldType.getElementType());
+
     // TODO: Fix storage class upstream
     //    auto storageClass = gpu_runtime::StorageClassAttr::get(
     //        getContext(), gpu_runtime::StorageClass::local);

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
@@ -1597,6 +1597,7 @@ static mlir::spirv::TargetEnvAttr deviceCapsMapper(mlir::gpu::GPUModuleOp op) {
       spirv::Capability::AtomicFloat32AddEXT,
       spirv::Capability::ExpectAssumeKHR,
       spirv::Capability::GenericPointer,
+      spirv::Capability::GroupNonUniformArithmetic,
       spirv::Capability::Groups,
       spirv::Capability::Int16,
       spirv::Capability::Int64,

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
@@ -1361,8 +1361,6 @@ public:
     auto gidY = rewriter.create<mlir::gpu::GlobalIdOp>(loc, Dim::y);
     auto gidZ = rewriter.create<mlir::gpu::GlobalIdOp>(loc, Dim::z);
 
-    auto gsX = launchOp.
-
     return mlir::failure();
   }
 };

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
@@ -1448,6 +1448,10 @@ public:
                             .create<mlir::scf::ForOp>(ifLoc, one, numSubgroups,
                                                       one, init, forBodyBuilder)
                             .getResult(0);
+      mlir::Value isSingleSg = ifBuilder.create<mlir::arith::CmpIOp>(
+          ifLoc, mlir::arith::CmpIPredicate::eq, numSubgroups, one);
+      res =
+          ifBuilder.create<mlir::arith::SelectOp>(ifLoc, isSingleSg, init, res);
       ifBuilder.create<mlir::memref::StoreOp>(ifLoc, res, groupBuffer, zero);
       ifBuilder.create<mlir::scf::YieldOp>(ifLoc);
     };

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
@@ -1435,8 +1435,8 @@ public:
     }();
 
     auto loc = op->getLoc();
-    auto reduceType = static_cast<gpu_runtime::AllReduceOperation>(*op.getOp());
-    mlir::Value sgResult = rewriter.create<gpu_runtime::GPUSubGroupReduceOp>(
+    auto reduceType = *op.getOp();
+    mlir::Value sgResult = rewriter.create<mlir::gpu::SubgroupReduceOp>(
         loc, op.getValue(), reduceType);
     rewriter.create<mlir::memref::StoreOp>(loc, sgResult, groupBuffer,
                                            subgroupId);

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
@@ -1408,6 +1408,12 @@ public:
     rewriter.create<gpu_runtime::GPUBarrierOp>(loc,
                                                gpu_runtime::FenceFlags::local);
 
+    mlir::Value numSubgroups = [&]() {
+        mlir::OpBuilder::InsertionGuard g(rewriter);
+      rewriter.setInsertionPointToStart(&launchOp.body().front());
+        return rewriter.create<mlir::gpu::NumSubgroupsOp>(rewriter.getUnknownLoc());
+    }();
+
     mlir::Value zero = rewriter.create<mlir::arith::ConstantIndexOp>(loc, 0);
     mlir::Value one = rewriter.create<mlir::arith::ConstantIndexOp>(loc, 1);
     mlir::Value isFirstSg = rewriter.create<mlir::arith::CmpIOp>(
@@ -1416,9 +1422,6 @@ public:
     auto ifBodyBuilder = [&](mlir::OpBuilder &ifBuilder, mlir::Location ifLoc) {
       mlir::Value init =
           ifBuilder.create<mlir::memref::LoadOp>(ifLoc, groupBuffer, zero);
-
-      mlir::Value numSubgroups =
-          ifBuilder.create<mlir::gpu::NumSubgroupsOp>(ifLoc);
 
       auto forBodyBuilder = [&](mlir::OpBuilder &forBuilder,
                                 mlir::Location forLoc, mlir::Value i,

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
@@ -1307,6 +1307,9 @@ public:
   mlir::LogicalResult
   matchAndRewrite(mlir::func::CallOp op,
                   mlir::PatternRewriter &rewriter) const override {
+    if (!op->getParentOfType<mlir::gpu::LaunchOp>())
+      return mlir::failure();
+
     auto operands = op.operands();
     if (operands.size() != 1)
       return mlir::failure();


### PR DESCRIPTION
* This is group work for reduction support for GPU
* Add kernel group reduction API, including kernel simulator, only `add` reduction for now
* There are instructions like `GroupNonUniformIAddOp` in spirv which can work either on `workgroup` or `subgroup` level, but it seems only subgroup version is supported in IGC.
* Add a pattern to  convert `gpu.all_reduce`, do a subgroup reduction first and accumulate subgroup results in local memory, then do a reduce across local memory.
* Subgroup size is hardcoded 8 for now, need to add API to query actual value. It will still work for bigger sizes but will waste local memory.
* Add support for dynamically sized local memory in L0 runtime, it can be used in passes, but there is no public kernel API yet
