### PR TITLE
Make gpu barriers follow uniform control flow

### DIFF
--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -48,6 +48,7 @@ set(SOURCES_LIST
     lib/Conversion/util_conversion.cpp
     lib/Conversion/util_to_llvm.cpp
     lib/Dialect/gpu_runtime/IR/gpu_runtime_ops.cpp
+    lib/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.cpp
     lib/Dialect/imex_util/dialect.cpp
     lib/Dialect/ntensor/IR/NTensorOps.cpp
     lib/Dialect/ntensor/Transforms/ResolveArrayOps.cpp
@@ -89,6 +90,7 @@ set(HEADERS_LIST
     include/imex/Conversion/util_conversion.hpp
     include/imex/Conversion/util_to_llvm.hpp
     include/imex/Dialect/gpu_runtime/IR/gpu_runtime_ops.hpp
+    include/imex/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.hpp
     include/imex/Dialect/imex_util/dialect.hpp
     include/imex/Dialect/ntensor/IR/NTensorOps.hpp
     include/imex/Dialect/ntensor/Transforms/ResolveArrayOps.hpp

--- a/mlir/include/imex/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.hpp
+++ b/mlir/include/imex/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.hpp
@@ -1,0 +1,30 @@
+// Copyright 2022 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+namespace mlir {
+class MLIRContext;
+class Pass;
+class RewritePatternSet;
+} // namespace mlir
+
+namespace gpu_runtime {
+void populateMakeBarriersUniformPatterns(mlir::MLIRContext &context,
+                                         mlir::RewritePatternSet &patterns);
+
+std::unique_ptr<mlir::Pass> createMakeBarriersUniformPass();
+} // namespace gpu_runtime

--- a/mlir/include/imex/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.hpp
+++ b/mlir/include/imex/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.hpp
@@ -26,5 +26,7 @@ namespace gpu_runtime {
 void populateMakeBarriersUniformPatterns(mlir::MLIRContext &context,
                                          mlir::RewritePatternSet &patterns);
 
+/// gpu barriers ops require uniform control flow, this pass tries to rearrange
+/// control flow in a way to satisfy this requirement.
 std::unique_ptr<mlir::Pass> createMakeBarriersUniformPass();
 } // namespace gpu_runtime

--- a/mlir/lib/Conversion/gpu_to_gpu_runtime.cpp
+++ b/mlir/lib/Conversion/gpu_to_gpu_runtime.cpp
@@ -970,13 +970,18 @@ public:
 
 static llvm::Optional<mlir::spirv::StorageClass>
 convertStorageClass(mlir::Attribute src) {
-  auto attr = src.dyn_cast_or_null<gpu_runtime::StorageClassAttr>();
-  if (!attr)
-    return llvm::None;
+  // TODO: Fix storage class upstream
+  //  auto attr = src.dyn_cast_or_null<gpu_runtime::StorageClassAttr>();
+  //  if (!attr)
+  //    return llvm::None;
 
-  auto sc = attr.getValue();
-  if (sc == gpu_runtime::StorageClass::local)
-    return mlir::spirv::StorageClass::Workgroup;
+  //  auto sc = attr.getValue();
+  //  if (sc == gpu_runtime::StorageClass::local)
+  //    return mlir::spirv::StorageClass::Workgroup;
+
+  if (auto attr = src.dyn_cast_or_null<mlir::IntegerAttr>())
+    if (attr.getInt() == mlir::gpu::GPUDialect::getPrivateAddressSpace())
+      return mlir::spirv::StorageClass::Workgroup;
 
   return llvm::None;
 }

--- a/mlir/lib/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.cpp
+++ b/mlir/lib/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.cpp
@@ -162,8 +162,10 @@ struct MakeBarriersUniformPass
 
     gpu_runtime::populateMakeBarriersUniformPatterns(ctx, patterns);
 
+    mlir::GreedyRewriteConfig config;
+    config.useTopDownTraversal = true; // We need to visit top barriers first
     (void)mlir::applyPatternsAndFoldGreedily(getOperation(),
-                                             std::move(patterns));
+                                             std::move(patterns), config);
   }
 };
 } // namespace

--- a/mlir/lib/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.cpp
+++ b/mlir/lib/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.cpp
@@ -1,0 +1,171 @@
+// Copyright 2022 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "imex/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.hpp"
+
+#include "imex/Dialect/gpu_runtime/IR/gpu_runtime_ops.hpp"
+#include "imex/Dialect/imex_util/dialect.hpp"
+
+#include <mlir/Dialect/GPU/IR/GPUDialect.h>
+#include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/IR/Dominance.h>
+#include <mlir/Pass/Pass.h>
+#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
+
+namespace {
+struct ConvertBarrierOp
+    : public mlir::OpRewritePattern<gpu_runtime::GPUBarrierOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(gpu_runtime::GPUBarrierOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto launchOp = op->getParentOfType<mlir::gpu::LaunchOp>();
+
+    // Must be within launch op.
+    if (!launchOp)
+      return mlir::failure();
+
+    // If op must be an immediate parent
+    auto ifOp = mlir::dyn_cast<mlir::scf::IfOp>(op->getParentOp());
+    if (!ifOp)
+      return mlir::failure();
+
+    // Launch op must be an immediate parent of ifOp.
+    if (ifOp->getParentOp() != launchOp)
+      return mlir::failure();
+
+    // IfOp with else block is not yet supported;
+    if (ifOp.elseBlock())
+      return mlir::failure();
+
+    mlir::Block *ifBody = ifOp.thenBlock();
+    assert(ifBody);
+
+    mlir::DominanceInfo dom;
+    llvm::SmallMapVector<mlir::Value, unsigned, 8> yieldArgsMap;
+
+    auto barrierIt = op->getIterator();
+    for (auto &beforeOp : llvm::make_range(ifBody->begin(), barrierIt)) {
+      for (auto result : beforeOp.getResults()) {
+        for (mlir::OpOperand user : result.getUsers()) {
+          auto owner = user.getOwner();
+          if (dom.properlyDominates(op, owner)) {
+            auto idx = static_cast<unsigned>(yieldArgsMap.size());
+            yieldArgsMap.insert({result, idx});
+          }
+        }
+      }
+    }
+
+    auto yieldArgs = [&]() {
+      auto range = llvm::make_first_range(yieldArgsMap);
+      return llvm::SmallVector<mlir::Value>(std::begin(range), std::end(range));
+    }();
+
+    auto afterBlock = rewriter.splitBlock(ifBody, std::next(barrierIt));
+
+    auto barrierLoc = op->getLoc();
+    auto barrierFlags = op.flags();
+    rewriter.eraseOp(op);
+
+    rewriter.setInsertionPointToEnd(ifBody);
+    rewriter.create<mlir::scf::YieldOp>(rewriter.getUnknownLoc(), yieldArgs);
+
+    rewriter.setInsertionPoint(ifOp);
+    auto ifLoc = ifOp->getLoc();
+    auto cond = ifOp.getCondition();
+
+    auto elseBodyBuilder = [&](mlir::OpBuilder &builder, mlir::Location loc) {
+      llvm::SmallVector<mlir::Value> results;
+      results.reserve(yieldArgs.size());
+      for (auto arg : yieldArgs)
+        builder.create<imex::util::UndefOp>(loc, arg.getType());
+
+      builder.create<mlir::scf::YieldOp>(loc, results);
+    };
+
+    mlir::ValueRange yieldArgsRange(yieldArgs);
+    auto beforeIf = rewriter.create<mlir::scf::IfOp>(
+        ifLoc, yieldArgsRange.getTypes(), cond, nullptr, elseBodyBuilder);
+    auto &beforeIfThenReg = beforeIf.getThenRegion();
+    rewriter.inlineRegionBefore(ifOp.getThenRegion(), beforeIfThenReg,
+                                beforeIfThenReg.end());
+
+    rewriter.create<gpu_runtime::GPUBarrierOp>(barrierLoc, barrierFlags);
+
+    auto beforeIfResults = beforeIf.getResults();
+
+    auto thenBodyBuilder = [](mlir::OpBuilder & /*builder*/,
+                              mlir::Location /*loc*/) {
+      // Nothing
+    };
+
+    auto afterIf =
+        rewriter.create<mlir::scf::IfOp>(ifLoc, cond, thenBodyBuilder);
+    rewriter.mergeBlocks(afterBlock, afterIf.thenBlock());
+
+    for (auto &op : *afterIf.thenBlock()) {
+      for (mlir::OpOperand &arg : op.getOpOperands()) {
+        auto val = arg.get();
+        auto it = yieldArgsMap.find(val);
+        if (it != yieldArgsMap.end()) {
+          auto i = it->second;
+          assert(i < beforeIfResults.size() && "Invalid result index.");
+          auto newVal = beforeIfResults[i];
+          rewriter.updateRootInPlace(&op, [&]() { arg.set(newVal); });
+        }
+      }
+    }
+
+    rewriter.eraseOp(ifOp);
+    return mlir::success();
+  }
+};
+} // namespace
+
+void gpu_runtime::populateMakeBarriersUniformPatterns(
+    mlir::MLIRContext &context, mlir::RewritePatternSet &patterns) {
+  patterns.insert<ConvertBarrierOp>(&context);
+}
+
+namespace {
+struct MakeBarriersUniformPass
+    : public mlir::PassWrapper<MakeBarriersUniformPass,
+                               mlir::OperationPass<void>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MakeBarriersUniformPass)
+
+  virtual void
+  getDependentDialects(mlir::DialectRegistry &registry) const override {
+    registry.insert<gpu_runtime::GpuRuntimeDialect>();
+    registry.insert<imex::util::ImexUtilDialect>();
+    registry.insert<mlir::gpu::GPUDialect>();
+    registry.insert<mlir::scf::SCFDialect>();
+  }
+
+  void runOnOperation() override {
+    auto &ctx = getContext();
+    mlir::RewritePatternSet patterns(&ctx);
+
+    gpu_runtime::populateMakeBarriersUniformPatterns(ctx, patterns);
+
+    (void)mlir::applyPatternsAndFoldGreedily(getOperation(),
+                                             std::move(patterns));
+  }
+};
+} // namespace
+
+std::unique_ptr<mlir::Pass> gpu_runtime::createMakeBarriersUniformPass() {
+  return std::make_unique<MakeBarriersUniformPass>();
+}

--- a/mlir/lib/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.cpp
+++ b/mlir/lib/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.cpp
@@ -88,8 +88,8 @@ struct ConvertBarrierOp
     auto ifLoc = ifOp->getLoc();
     auto cond = ifOp.getCondition();
 
-    auto thenBodyBuilder = [](mlir::OpBuilder & /*builder*/,
-                              mlir::Location /*loc*/) {
+    auto thenBodyBuilder = [&](mlir::OpBuilder & /*builder*/,
+                               mlir::Location /*loc*/) {
       // Nothing
     };
 

--- a/mlir/lib/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.cpp
+++ b/mlir/lib/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.cpp
@@ -78,7 +78,7 @@ struct ConvertBarrierOp
     auto beforeBlock = rewriter.splitBlock(ifBody, ifBody->begin());
 
     auto barrierLoc = op->getLoc();
-    auto barrierFlags = op.flags();
+    auto barrierFlags = op.getFlags();
     rewriter.eraseOp(op);
 
     rewriter.setInsertionPointToEnd(beforeBlock);

--- a/mlir/test/Transforms/make-barriers-uniform.mlir
+++ b/mlir/test/Transforms/make-barriers-uniform.mlir
@@ -1,0 +1,38 @@
+// RUN: imex-opt -allow-unregistered-dialect --gpux-make-barriers-uniform --split-input-file %s | FileCheck %s
+
+func.func @test() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  gpu.launch blocks(%bx, %by, %bz) in (%grid_x = %c1, %grid_y = %c1, %grid_z = %c1)
+             threads(%tx, %ty, %tz) in (%block_x = %c1, %block_y = %c1, %block_z = %c1) {
+    %cond = "test.test1"() : () -> i1
+    scf.if %cond {
+      "test.test2"() : () -> ()
+      %1 = "test.test3"() : () -> i32
+      gpu_runtime.barrier  local
+      "test.test4"() : () -> ()
+      "test.test5"(%1) : (i32) -> ()
+    }
+    gpu.terminator
+  }
+  return
+}
+
+// CHECK-LABEL: func @test
+//       CHECK: gpu.launch blocks
+//  CHECK-NEXT: %[[COND:.*]] = "test.test1"() : () -> i1
+//  CHECK-NEXT: %[[RES1:.*]] = scf.if %[[COND]] -> (i32) {
+//  CHECK-NEXT: "test.test2"() : () -> ()
+//  CHECK-NEXT: %[[V1:.*]] = "test.test3"() : () -> i32
+//  CHECK-NEXT: scf.yield %[[V1]] : i32
+//  CHECK-NEXT: } else {
+//  CHECK-NEXT: %[[V2:.*]] = imex_util.undef : i32
+//  CHECK-NEXT: scf.yield %[[V2]] : i32
+//  CHECK-NEXT: }
+//  CHECK-NEXT: gpu_runtime.barrier  local
+//  CHECK-NEXT: scf.if %[[COND]] {
+//  CHECK-NEXT: "test.test4"() : () -> ()
+//  CHECK-NEXT: "test.test5"(%[[RES1]]) : (i32) -> ()
+//  CHECK-NEXT: }
+//  CHECK-NEXT: gpu.terminator
+//        NEXT: return

--- a/mlir/test/Transforms/make-barriers-uniform.mlir
+++ b/mlir/test/Transforms/make-barriers-uniform.mlir
@@ -35,4 +35,62 @@ func.func @test() {
 //  CHECK-NEXT: "test.test5"(%[[RES1]]) : (i32) -> ()
 //  CHECK-NEXT: }
 //  CHECK-NEXT: gpu.terminator
-//        NEXT: return
+//        CHECK: return
+
+// -----
+
+func.func @test() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  gpu.launch blocks(%bx, %by, %bz) in (%grid_x = %c1, %grid_y = %c1, %grid_z = %c1)
+             threads(%tx, %ty, %tz) in (%block_x = %c1, %block_y = %c1, %block_z = %c1) {
+    %cond = "test.test1"() : () -> i1
+    scf.if %cond {
+      "test.test2"() : () -> ()
+      %1 = "test.test3"() : () -> i32
+      %2 = "test.test4"() : () -> i64
+      gpu_runtime.barrier  local
+      "test.test5"() : () -> ()
+      "test.test6"(%1) : (i32) -> ()
+      %3 = "test.test7"() : () -> index
+      gpu_runtime.barrier  global
+      "test.test8"() : () -> ()
+      "test.test9"(%2) : (i64) -> ()
+      "test.test10"(%3) : (index) -> ()
+    }
+    gpu.terminator
+  }
+  return
+}
+
+// CHECK-LABEL: func @test
+//       CHECK: gpu.launch blocks
+//  CHECK-NEXT: %[[COND:.*]] = "test.test1"() : () -> i1
+//  CHECK-NEXT: %[[RES1:.*]]:2 = scf.if %[[COND]] -> (i32, i64) {
+//  CHECK-NEXT: "test.test2"() : () -> ()
+//  CHECK-NEXT: %[[V1:.*]] = "test.test3"() : () -> i32
+//  CHECK-NEXT: %[[V2:.*]] = "test.test4"() : () -> i64
+//  CHECK-NEXT: scf.yield %[[V1]], %[[V2]] : i32, i64
+//  CHECK-NEXT: } else {
+//  CHECK-NEXT: %[[V3:.*]] = imex_util.undef : i32
+//  CHECK-NEXT: %[[V4:.*]] = imex_util.undef : i64
+//  CHECK-NEXT: scf.yield %[[V3]], %[[V4]] : i32, i64
+//  CHECK-NEXT: }
+//  CHECK-NEXT: gpu_runtime.barrier  local
+//  CHECK-NEXT: %[[RES2:.*]] = scf.if %[[COND]] -> (index) {
+//  CHECK-NEXT: "test.test5"() : () -> ()
+//  CHECK-NEXT: "test.test6"(%[[RES1]]#0) : (i32) -> ()
+//  CHECK-NEXT: %[[V5:.*]] = "test.test7"() : () -> index
+//  CHECK-NEXT: scf.yield %[[V5]] : index
+//  CHECK-NEXT: } else {
+//  CHECK-NEXT: %[[V6:.*]] = imex_util.undef : index
+//  CHECK-NEXT: scf.yield %[[V6]] : index
+//  CHECK-NEXT: }
+//  CHECK-NEXT: gpu_runtime.barrier global
+//  CHECK-NEXT: scf.if %[[COND]] {
+//  CHECK-NEXT: "test.test8"() : () -> ()
+//  CHECK-NEXT: "test.test9"(%[[RES1]]#1) : (i64) -> ()
+//  CHECK-NEXT: "test.test10"(%[[RES2]]) : (index) -> ()
+//  CHECK-NEXT: }
+//  CHECK-NEXT: gpu.terminator
+//       CHECK: return

--- a/mlir/tools/imex-opt/main.cpp
+++ b/mlir/tools/imex-opt/main.cpp
@@ -17,6 +17,7 @@
 #include <mlir/InitAllPasses.h>
 #include <mlir/Tools/mlir-opt/MlirOptMain.h>
 
+#include "imex/Dialect/gpu_runtime/IR/gpu_runtime_ops.hpp"
 #include "imex/Dialect/imex_util/dialect.hpp"
 #include "imex/Dialect/ntensor/IR/NTensorOps.hpp"
 
@@ -24,8 +25,9 @@ int main(int argc, char **argv) {
   mlir::registerAllPasses();
   mlir::DialectRegistry registry;
   mlir::registerAllDialects(registry);
-  registry.insert<imex::util::ImexUtilDialect>();
+  registry.insert<gpu_runtime::GpuRuntimeDialect>();
   registry.insert<imex::ntensor::NTensorDialect>();
+  registry.insert<imex::util::ImexUtilDialect>();
   return mlir::failed(MlirOptMain(argc, argv, "imex modular optimizer driver\n",
                                   registry,
                                   /*preloadDialectsInContext=*/false));

--- a/mlir/tools/imex-opt/passes.cpp
+++ b/mlir/tools/imex-opt/passes.cpp
@@ -27,6 +27,7 @@
 #include "imex/Conversion/gpu_runtime_to_llvm.hpp"
 #include "imex/Conversion/gpu_to_gpu_runtime.hpp"
 #include "imex/Conversion/ntensor_to_memref.hpp"
+#include "imex/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.hpp"
 #include "imex/Dialect/ntensor/Transforms/ResolveArrayOps.hpp"
 #include "imex/Transforms/expand_tuple.hpp"
 
@@ -124,3 +125,10 @@ static mlir::PassPipelineRegistration<>
                     [](mlir::OpPassManager &pm) {
                       pm.addPass(imex::createNtensorToMemrefPass());
                     });
+
+static mlir::PassPipelineRegistration<> makeBarriersUniform(
+    "gpux-make-barriers-uniform",
+    "Adapt gpu barriers to non-uniform control flow",
+    [](mlir::OpPassManager &pm) {
+      pm.addPass(gpu_runtime::createMakeBarriersUniformPass());
+    });

--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_gpu.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_gpu.py
@@ -754,7 +754,7 @@ def test_barrier1(global_size, local_size):
 
 
 @require_gpu
-@pytest.mark.parametrize("blocksize", [1, 10, 64])
+@pytest.mark.parametrize("blocksize", [1, 10, 17, 64, 67, 101])
 def test_local_memory(blocksize):
     local_array = local.array
 

--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_gpu.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_gpu.py
@@ -692,8 +692,8 @@ def test_input_load_cse():
 @require_gpu
 @pytest.mark.parametrize("op", [barrier, mem_fence])
 @pytest.mark.parametrize("flags", [CLK_LOCAL_MEM_FENCE, CLK_GLOBAL_MEM_FENCE])
-@pytest.mark.parametrize("global_size", [1, 2, 27])
-@pytest.mark.parametrize("local_size", [1, 2, 7])
+@pytest.mark.parametrize("global_size", [1, 2, 27, 67, 101])
+@pytest.mark.parametrize("local_size", [1, 2, 7, 17, 33])
 def test_barrier_ops(op, flags, global_size, local_size):
     atomic_add = atomic.add
 

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
@@ -1331,8 +1331,11 @@ public:
     }
 
     auto type = mlir::MemRefType::get(shape, oldType.getElementType());
-    auto storageClass = gpu_runtime::StorageClassAttr::get(
-        getContext(), gpu_runtime::StorageClass::local);
+    // TODO: Fix storage class upstream
+    //    auto storageClass = gpu_runtime::StorageClassAttr::get(
+    //        getContext(), gpu_runtime::StorageClass::local);
+    auto storageClass = rewriter.getI64IntegerAttr(
+        mlir::gpu::GPUDialect::getPrivateAddressSpace());
     auto typeLocal = mlir::MemRefType::get(shape, type.getElementType(),
                                            nullptr, storageClass);
 

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/lower_to_gpu.cpp
@@ -48,6 +48,7 @@
 #include "imex/Conversion/gpu_to_gpu_runtime.hpp"
 #include "imex/Conversion/util_conversion.hpp"
 #include "imex/Dialect/gpu_runtime/IR/gpu_runtime_ops.hpp"
+#include "imex/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.hpp"
 #include "imex/Dialect/imex_util/dialect.hpp"
 #include "imex/Transforms/call_lowering.hpp"
 #include "imex/Transforms/cast_utils.hpp"
@@ -1541,6 +1542,7 @@ static void populateLowerToGPUPipelineLow(mlir::OpPassManager &pm) {
   commonOptPasses(funcPM);
   funcPM.addPass(std::make_unique<KernelMemrefOpsMovementPass>());
   funcPM.addPass(std::make_unique<LowerGpuBuiltins2Pass>());
+  funcPM.addPass(gpu_runtime::createMakeBarriersUniformPass());
   funcPM.addPass(std::make_unique<SinkGpuDimsPass>());
   funcPM.addPass(std::make_unique<GpuLaunchSinkOpsPass>());
   pm.addPass(mlir::createGpuKernelOutliningPass());


### PR DESCRIPTION
gpu barriers require uniform control flow, but in our kernel api we always insert top level `IfOp` to avoid out of bounds access if global and local sizes are not evenly divisible.

Add new pass which splits such `IfOp` in a way to put barrier in uniform flow, see tests for specific transformation details.

Also:
* This pass exposed some additional issues
* `gpu_runtime::StorageClassAttr` is not handled well by upstream memref type converter, use `mlir::gpu::GPUDialect::getPrivateAddressSpace()` for now (need to fix upstream)
* Add new `util.sign_cast` canonicalization as it used as memory space cast op now (THIS IS A HACK, need dedicated op for this)