### PR TITLE
Introduce python->mlir type converter

### DIFF
--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/CMakeLists.txt
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/CMakeLists.txt
@@ -36,6 +36,7 @@ set(SOURCES_LIST
     lib/PyLinalgResolver.cpp
     lib/PyMapTypes.cpp
     lib/PyModule.cpp
+    lib/PyTypeConverter.cpp
     lib/pipelines/BasePipeline.cpp
     lib/pipelines/LowerToGpu.cpp
     lib/pipelines/LowerToLlvm.cpp
@@ -55,6 +56,7 @@ set(HEADERS_LIST
     lib/PyLinalgResolver.hpp
     lib/PyMapTypes.hpp
     lib/PyModule.hpp
+    lib/PyTypeConverter.hpp
     lib/pipelines/BasePipeline.hpp
     lib/pipelines/LowerToGpu.hpp
     lib/pipelines/LowerToLlvm.hpp

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/Lowering.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/Lowering.cpp
@@ -45,6 +45,7 @@
 #include "imex/ExecutionEngine/ExecutionEngine.hpp"
 #include "imex/Utils.hpp"
 
+#include "PyTypeConverter.hpp"
 #include "pipelines/BasePipeline.hpp"
 #include "pipelines/LowerToGpu.hpp"
 #include "pipelines/LowerToLlvm.hpp"
@@ -147,7 +148,8 @@ struct InstHandles {
 };
 
 struct PlierLowerer final {
-  PlierLowerer(mlir::MLIRContext &context) : ctx(context), builder(&ctx) {
+  PlierLowerer(mlir::MLIRContext &context, PyTypeConverter &conv)
+      : ctx(context), builder(&ctx), typeConverter(conv) {
     ctx.loadDialect<imex::util::ImexUtilDialect>();
     ctx.loadDialect<mlir::func::FuncDialect>();
     ctx.loadDialect<plier::PlierDialect>();
@@ -204,11 +206,16 @@ private:
 
   std::unordered_map<mlir::Block *, BlockInfo> blockInfos;
 
-  plier::PyType getObjType(py::handle obj) const {
+  PyTypeConverter &typeConverter;
+
+  mlir::Type getObjType(py::handle obj) const {
+    if (auto type = typeConverter.convertType(ctx, obj))
+      return type;
+
     return plier::PyType::get(&ctx, py::str(obj).cast<std::string>());
   }
 
-  plier::PyType getType(py::handle inst) const {
+  mlir::Type getType(py::handle inst) const {
     auto type = typemap(inst);
     return getObjType(type);
   }
@@ -697,6 +704,7 @@ struct Module {
   mlir::MLIRContext context;
   imex::PipelineRegistry registry;
   mlir::ModuleOp module;
+  PyTypeConverter typeConverter;
 
   Module(const ModuleSettings &settings) { createPipeline(registry, settings); }
 };
@@ -826,7 +834,8 @@ py::capsule lowerFunction(const py::object &compilationContext,
   auto mod = static_cast<Module *>(pyMod);
   auto &context = mod->context;
   auto &module = mod->module;
-  auto func = PlierLowerer(context).lower(compilationContext, module, funcIr);
+  auto func = PlierLowerer(context, mod->typeConverter)
+                  .lower(compilationContext, module, funcIr);
   return py::capsule(func.getOperation()); // no dtor, func owned by module
 }
 

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/Lowering.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/Lowering.cpp
@@ -212,7 +212,8 @@ private:
     if (auto type = typeConverter.convertType(ctx, obj))
       return type;
 
-    return plier::PyType::get(&ctx, py::str(obj).cast<std::string>());
+    imex::reportError(llvm::Twine("Unhandled type: ") +
+                      py::str(obj).cast<std::string>());
   }
 
   mlir::Type getType(py::handle inst) const {
@@ -682,6 +683,11 @@ struct ModuleSettings {
 
 static void createPipeline(imex::PipelineRegistry &registry,
                            const ModuleSettings &settings) {
+  converter.addConversion(
+      [](mlir::MLIRContext &ctx, py::handle obj) -> llvm::Optional<mlir::Type> {
+        return plier::PyType::get(&ctx, py::str(obj).cast<std::string>());
+      });
+
   registerBasePipeline(registry);
   registerLowerToLLVMPipeline(registry);
   registerPlierToScfPipeline(registry);

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/Lowering.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/Lowering.cpp
@@ -682,6 +682,7 @@ struct ModuleSettings {
 };
 
 static void createPipeline(imex::PipelineRegistry &registry,
+                           PyTypeConverter &converter,
                            const ModuleSettings &settings) {
   converter.addConversion(
       [](mlir::MLIRContext &ctx, py::handle obj) -> llvm::Optional<mlir::Type> {
@@ -712,7 +713,9 @@ struct Module {
   mlir::ModuleOp module;
   PyTypeConverter typeConverter;
 
-  Module(const ModuleSettings &settings) { createPipeline(registry, settings); }
+  Module(const ModuleSettings &settings) {
+    createPipeline(registry, typeConverter, settings);
+  }
 };
 
 static void runCompiler(Module &mod, const py::object &compilationContext) {

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/PyTypeConverter.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/PyTypeConverter.cpp
@@ -1,0 +1,38 @@
+// Copyright 2022 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "PyTypeConverter.hpp"
+
+#include <pybind11/pybind11.h>
+
+#include <mlir/IR/Types.h>
+
+void PyTypeConverter::addConversion(Conversion conv) {
+  assert(conv && "Invalid conversion func");
+  conversions.emplace_back(std::move(conv));
+}
+
+mlir::Type PyTypeConverter::convertType(mlir::MLIRContext &context,
+                                        pybind11::handle pyObj) const {
+  // Iterate in reverse order to follow mlir type conversion behavior.
+  for (auto &conv : llvm::reverse(conversions)) {
+    assert(conv && "Invalid conversion func");
+    llvm::Optional<mlir::Type> result = conv(context, pyObj);
+    if (!result)
+      continue;
+
+    return *result;
+  }
+  return nullptr;
+}

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/PyTypeConverter.hpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/PyTypeConverter.hpp
@@ -1,0 +1,46 @@
+// Copyright 2022 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <functional>
+
+#include <llvm/ADT/Optional.h>
+#include <llvm/ADT/SmallVector.h>
+
+namespace mlir {
+class MLIRContext;
+class Type;
+} // namespace mlir
+
+namespace pybind11 {
+class handle;
+}
+
+class PyTypeConverter {
+public:
+  PyTypeConverter() = default;
+  PyTypeConverter(const PyTypeConverter &) = delete;
+
+  using Conversion = std::function<llvm::Optional<mlir::Type>(
+      mlir::MLIRContext &, pybind11::handle)>;
+
+  void addConversion(Conversion conv);
+
+  mlir::Type convertType(mlir::MLIRContext &context,
+                         pybind11::handle pyObj) const;
+
+private:
+  llvm::SmallVector<Conversion, 0> conversions;
+};


### PR DESCRIPTION
We are still using text-based representation to represent numba types which is _not ideal_. Introduce proper type converter in frontend.

This PR only adds requires infrastructure, actual conversions will be added in follow-up PRs.