### PR TITLE
Remove literal type from `plier` dialect

### DIFF
--- a/mlir/include/imex/Dialect/plier/dialect.hpp
+++ b/mlir/include/imex/Dialect/plier/dialect.hpp
@@ -32,7 +32,6 @@
 namespace plier {
 namespace detail {
 struct PyTypeStorage;
-struct LiteralTypeStorage;
 struct TypeVarStorage;
 
 struct OperatorNamePair {
@@ -83,17 +82,6 @@ public:
   static PyType getUndefined(mlir::MLIRContext *context);
 
   mlir::StringRef getName() const;
-};
-
-class LiteralType
-    : public mlir::Type::TypeBase<::plier::LiteralType, mlir::Type,
-                                  ::plier::detail::LiteralTypeStorage> {
-public:
-  using Base::Base;
-
-  static LiteralType get(mlir::Attribute value);
-
-  mlir::Attribute getValue() const;
 };
 
 class SliceType : public ::mlir::Type::TypeBase<SliceType, ::mlir::Type,

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_linalg.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/plier_to_linalg.cpp
@@ -603,7 +603,7 @@ static bool isValidGetitemIndex(mlir::Type type) {
   if (auto tupleType = type.dyn_cast<mlir::TupleType>())
     return llvm::all_of(tupleType.getTypes(), &isValidGetitemIndex);
 
-  return type.isa<mlir::IntegerType, mlir::IndexType, plier::LiteralType>();
+  return type.isa<mlir::IntegerType, mlir::IndexType>();
 }
 
 static mlir::LogicalResult
@@ -686,9 +686,6 @@ computeIndices(mlir::OpBuilder &builder, mlir::Location loc, mlir::Value value,
         size = builder.createOrFold<mlir::arith::DivUIOp>(loc, size, stride);
       }
       return {foldConst(offset), foldConst(size), stride, true};
-    } else if (auto literal = valType.dyn_cast<plier::LiteralType>()) {
-      auto offset = foldConst(handleNegativeVal(literal.getValue()));
-      return {offset, builder.getIndexAttr(1), builder.getIndexAttr(1), false};
     } else {
       auto offset =
           foldConst(handleNegativeVal(index_cast(indexVal, loc, builder)));

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/py_linalg_resolver.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/py_linalg_resolver.cpp
@@ -155,7 +155,7 @@ static bool isCompatibleType(mlir::Type type) {
 
   return type.isa<mlir::IntegerType, mlir::IndexType, mlir::FloatType,
                   mlir::RankedTensorType, mlir::MemRefType, mlir::NoneType,
-                  plier::LiteralType, plier::TypeVar>();
+                  plier::TypeVar>();
 }
 
 static bool isCompatibleTypeVal(mlir::Value val) {
@@ -400,9 +400,6 @@ private:
   llvm::Optional<py::object> makePyLiteral(py::capsule context,
                                            mlir::Value val) {
     assert(val);
-    if (auto literal = val.getType().dyn_cast<plier::LiteralType>())
-      return getPyLiteral(literal.getValue());
-
     if (auto buildTuple = val.getDefiningOp<imex::util::BuildTupleOp>()) {
       auto args = buildTuple.getArgs();
       auto count = static_cast<unsigned>(args.size());


### PR DESCRIPTION
This was an oddity from Numba side, we don't need it on mlir side and can convert it directly to int type.
