### PR TITLE
Properly check L0 device capabilities before running gpu kernels

### DIFF
--- a/dpcomp_gpu_runtime/lib/gpu_runtime.cpp
+++ b/dpcomp_gpu_runtime/lib/gpu_runtime.cpp
@@ -511,7 +511,7 @@ dpcompGpuSuggestBlockSize(void *stream, void *kernel, const uint32_t *gridSize,
   });
 }
 
-// Must be kept in sync with compiler version version.
+// Must be kept in sync with compiler version.
 struct OffloadDeviceCapabilities {
   uint16_t spirvMajorVersion;
   uint16_t spirvMinorVersion;

--- a/mlir/include/imex/Conversion/gpu_to_gpu_runtime.hpp
+++ b/mlir/include/imex/Conversion/gpu_to_gpu_runtime.hpp
@@ -14,16 +14,25 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 
 namespace mlir {
 class Pass;
+namespace spirv {
+class TargetEnvAttr;
 }
+namespace gpu {
+class GPUModuleOp;
+}
+} // namespace mlir
 
 namespace gpu_runtime {
 
 std::unique_ptr<mlir::Pass> createAbiAttrsPass();
-std::unique_ptr<mlir::Pass> createSetSPIRVCapabilitiesPass();
+std::unique_ptr<mlir::Pass> createSetSPIRVCapabilitiesPass(
+    std::function<mlir::spirv::TargetEnvAttr(mlir::gpu::GPUModuleOp)> mapper =
+        nullptr);
 std::unique_ptr<mlir::Pass> createGPUToSpirvPass();
 std::unique_ptr<mlir::Pass> createInsertGPUAllocsPass();
 std::unique_ptr<mlir::Pass> createConvertGPUDeallocsPass();

--- a/mlir/lib/Conversion/gpu_to_gpu_runtime.cpp
+++ b/mlir/lib/Conversion/gpu_to_gpu_runtime.cpp
@@ -1376,23 +1376,25 @@ static mlir::spirv::TargetEnvAttr defaultCapsMapper(mlir::gpu::GPUModuleOp op) {
   spirv::Capability caps[] = {
       // clang-format off
       spirv::Capability::Addresses,
+      spirv::Capability::AtomicFloat32AddEXT,
+      spirv::Capability::ExpectAssumeKHR,
+      spirv::Capability::Float16,
       spirv::Capability::Float16Buffer,
-      spirv::Capability::Int64,
+      spirv::Capability::Float64,
+      spirv::Capability::GenericPointer,
+      spirv::Capability::Groups,
       spirv::Capability::Int16,
+      spirv::Capability::Int64,
       spirv::Capability::Int8,
       spirv::Capability::Kernel,
       spirv::Capability::Linkage,
       spirv::Capability::Vector16,
-      spirv::Capability::GenericPointer,
-      spirv::Capability::Groups,
-      spirv::Capability::Float16,
-      spirv::Capability::Float64,
-      spirv::Capability::AtomicFloat32AddEXT,
-      spirv::Capability::ExpectAssumeKHR,
       // clang-format on
   };
   spirv::Extension exts[] = {spirv::Extension::SPV_EXT_shader_atomic_float_add,
                              spirv::Extension::SPV_KHR_expect_assume};
+  llvm::sort(caps);
+  llvm::sort(exts);
   auto triple =
       spirv::VerCapExtAttr::get(spirv::Version::V_1_0, caps, exts, context);
   auto attr = spirv::TargetEnvAttr::get(

--- a/mlir/test/Transforms/set-spirv-capability.mlir
+++ b/mlir/test/Transforms/set-spirv-capability.mlir
@@ -3,7 +3,7 @@
 module attributes {gpu.container_module} {
 
 // CHECK: module attributes {gpu.container_module} {
-// CHECK: gpu.module @main_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume]>, #spirv.resource_limits<>>} {
+// CHECK: gpu.module @main_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Linkage, Kernel, Vector16, Float16Buffer, Float16, Float64, Int64, Groups, Int16, GenericPointer, Int8, ExpectAssumeKHR, AtomicFloat32AddEXT], [SPV_KHR_expect_assume, SPV_EXT_shader_atomic_float_add]>, #spirv.resource_limits<>>} {
 
   gpu.module @main_kernel {
     gpu.func @main_kernel(%arg0: memref<8xf32>, %arg1: memref<8xf32>, %arg2: memref<8xf32>) kernel attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {

--- a/mlir/test/Transforms/set-spirv-capability.mlir
+++ b/mlir/test/Transforms/set-spirv-capability.mlir
@@ -2,7 +2,8 @@
 
 module attributes {gpu.container_module} {
 
-// CHECK: module attributes {gpu.container_module, spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume]>, #spirv.resource_limits<>>} {
+// CHECK: module attributes {gpu.container_module} {
+// CHECK: gpu.module @main_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume]>, #spirv.resource_limits<>>} {
 
   gpu.module @main_kernel {
     gpu.func @main_kernel(%arg0: memref<8xf32>, %arg1: memref<8xf32>, %arg2: memref<8xf32>) kernel attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {

--- a/numba_dpcomp/numba_dpcomp/mlir/gpu_runtime.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/gpu_runtime.py
@@ -71,3 +71,7 @@ if IS_GPU_RUNTIME_AVAILABLE:
 
     _register_funcs()
     del _register_funcs
+
+    get_device_caps_addr = int(
+        ctypes.cast(runtime_lib.dpcompGetDeviceCapabilities, ctypes.c_void_p).value
+    )

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/CMakeLists.txt
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/CMakeLists.txt
@@ -27,34 +27,36 @@ include(AddMLIR)
 include(HandleLLVMOptions)
 
 set(SOURCES_LIST
+    lib/CheckGpuCaps.cpp
+    lib/loop_utils.cpp
+    lib/lowering.cpp
+    lib/mangle.cpp
     lib/pipelines/base_pipeline.cpp
     lib/pipelines/lower_to_gpu.cpp
     lib/pipelines/lower_to_llvm.cpp
     lib/pipelines/parallel_to_tbb.cpp
     lib/pipelines/plier_to_linalg.cpp
-    lib/pipelines/plier_to_std.cpp
     lib/pipelines/plier_to_scf.cpp
+    lib/pipelines/plier_to_std.cpp
     lib/pipelines/pre_low_simplifications.cpp
-    lib/loop_utils.cpp
-    lib/lowering.cpp
-    lib/mangle.cpp
     lib/py_func_resolver.cpp
     lib/py_linalg_resolver.cpp
     lib/py_map_types.cpp
     lib/py_module.cpp
     )
 set(HEADERS_LIST
+    lib/CheckGpuCaps.hpp
+    lib/loop_utils.hpp
+    lib/lowering.hpp
+    lib/mangle.hpp
     lib/pipelines/base_pipeline.hpp
     lib/pipelines/lower_to_gpu.hpp
     lib/pipelines/lower_to_llvm.hpp
     lib/pipelines/parallel_to_tbb.hpp
     lib/pipelines/plier_to_linalg.hpp
-    lib/pipelines/plier_to_std.hpp
     lib/pipelines/plier_to_scf.hpp
+    lib/pipelines/plier_to_std.hpp
     lib/pipelines/pre_low_simplifications.hpp
-    lib/loop_utils.hpp
-    lib/lowering.hpp
-    lib/mangle.hpp
     lib/py_func_resolver.hpp
     lib/py_linalg_resolver.hpp
     lib/py_map_types.hpp

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/CheckGpuCaps.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/CheckGpuCaps.cpp
@@ -1,0 +1,45 @@
+// Copyright 202 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "CheckGpuCaps.hpp"
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+using ResolveFptr = bool (*)(OffloadDeviceCapabilities *);
+
+static ResolveFptr getResolver() {
+  static ResolveFptr resolver = []() {
+    py::object mod = py::module::import("numba_dpcomp.mlir.gpu_runtime");
+    py::object attr = mod.attr("get_device_caps_addr");
+    return reinterpret_cast<ResolveFptr>(attr.cast<uintptr_t>());
+  }();
+  return resolver;
+}
+
+llvm::Optional<OffloadDeviceCapabilities> getOffloadDeviceCapabilities() {
+  auto resolver = getResolver();
+  if (!resolver)
+    return llvm::None;
+
+  OffloadDeviceCapabilities ret;
+  if (!resolver(&ret))
+    return llvm::None;
+
+  if (ret.spirvMajorVersion == 0 && ret.spirvMinorVersion == 0)
+    return llvm::None;
+
+  return ret;
+}

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/CheckGpuCaps.hpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/CheckGpuCaps.hpp
@@ -1,0 +1,30 @@
+// Copyright 2022 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+#include <llvm/ADT/Optional.h>
+
+// Must be kept in sync with gpu_runtime version.
+struct OffloadDeviceCapabilities {
+  uint16_t spirvMajorVersion;
+  uint16_t spirvMinorVersion;
+  bool hasFP16;
+  bool hasFP64;
+};
+
+// TODO: device name
+llvm::Optional<OffloadDeviceCapabilities> getOffloadDeviceCapabilities();


### PR DESCRIPTION
This is needed to avoid crashes when running on devices without f64 support.

* Set `TargetEnvAttr` per each `gpu.module` separately instead of top-level module as different gpu modules can potentially have different capabilities.
* Add callback to `createSetSPIRVCapabilitiesPass` so user can provide custom capabilities instead of hardcoding them.
* Add `dpcompGetDeviceCapabilities` to gpu runtime to get device caps
* Connect passes to gpu runtime using python bridge.

