### PR TITLE
Fix GPU to spirv subgroup builtins lowering

### DIFF
--- a/mlir/test/Conversion/GPUToSPIRV/builtins.mlir
+++ b/mlir/test/Conversion/GPUToSPIRV/builtins.mlir
@@ -1,0 +1,167 @@
+// RUN: imex-opt -allow-unregistered-dialect --gpux-to-spirv -split-input-file %s | FileCheck %s
+
+module attributes {gpu.container_module, spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Int64, Kernel], []>, #spirv.resource_limits<>>} {
+  func.func @builtin() {
+    %c0 = arith.constant 1 : index
+    gpu.launch_func @kernels::@builtin_workgroup_size_x
+        blocks in (%c0, %c0, %c0) threads in (%c0, %c0, %c0)
+    return
+  }
+
+  // CHECK-LABEL:  spirv.module @{{.*}}
+  // CHECK: spirv.GlobalVariable [[VALUE:@.*]] built_in("WorkgroupSize")
+  gpu.module @kernels {
+    gpu.func @builtin_workgroup_size_x() kernel
+      attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      // CHECK: [[ADDRESS:%.*]] = spirv.mlir.addressof [[VALUE]]
+      // CHECK-NEXT: [[VEC:%.*]] = spirv.Load "Input" [[ADDRESS]] : vector<3xi64>
+      // CHECK-NEXT: {{%.*}} = spirv.CompositeExtract [[VEC]]{{\[}}0 : i32{{\]}}
+      %0 = gpu.block_dim x
+      gpu.return
+    }
+  }
+}
+
+// -----
+
+module attributes {gpu.container_module, spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Int64, Kernel], []>, #spirv.resource_limits<>>} {
+  func.func @builtin() {
+    %c0 = arith.constant 1 : index
+    gpu.launch_func @kernels::@builtin_workgroup_size_x
+        blocks in (%c0, %c0, %c0) threads in (%c0, %c0, %c0)
+    return
+  }
+
+  // CHECK-LABEL:  spirv.module @{{.*}}
+  // CHECK: spirv.GlobalVariable [[VALUE:@.*]] built_in("NumWorkgroups")
+  gpu.module @kernels {
+    gpu.func @builtin_workgroup_size_x() kernel
+      attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      // CHECK: [[ADDRESS:%.*]] = spirv.mlir.addressof [[VALUE]]
+      // CHECK-NEXT: [[VEC:%.*]] = spirv.Load "Input" [[ADDRESS]] : vector<3xi64>
+      // CHECK-NEXT: {{%.*}} = spirv.CompositeExtract [[VEC]]{{\[}}0 : i32{{\]}}
+      %0 = gpu.grid_dim x
+      gpu.return
+    }
+  }
+}
+
+// -----
+
+module attributes {gpu.container_module, spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Int64, Kernel], []>, #spirv.resource_limits<>>} {
+  func.func @builtin() {
+    %c0 = arith.constant 1 : index
+    gpu.launch_func @kernels::@builtin_workgroup_size_x
+        blocks in (%c0, %c0, %c0) threads in (%c0, %c0, %c0)
+    return
+  }
+
+  // CHECK-LABEL:  spirv.module @{{.*}}
+  // CHECK: spirv.GlobalVariable [[VALUE:@.*]] built_in("LocalInvocationId")
+  gpu.module @kernels {
+    gpu.func @builtin_workgroup_size_x() kernel
+      attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      // CHECK: [[ADDRESS:%.*]] = spirv.mlir.addressof [[VALUE]]
+      // CHECK-NEXT: [[VEC:%.*]] = spirv.Load "Input" [[ADDRESS]] : vector<3xi64>
+      // CHECK-NEXT: {{%.*}} = spirv.CompositeExtract [[VEC]]{{\[}}0 : i32{{\]}}
+      %0 = gpu.thread_id x
+      gpu.return
+    }
+  }
+}
+
+// -----
+
+module attributes {gpu.container_module, spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Int64, Kernel], []>, #spirv.resource_limits<>>} {
+  func.func @builtin() {
+    %c0 = arith.constant 1 : index
+    gpu.launch_func @kernels::@builtin_workgroup_size_x
+        blocks in (%c0, %c0, %c0) threads in (%c0, %c0, %c0)
+    return
+  }
+
+  // CHECK-LABEL:  spirv.module @{{.*}}
+  // CHECK: spirv.GlobalVariable [[VALUE:@.*]] built_in("WorkgroupId")
+  gpu.module @kernels {
+    gpu.func @builtin_workgroup_size_x() kernel
+      attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      // CHECK: [[ADDRESS:%.*]] = spirv.mlir.addressof [[VALUE]]
+      // CHECK-NEXT: [[VEC:%.*]] = spirv.Load "Input" [[ADDRESS]] : vector<3xi64>
+      // CHECK-NEXT: {{%.*}} = spirv.CompositeExtract [[VEC]]{{\[}}0 : i32{{\]}}
+      %0 = gpu.block_id x
+      gpu.return
+    }
+  }
+}
+
+// -----
+
+module attributes {gpu.container_module, spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Int64, Kernel], []>, #spirv.resource_limits<>>} {
+  func.func @builtin() {
+    %c0 = arith.constant 1 : index
+    gpu.launch_func @kernels::@builtin_workgroup_size_x
+        blocks in (%c0, %c0, %c0) threads in (%c0, %c0, %c0)
+    return
+  }
+
+  // CHECK-LABEL:  spirv.module @{{.*}}
+  // CHECK: spirv.GlobalVariable [[VALUE:@.*]] built_in("GlobalInvocationId")
+  gpu.module @kernels {
+    gpu.func @builtin_workgroup_size_x() kernel
+      attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      // CHECK: [[ADDRESS:%.*]] = spirv.mlir.addressof [[VALUE]]
+      // CHECK-NEXT: [[VEC:%.*]] = spirv.Load "Input" [[ADDRESS]] : vector<3xi64>
+      // CHECK-NEXT: {{%.*}} = spirv.CompositeExtract [[VEC]]{{\[}}0 : i32{{\]}}
+      %0 = gpu.global_id x
+      gpu.return
+    }
+  }
+}
+
+// -----
+
+module attributes {gpu.container_module, spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Int64, Kernel], []>, #spirv.resource_limits<>>} {
+  // CHECK-LABEL:  spirv.module @{{.*}}
+  // CHECK: spirv.GlobalVariable [[VALUE:@.*]] built_in("SubgroupId")
+  gpu.module @kernels {
+    gpu.func @builtin_subgroup_id() kernel
+      attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      // CHECK: [[ADDRESS:%.*]] = spirv.mlir.addressof [[VALUE]]
+      // CHECK-NEXT: {{%.*}} = spirv.Load "Input" [[ADDRESS]] : i32
+      %0 = gpu.subgroup_id : index
+      gpu.return
+    }
+  }
+}
+
+// -----
+
+module attributes {gpu.container_module, spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Int64, Kernel], []>, #spirv.resource_limits<>>} {
+  // CHECK-LABEL:  spirv.module @{{.*}}
+  // CHECK: spirv.GlobalVariable [[VALUE:@.*]] built_in("NumSubgroups")
+  gpu.module @kernels {
+    gpu.func @builtin_subgroup_id() kernel
+      attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      // CHECK: [[ADDRESS:%.*]] = spirv.mlir.addressof [[VALUE]]
+      // CHECK-NEXT: {{%.*}} = spirv.Load "Input" [[ADDRESS]] : i32
+      %0 = gpu.num_subgroups : index
+      gpu.return
+    }
+  }
+}
+
+// -----
+
+module attributes {gpu.container_module, spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Int64, Kernel], []>, #spirv.resource_limits<>>} {
+  // CHECK-LABEL:  spirv.module @{{.*}}
+  // CHECK: spirv.GlobalVariable [[VALUE:@.*]] built_in("SubgroupSize")
+  gpu.module @kernels {
+    gpu.func @builtin_subgroup_id() kernel
+      attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      // CHECK: [[ADDRESS:%.*]] = spirv.mlir.addressof [[VALUE]]
+      // CHECK-NEXT: {{%.*}} = spirv.Load "Input" [[ADDRESS]] : i32
+      %0 = gpu.subgroup_size : index
+      gpu.return
+    }
+  }
+}

--- a/mlir/test/Conversion/GPUToSPIRV/gpu-to-spirv.mlir
+++ b/mlir/test/Conversion/GPUToSPIRV/gpu-to-spirv.mlir
@@ -1,4 +1,4 @@
-// RUN: imex-opt --gpu-to-spirv %s | FileCheck %s
+// RUN: imex-opt --gpux-to-spirv %s | FileCheck %s
 
 module attributes {gpu.container_module, spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume]>, #spirv.resource_limits<>>} {
   func.func @main() {

--- a/mlir/tools/imex-opt/passes.cpp
+++ b/mlir/tools/imex-opt/passes.cpp
@@ -67,7 +67,7 @@ static mlir::PassPipelineRegistration<> SetSpirvCapabalities(
     });
 
 static mlir::PassPipelineRegistration<>
-    GpuToSpirv("gpu-to-spirv", "Converts Gpu to spirv module",
+    GpuToSpirv("gpux-to-spirv", "Converts Gpu to spirv module",
                [](mlir::OpPassManager &pm) {
                  pm.addPass(gpu_runtime::createGPUToSpirvPass());
                });


### PR DESCRIPTION
Upstream GPU to spirv lowering controls builtins type lowering via single variable `use64bitIndex`, but IGC expects get_global/local/id/size to be i64 (size_t) but subgroup builtins are still expected to be i32 (uint).

For now, set `use64bitIndex=true` but add custom lowering for subgroup builtins to lower them to i32.