### PR TITLE
Refactor loop rewrites patterns

### DIFF
--- a/mlir/include/imex/Transforms/loop_rewrites.hpp
+++ b/mlir/include/imex/Transforms/loop_rewrites.hpp
@@ -14,20 +14,13 @@
 
 #pragma once
 
-#include <mlir/IR/PatternMatch.h>
-
 namespace mlir {
-namespace scf {
-class ForOp;
-}
+class MLIRContext;
+class RewritePatternSet;
 } // namespace mlir
 
 namespace imex {
-struct CmpLoopBoundsSimplify : public mlir::OpRewritePattern<mlir::scf::ForOp> {
-  using mlir::OpRewritePattern<mlir::scf::ForOp>::OpRewritePattern;
+void populateLoopRewritesPatterns(mlir::MLIRContext &context,
+                                  mlir::RewritePatternSet &patterns);
 
-  mlir::LogicalResult
-  matchAndRewrite(mlir::scf::ForOp op,
-                  mlir::PatternRewriter &rewriter) const override;
-};
 } // namespace imex

--- a/mlir/lib/Transforms/common_opts.cpp
+++ b/mlir/lib/Transforms/common_opts.cpp
@@ -18,7 +18,6 @@
 #include "imex/Transforms/if_rewrites.hpp"
 #include "imex/Transforms/index_type_propagation.hpp"
 #include "imex/Transforms/loop_rewrites.hpp"
-#include "imex/Transforms/memory_rewrites.hpp"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 

--- a/mlir/lib/Transforms/common_opts.cpp
+++ b/mlir/lib/Transforms/common_opts.cpp
@@ -164,7 +164,6 @@ void imex::populateCommonOptsPatterns(mlir::MLIRContext &context,
   patterns.insert<
       // clang-format off
 //      LoopInvariantCodeMotion, TODO
-      imex::CmpLoopBoundsSimplify,
       imex::IfOpConstCond,
       imex::CSERewrite<mlir::func::FuncOp, /*recusive*/ false>,
       SubviewLoadPropagate,
@@ -173,6 +172,7 @@ void imex::populateCommonOptsPatterns(mlir::MLIRContext &context,
       // clang-format on
       >(&context);
 
+  imex::populateLoopRewritesPatterns(context, patterns);
   imex::populateIndexPropagatePatterns(context, patterns);
 }
 

--- a/mlir/lib/Transforms/loop_rewrites.cpp
+++ b/mlir/lib/Transforms/loop_rewrites.cpp
@@ -59,63 +59,74 @@ handlerImpl(mlir::arith::CmpIPredicate pred, mlir::Value lhs, mlir::Value rhs,
   return {};
 }
 
-struct CmpLoopBoundsSimplify : public mlir::OpRewritePattern<mlir::scf::ForOp> {
+struct CmpLoopBoundsSimplify
+    : public mlir::OpRewritePattern<mlir::arith::CmpIOp> {
   using OpRewritePattern::OpRewritePattern;
 
   mlir::LogicalResult
-  matchAndRewrite(mlir::scf::ForOp op,
+  matchAndRewrite(mlir::arith::CmpIOp cmp,
                   mlir::PatternRewriter &rewriter) const override {
-    auto indexVar = op.getLoopBody().front().getArgument(0);
-    bool matched = false;
-    for (auto user : llvm::make_early_inc_range(indexVar.getUsers())) {
-      auto cmp = mlir::dyn_cast<mlir::arith::CmpIOp>(user);
-      if (cmp) {
-        auto pred = cmp.getPredicate();
-        auto lhs = cmp.getLhs();
-        auto rhs = cmp.getRhs();
-        // Normalize index and predicate (index always on the left)
-        using norm_fptr_t =
-            bool (*)(mlir::arith::CmpIPredicate & pred, mlir::Value index,
-                     mlir::Value & lhs, mlir::Value & rhs);
-        using Predicate = mlir::arith::CmpIPredicate;
-        const norm_fptr_t norm_handlers[] = {
-            &normImpl<Predicate::sle, Predicate::sge>,
-            &normImpl<Predicate::slt, Predicate::sgt>,
-            &normImpl<Predicate::ule, Predicate::uge>,
-            &normImpl<Predicate::ult, Predicate::ugt>,
-            &normImpl<Predicate::eq, Predicate::eq>,
-            &normImpl<Predicate::ne, Predicate::ne>,
-        };
+    auto pair =
+        [&]() -> llvm::Optional<std::pair<mlir::scf::ForOp, mlir::Value>> {
+      for (auto val : {cmp.getLhs(), cmp.getRhs()}) {
+        auto block = val.getParentBlock();
+        if (block->getNumArguments() > 0 && val == block->getArgument(0))
+          if (auto forOp =
+                  mlir::dyn_cast<mlir::scf::ForOp>(block->getParentOp()))
+            return std::make_pair(forOp, val);
+      }
+      return llvm::None;
+    }();
 
-        for (auto h : norm_handlers)
-          if (h(pred, indexVar, lhs, rhs))
-            break;
+    if (!pair)
+      return mlir::failure();
 
-        using fptr_t = llvm::Optional<int64_t> (*)(
-            Predicate pred, mlir::Value lhs, mlir::Value rhs, mlir::Value index,
-            mlir::Value lowerBound, mlir::Value upperBound);
-        const fptr_t handlers[] = {
-            &handlerImpl<Predicate::sge, UpperBound, 0>,
-            &handlerImpl<Predicate::slt, LowerBound, 0>,
-            &handlerImpl<Predicate::sge, LowerBound, 1>,
-            &handlerImpl<Predicate::slt, UpperBound, 1>,
-        };
+    auto [forOp, indexVar] = *pair;
 
-        for (auto h : handlers) {
-          if (auto c = h(pred, lhs, rhs, indexVar, op.getLowerBound(),
-                         op.getUpperBound())) {
-            auto type = rewriter.getI1Type();
-            auto val = rewriter.getIntegerAttr(type, *c);
-            auto constVal =
-                rewriter.create<mlir::arith::ConstantOp>(cmp.getLoc(), val);
-            rewriter.replaceOp(cmp, constVal.getResult());
-            matched = true;
-            break;
-          }
-        }
+    auto pred = cmp.getPredicate();
+    auto lhs = cmp.getLhs();
+    auto rhs = cmp.getRhs();
+    // Normalize index and predicate (index always on the left)
+    using norm_fptr_t =
+        bool (*)(mlir::arith::CmpIPredicate & pred, mlir::Value index,
+                 mlir::Value & lhs, mlir::Value & rhs);
+    using Predicate = mlir::arith::CmpIPredicate;
+    const norm_fptr_t norm_handlers[] = {
+        &normImpl<Predicate::sle, Predicate::sge>,
+        &normImpl<Predicate::slt, Predicate::sgt>,
+        &normImpl<Predicate::ule, Predicate::uge>,
+        &normImpl<Predicate::ult, Predicate::ugt>,
+        &normImpl<Predicate::eq, Predicate::eq>,
+        &normImpl<Predicate::ne, Predicate::ne>,
+    };
+
+    for (auto h : norm_handlers)
+      if (h(pred, indexVar, lhs, rhs))
+        break;
+
+    using fptr_t = llvm::Optional<int64_t> (*)(
+        Predicate pred, mlir::Value lhs, mlir::Value rhs, mlir::Value index,
+        mlir::Value lowerBound, mlir::Value upperBound);
+    const fptr_t handlers[] = {
+        &handlerImpl<Predicate::sge, UpperBound, 0>,
+        &handlerImpl<Predicate::slt, LowerBound, 0>,
+        &handlerImpl<Predicate::sge, LowerBound, 1>,
+        &handlerImpl<Predicate::slt, UpperBound, 1>,
+    };
+
+    for (auto h : handlers) {
+      if (auto c = h(pred, lhs, rhs, indexVar, forOp.getLowerBound(),
+                     forOp.getUpperBound())) {
+        auto type = rewriter.getI1Type();
+        auto val = rewriter.getIntegerAttr(type, *c);
+        auto constVal =
+            rewriter.create<mlir::arith::ConstantOp>(cmp.getLoc(), val);
+        rewriter.replaceOp(cmp, constVal.getResult());
+        return mlir::success();
       }
     }
-    return mlir::success(matched);
+
+    return mlir::failure();
   }
 };
 } // namespace


### PR DESCRIPTION
* Use `populateXYZPatterns` idiom instead of exposing rewrite struct directly
* Root `CmpLoopBoundsSimplify` on `CmpIOp` instead of `ForOp` as it wasn't safe wrt detecting IR changes
