### PR TITLE
Check all usm_array args have same device

### DIFF
--- a/numba_dpcomp/numba_dpcomp/mlir/kernel_impl.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/kernel_impl.py
@@ -31,6 +31,7 @@ from .func_registry import add_func
 
 from ..decorators import mlir_njit
 from .kernel_base import KernelBase
+from .dpctl_interop import check_usm_ndarray_args
 
 registry = FuncRegistry()
 
@@ -173,6 +174,9 @@ class Kernel(KernelBase):
 
     def __call__(self, *args, **kwargs):
         self.check_call_args(args, kwargs)
+
+        # kwargs is not supported
+        check_usm_ndarray_args(args)
 
         local_size = self.local_size
         if len(local_size) != 0:


### PR DESCRIPTION
* Check is based on filter string comparison for now
* Also, remove unused `addrspace` field in `USMNdArrayType`
* This filter string is still ignored in compiler part, will be updated in follow-up PR