### PR TITLE
Swith gpu lowering to new python type converter and generate proper device name for env region

### DIFF
--- a/mlir/lib/Conversion/NtensorToMemref.cpp
+++ b/mlir/lib/Conversion/NtensorToMemref.cpp
@@ -335,9 +335,6 @@ struct CastOpLowering
     if (!origDstType)
       return mlir::failure();
 
-    if (origSrcType.getEnvironment() != origDstType.getEnvironment())
-      return mlir::failure();
-
     auto *converter = getTypeConverter();
     assert(converter && "Type converter is not set");
 
@@ -345,6 +342,14 @@ struct CastOpLowering
                        .dyn_cast_or_null<mlir::MemRefType>();
 
     if (!retType)
+      return mlir::failure();
+
+    if (srcType == retType) {
+      rewriter.replaceOp(op, src);
+      return mlir::success();
+    }
+
+    if (origSrcType.getEnvironment() != origDstType.getEnvironment())
       return mlir::failure();
 
     if (!mlir::memref::CastOp::areCastCompatible(srcType, retType))

--- a/numba_dpcomp/numba_dpcomp/mlir/dpctl_interop.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/dpctl_interop.py
@@ -203,6 +203,8 @@ if _is_dpctl_available:
 
 else:  # _is_dpctl_available
 
+    USMNdArrayType = None  # dummy
+
     def check_usm_ndarray_args(args):
         # dpctl is not loaded, nothing to do
         pass

--- a/numba_dpcomp/numba_dpcomp/mlir/dpctl_interop.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/dpctl_interop.py
@@ -55,6 +55,7 @@ if _is_dpctl_available:
             readonly=False,
             name=None,
             aligned=True,
+            filter_string=None,
         ):
             super(USMNdArrayBaseType, self).__init__(
                 dtype,
@@ -64,6 +65,8 @@ if _is_dpctl_available:
                 name=name,
                 aligned=aligned,
             )
+
+            self.filter_string = filter_string
 
         def copy(self, dtype=None, ndim=None, layout=None, readonly=None):
             if dtype is None:
@@ -90,6 +93,7 @@ if _is_dpctl_available:
                 self.layout,
                 self.mutable,
                 self.aligned,
+                self.filter_string,
             )
 
         @property
@@ -141,9 +145,8 @@ if _is_dpctl_available:
                 layout,
                 readonly=readonly,
                 name=name,
+                filter_string=filter_string,
             )
-
-            self.filter_string = filter_string
 
         def copy(self, *args, **kwargs):
             return super(USMNdArrayType, self).copy(*args, **kwargs)

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/CMakeLists.txt
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/CMakeLists.txt
@@ -39,6 +39,7 @@ set(SOURCES_LIST
     lib/PyTypeConverter.cpp
     lib/pipelines/BasePipeline.cpp
     lib/pipelines/LowerToGpu.cpp
+    lib/pipelines/LowerToGpuTypeConversion.cpp
     lib/pipelines/LowerToLlvm.cpp
     lib/pipelines/ParallelToTbb.cpp
     lib/pipelines/PlierToLinalg.cpp
@@ -61,6 +62,7 @@ set(HEADERS_LIST
     lib/PyTypeConverter.hpp
     lib/pipelines/BasePipeline.hpp
     lib/pipelines/LowerToGpu.hpp
+    lib/pipelines/LowerToGpuTypeConversion.hpp
     lib/pipelines/LowerToLlvm.hpp
     lib/pipelines/ParallelToTbb.hpp
     lib/pipelines/PlierToLinalg.hpp

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/Lowering.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/Lowering.cpp
@@ -49,6 +49,7 @@
 #include "PyTypeConverter.hpp"
 #include "pipelines/BasePipeline.hpp"
 #include "pipelines/LowerToGpu.hpp"
+#include "pipelines/LowerToGpuTypeConversion.hpp"
 #include "pipelines/LowerToLlvm.hpp"
 #include "pipelines/ParallelToTbb.hpp"
 #include "pipelines/PlierToLinalg.hpp"
@@ -711,6 +712,7 @@ static void createPipeline(imex::PipelineRegistry &registry,
 
   if (settings.enableGpuPipeline) {
 #ifdef IMEX_ENABLE_IGPU_DIALECT
+    populateGpuTypeConverter(converter);
     registerLowerToGPUPipeline(registry);
     // TODO(nbpatel): Add Gpu->GpuRuntime & GpuRuntimetoLlvm Transformation
 #else

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/Lowering.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/Lowering.cpp
@@ -37,6 +37,7 @@
 #include <llvm/Support/ManagedStatic.h>
 #include <llvm/Support/TargetSelect.h>
 
+#include "imex/Dialect/gpu_runtime/IR/GpuRuntimeOps.hpp"
 #include "imex/Dialect/imex_util/Dialect.hpp"
 #include "imex/Dialect/ntensor/IR/NTensorOps.hpp"
 #include "imex/Dialect/plier/Dialect.hpp"
@@ -154,6 +155,7 @@ struct InstHandles {
 struct PlierLowerer final {
   PlierLowerer(mlir::MLIRContext &context, PyTypeConverter &conv)
       : ctx(context), builder(&ctx), typeConverter(conv) {
+    ctx.loadDialect<gpu_runtime::GpuRuntimeDialect>();
     ctx.loadDialect<imex::ntensor::NTensorDialect>();
     ctx.loadDialect<imex::util::ImexUtilDialect>();
     ctx.loadDialect<mlir::func::FuncDialect>();

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpu.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpu.cpp
@@ -1804,7 +1804,7 @@ static void commonOptPasses(mlir::OpPassManager &pm) {
 
 static void populateLowerToGPUPipelineHigh(mlir::OpPassManager &pm) {
   pm.addNestedPass<mlir::func::FuncOp>(std::make_unique<MarkGpuArraysInputs>());
-  pm.addPass(std::make_unique<ConvertGpuArrays>());
+  //  pm.addPass(std::make_unique<ConvertGpuArrays>());
   pm.addPass(std::make_unique<LowerGpuRangePass>());
   pm.addPass(std::make_unique<LowerGpuBuiltinsPass>());
   commonOptPasses(pm);

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpuTypeConversion.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpuTypeConversion.cpp
@@ -1,0 +1,60 @@
+// Copyright 2022 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "LowerToGpuTypeConversion.hpp"
+
+#include "PyTypeConverter.hpp"
+
+#include "imex/Dialect/ntensor/IR/NTensorOps.hpp"
+
+#include <pybind11/pybind11.h>
+
+#include <mlir/IR/BuiltinTypes.h>
+#include <mlir/IR/Types.h>
+
+namespace py = pybind11;
+
+namespace {
+struct Conversion {
+  Conversion(PyTypeConverter &conv) : converter(conv) {
+    py::object mod = py::module::import("numba_dpcomp.mlir.dpctl_interop");
+    usmArrayType = mod.attr("USMNdArrayType");
+  }
+
+  llvm::Optional<mlir::Type> operator()(mlir::MLIRContext &context,
+                                        py::handle obj) {
+    if (usmArrayType.is_none() || !py::isinstance(obj, usmArrayType))
+      return llvm::None;
+
+    auto elemType = converter.convertType(context, obj.attr("dtype"));
+    if (!elemType)
+      return llvm::None;
+
+    auto ndim = obj.attr("ndim").cast<size_t>();
+    llvm::SmallVector<int64_t> shape(ndim, mlir::ShapedType::kDynamicSize);
+
+    // TODO: environment
+    return imex::ntensor::NTensorType::get(shape, elemType);
+  }
+
+private:
+  PyTypeConverter &converter;
+
+  py::object usmArrayType;
+};
+} // namespace
+
+void populateGpuTypeConverter(PyTypeConverter &converter) {
+  converter.addConversion(Conversion(converter));
+}

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpuTypeConversion.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpuTypeConversion.cpp
@@ -16,6 +16,7 @@
 
 #include "PyTypeConverter.hpp"
 
+#include "imex/Dialect/gpu_runtime/IR/GpuRuntimeOps.hpp"
 #include "imex/Dialect/ntensor/IR/NTensorOps.hpp"
 
 #include <pybind11/pybind11.h>
@@ -46,8 +47,11 @@ struct Conversion {
     auto ndim = obj.attr("ndim").cast<size_t>();
     llvm::SmallVector<int64_t> shape(ndim, mlir::ShapedType::kDynamicSize);
 
-    // TODO: environment
-    return imex::ntensor::NTensorType::get(shape, elemType, /*env*/ {},
+    auto devAttr = mlir::StringAttr::get(
+        &context, obj.attr("filter_string").cast<std::string>());
+    auto env = gpu_runtime::GPURegionDescAttr::get(&context, devAttr);
+
+    return imex::ntensor::NTensorType::get(shape, elemType, env,
                                            llvm::StringRef(layout));
   }
 

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpuTypeConversion.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpuTypeConversion.cpp
@@ -41,11 +41,14 @@ struct Conversion {
     if (!elemType)
       return llvm::None;
 
+    auto layout = obj.attr("layout").cast<std::string>();
+
     auto ndim = obj.attr("ndim").cast<size_t>();
     llvm::SmallVector<int64_t> shape(ndim, mlir::ShapedType::kDynamicSize);
 
     // TODO: environment
-    return imex::ntensor::NTensorType::get(shape, elemType);
+    return imex::ntensor::NTensorType::get(shape, elemType, /*env*/ {},
+                                           llvm::StringRef(layout));
   }
 
 private:

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpuTypeConversion.hpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpuTypeConversion.hpp
@@ -1,0 +1,19 @@
+// Copyright 2022 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+class PyTypeConverter;
+
+void populateGpuTypeConverter(PyTypeConverter &converter);

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.hpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.hpp
@@ -27,9 +27,6 @@ class MLIRContext;
 class TypeConverter;
 } // namespace mlir
 
-void populateArrayTypeConverter(mlir::MLIRContext &context,
-                                mlir::TypeConverter &converter);
-
 void registerPlierToLinalgPipeline(imex::PipelineRegistry &registry);
 
 llvm::StringRef plierToLinalgGenPipelineName();

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalgTypeConversion.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalgTypeConversion.cpp
@@ -45,10 +45,7 @@ struct Conversion {
       return imex::util::TypeVar::get(type);
     }
 
-    // TODO: Our usm_array type is derived from Array and is not yet covered
-    // yet. We do not want to handle it here so check direct type instead of
-    // isinstance.
-    if (obj.get_type().is(array)) {
+    if (py::isinstance(obj, array)) {
       auto elemType = converter.convertType(context, obj.attr("dtype"));
       if (!elemType)
         return llvm::None;


### PR DESCRIPTION
This device name is not yet used in next passes and gpu runtime is not ready, but it will be fixed in follow-up PRs.
