### PR TITLE
Refactor gpu builtins lowering

### DIFF
--- a/numba_dpcomp/numba_dpcomp/mlir/kernel_impl.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/kernel_impl.py
@@ -65,32 +65,6 @@ class _RangeId(ConcreteTemplate):
     ]
 
 
-def _kernel_marker(*args):
-    _stub_error()
-
-
-@registry.register_func("_kernel_marker", _kernel_marker)
-def _kernel_marker_impl(builder, *args):
-    if len(args) == 6:
-        res = 0  # TODO: remove
-        return builder.external_call("kernel_marker", inputs=args, outputs=res)
-
-
-@infer_global(_kernel_marker)
-class _KernelMarkerId(ConcreteTemplate):
-    cases = [
-        signature(
-            types.void,
-            types.int64,
-            types.int64,
-            types.int64,
-            types.int64,
-            types.int64,
-            types.int64,
-        ),
-    ]
-
-
 def _get_default_local_size():
     _stub_error()
 
@@ -117,7 +91,6 @@ class _GetDefaultLocalSizeId(ConcreteTemplate):
 def _kernel_body(global_size, local_size, body, *args):
     x, y, z = global_size
     lx, ly, lz = local_size
-    _kernel_marker(x, y, z, lx, ly, lz)
     gx = (x + lx - 1) // lx
     gy = (y + ly - 1) // ly
     gz = (z + lz - 1) // lz
@@ -138,7 +111,6 @@ def _kernel_body(global_size, local_size, body, *args):
 def _kernel_body_def_size(global_size, body, *args):
     x, y, z = global_size
     lx, ly, lz = _get_default_local_size(x, y, z)
-    _kernel_marker(x, y, z, lx, ly, lz)
     gx = (x + lx - 1) // lx
     gy = (y + ly - 1) // ly
     gz = (z + lz - 1) // lz

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpu.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpu.cpp
@@ -816,32 +816,6 @@ protected:
   }
 };
 
-template <typename Op> struct ConvertOp : public mlir::OpConversionPattern<Op> {
-  using mlir::OpConversionPattern<Op>::OpConversionPattern;
-
-  mlir::LogicalResult
-  matchAndRewrite(Op op, typename Op::Adaptor adaptor,
-                  mlir::ConversionPatternRewriter &rewriter) const override {
-    auto origResTypes = op->getResultTypes();
-    llvm::SmallVector<mlir::Type, 2> newResTypes;
-
-    auto typeConverter = this->getTypeConverter();
-    assert(typeConverter);
-    if (mlir::failed(typeConverter->convertTypes(origResTypes, newResTypes)))
-      return mlir::failure();
-
-    auto attrs = adaptor.getAttributes();
-    llvm::SmallVector<mlir::NamedAttribute> attrsList;
-    attrsList.reserve(attrs.size());
-    for (auto it : attrs)
-      attrsList.emplace_back(it.getName(), it.getValue());
-
-    rewriter.replaceOpWithNewOp<Op>(op, newResTypes, adaptor.getOperands(),
-                                    attrsList);
-    return mlir::success();
-  }
-};
-
 static bool isGpuArray(mlir::Type type) {
   auto tensor = type.dyn_cast<imex::ntensor::NTensorType>();
   if (!tensor)

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpu.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpu.cpp
@@ -1776,7 +1776,7 @@ static void populateLowerToGPUPipelineLow(mlir::OpPassManager &pm) {
   modulePM.addPass(mlir::spirv::createLowerABIAttributesPass());
   modulePM.addPass(mlir::spirv::createUpdateVersionCapabilityExtensionPass());
   pm.addPass(gpu_runtime::createSerializeSPIRVPass());
-  funcPM.addNestedPass<mlir::func::FuncOp>(
+  pm.addNestedPass<mlir::func::FuncOp>(
       gpu_runtime::createConvertGPUDeallocsPass());
   pm.addNestedPass<mlir::func::FuncOp>(gpu_runtime::createGPUExPass());
   commonOptPasses(pm);

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpu.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpu.cpp
@@ -728,7 +728,7 @@ struct GenerateOutlineContextPass
   }
 };
 
-void rerun_std_pipeline(mlir::Operation *op) {
+void rerunStdPipeline(mlir::Operation *op) {
   assert(nullptr != op);
   auto marker =
       mlir::StringAttr::get(op->getContext(), plierToStdPipelineName());
@@ -811,7 +811,7 @@ protected:
       rewriter.replaceOp(op, newOp->getResults());
     }
 
-    rerun_std_pipeline(parent);
+    rerunStdPipeline(parent);
     return mlir::success();
   }
 };
@@ -956,7 +956,7 @@ protected:
         results[i] = rewriter.create<plier::CastOp>(loc, dstType, r);
     }
 
-    rerun_std_pipeline(op);
+    rerunStdPipeline(op);
     rewriter.replaceOp(op, results);
     return mlir::success();
   }

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpu.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpu.cpp
@@ -728,7 +728,7 @@ struct GenerateOutlineContextPass
   }
 };
 
-void rerunStdPipeline(mlir::Operation *op) {
+static void rerunStdPipeline(mlir::Operation *op) {
   assert(nullptr != op);
   auto marker =
       mlir::StringAttr::get(op->getContext(), plierToStdPipelineName());


### PR DESCRIPTION
* Move builtins lowering later in pipeline, after `gpu.launch ` generation to simplify logic
* Remove `_kernel_marker` as it no longer used
* Remove more unused code
