### PR TITLE
Introduce naive tiling pass for gpu

### DIFF
--- a/mlir/include/imex/Conversion/GpuToGpuRuntime.hpp
+++ b/mlir/include/imex/Conversion/GpuToGpuRuntime.hpp
@@ -41,4 +41,8 @@ std::unique_ptr<mlir::Pass> createSerializeSPIRVPass();
 std::unique_ptr<mlir::Pass> createGPUExPass();
 std::unique_ptr<mlir::Pass> createParallelLoopGPUMappingPass();
 
+/// Naively tile parallel loops for gpu, using values obtained from
+/// `suggest_block_size`.
+std::unique_ptr<mlir::Pass> createTileParallelLoopsForGPUPass();
+
 } // namespace gpu_runtime

--- a/mlir/include/imex/Dialect/gpu_runtime/IR/GpuRuntimeOps.td
+++ b/mlir/include/imex/Dialect/gpu_runtime/IR/GpuRuntimeOps.td
@@ -190,9 +190,19 @@ def GPUSuggestBlockSizeOp : GpuRuntime_Op<"suggest_block_size",
 
   let results = (outs Variadic<Index>);
 
-  let builders = [OpBuilder<(ins "::llvm::Optional<::mlir::Value>" : $stream,
-                                 "::mlir::OpFoldResult" : $kernel,
-                                 "::mlir::ValueRange" : $gridSize)>];
+  let builders = [
+    OpBuilder<(ins
+      "::llvm::Optional<::mlir::Value>":$stream,
+      "::mlir::ValueRange":$gridSize,
+      "::mlir::Value":$kernel)>,
+    OpBuilder<(ins
+      "::llvm::Optional<::mlir::Value>":$stream,
+      "::mlir::ValueRange":$gridSize,
+      "::mlir::SymbolRefAttr":$kernel)>,
+    OpBuilder<(ins
+      "::llvm::Optional<::mlir::Value>":$stream,
+      "::mlir::ValueRange":$gridSize)>
+  ];
 
   let extraClassDeclaration = [{
       /// The name of the kernel's containing module.

--- a/mlir/include/imex/Dialect/gpu_runtime/IR/GpuRuntimeOps.td
+++ b/mlir/include/imex/Dialect/gpu_runtime/IR/GpuRuntimeOps.td
@@ -188,7 +188,7 @@ def GPUSuggestBlockSizeOp : GpuRuntime_Op<"suggest_block_size",
                        OptionalAttr<SymbolRefAttr>:$kernelRef,
                        Variadic<Index>:$gridSize);
 
-  let results = (outs Variadic<Index>);
+  let results = (outs Variadic<Index>:$results);
 
   let builders = [
     OpBuilder<(ins
@@ -210,6 +210,10 @@ def GPUSuggestBlockSizeOp : GpuRuntime_Op<"suggest_block_size",
 
       /// The name of the kernel.
       ::mlir::StringAttr getKernelName();
+  }];
+
+  let assemblyFormat = [{
+    attr-dict (`:` $stream^)? ($kernel^)? ($kernelRef^)? `,` $gridSize `->` type($results)
   }];
 }
 

--- a/mlir/lib/Conversion/GpuToGpuRuntime.cpp
+++ b/mlir/lib/Conversion/GpuToGpuRuntime.cpp
@@ -1784,7 +1784,7 @@ struct TileParallelOp : public mlir::OpRewritePattern<mlir::scf::ParallelOp> {
           argMapping[i] =
               rewriter.create<mlir::arith::AddIOp>(loc, val, blockId);
         } else {
-          argMapping[i] = newBlock->getArgument(i + maxLoops - numLoops);
+          argMapping[i] = newBlock->getArgument(i + maxLoops * 2 - numLoops);
         }
       }
     }

--- a/mlir/lib/Conversion/GpuToGpuRuntime.cpp
+++ b/mlir/lib/Conversion/GpuToGpuRuntime.cpp
@@ -1681,6 +1681,142 @@ struct GPUExPass
   }
 };
 
+struct TileParallelOp : public mlir::OpRewritePattern<mlir::scf::ParallelOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::scf::ParallelOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+    // Process only loops inside gpu region.
+    auto envOp = op->getParentOfType<imex::util::EnvironmentRegionOp>();
+    if (!envOp || !envOp.getEnvironment().isa<gpu_runtime::GPURegionDescAttr>())
+      return mlir::failure();
+
+    // Process only outermost loops without mappings.
+    if (op->getParentOfType<mlir::scf::ParallelOp>() ||
+        op->hasAttr(mlir::gpu::getMappingAttrName()))
+      return mlir::failure();
+
+    auto oldLowerBounds = op.getLowerBound();
+    auto oldUpperBounds = op.getUpperBound();
+    auto oldSteps = op.getStep();
+    auto oldLoopsCount = static_cast<unsigned>(oldSteps.size());
+
+    const unsigned maxLoops = 3;
+    // Only unit step is supported and at most 3 loops.
+    unsigned numLoops = 0;
+    for (auto [start, step] : llvm::zip(oldLowerBounds.take_front(maxLoops),
+                                        oldSteps.take_front(maxLoops)))
+      if (mlir::isConstantIntValue(start, 0) &&
+          mlir::isConstantIntValue(step, 1))
+        ++numLoops;
+
+    // No suitable loops.
+    if (numLoops == 0)
+      return mlir::failure();
+
+    auto loc = op->getLoc();
+    auto zero = rewriter.create<mlir::arith::ConstantIndexOp>(loc, 0);
+    auto one = rewriter.create<mlir::arith::ConstantIndexOp>(loc, 1);
+
+    std::array<mlir::Value, 3> globalSize;
+    globalSize.fill(one);
+    llvm::copy(oldUpperBounds.take_front(numLoops), globalSize.begin());
+
+    llvm::Optional<mlir::Value> stream;
+    auto localSize =
+        rewriter
+            .create<gpu_runtime::GPUSuggestBlockSizeOp>(loc, stream, globalSize)
+            ->getResults();
+
+    llvm::SmallVector<mlir::Value> newLowerBounds;
+    llvm::SmallVector<mlir::Value> newUpperBounds;
+    llvm::SmallVector<mlir::Value> newSteps;
+
+    // Insert grid vars.
+    for (auto i : llvm::seq(0u, maxLoops)) {
+      newLowerBounds.emplace_back(zero);
+      newSteps.emplace_back(one);
+      if (i < numLoops) {
+        auto oldUpperBound = oldUpperBounds[i];
+        mlir::Value newUpperBound = rewriter.create<mlir::arith::CeilDivUIOp>(
+            loc, oldUpperBound, localSize[i]);
+        newUpperBounds.emplace_back(newUpperBound);
+      } else {
+        newUpperBounds.emplace_back(one);
+      }
+    }
+
+    // Insert block vars.
+    for (auto i : llvm::seq(0u, maxLoops)) {
+      newLowerBounds.emplace_back(zero);
+      newSteps.emplace_back(one);
+      if (i < numLoops) {
+        newUpperBounds.emplace_back(localSize[i]);
+      } else {
+        newUpperBounds.emplace_back(one);
+      }
+    }
+
+    for (auto i : llvm::seq(numLoops, oldLoopsCount)) {
+      newLowerBounds.emplace_back(oldLowerBounds[i]);
+      newUpperBounds.emplace_back(oldUpperBounds[i]);
+      newSteps.emplace_back(oldSteps[i]);
+    }
+
+    auto initVals = op.getInitVals();
+    auto newOp = rewriter.create<mlir::scf::ParallelOp>(
+        loc, newLowerBounds, newUpperBounds, newSteps, initVals);
+    mlir::Block *originalBlock = op.getBody();
+    mlir::Block *newBlock = newOp.getBody();
+
+    llvm::SmallVector<mlir::Value> argMapping(oldLoopsCount);
+    for (auto i : llvm::seq(0u, oldLoopsCount)) {
+      auto argIndex = (i < numLoops ? i : i + maxLoops - numLoops);
+      argMapping[i] = newBlock->getArgument(argIndex);
+    }
+    rewriter.eraseOp(newBlock->getTerminator()); // Erase exisitng yield.
+    rewriter.mergeBlocks(originalBlock, newBlock, argMapping);
+    newBlock->dump();
+    rewriter.replaceOp(op, newOp->getResults());
+
+    auto newLoopsCount = static_cast<unsigned>(newSteps.size());
+    auto identityMap = rewriter.getDimIdentityMap();
+    llvm::SmallVector<mlir::gpu::ParallelLoopDimMappingAttr> mapping(
+        newLoopsCount);
+    for (auto i : llvm::seq(0u, newLoopsCount))
+      mapping[i] = rewriter.getAttr<mlir::gpu::ParallelLoopDimMappingAttr>(
+          getProcessor(i), identityMap, identityMap);
+
+    return mlir::gpu::setMappingAttr(newOp, mapping);
+  }
+};
+
+struct TileParallelLoopsForGPUPass
+    : public mlir::PassWrapper<TileParallelLoopsForGPUPass,
+                               mlir::OperationPass<mlir::func::FuncOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TileParallelLoopsForGPUPass)
+
+  virtual void
+  getDependentDialects(mlir::DialectRegistry &registry) const override {
+    registry.insert<gpu_runtime::GpuRuntimeDialect>();
+    registry.insert<imex::util::ImexUtilDialect>();
+    registry.insert<mlir::arith::ArithDialect>();
+    registry.insert<mlir::gpu::GPUDialect>();
+    registry.insert<mlir::scf::SCFDialect>();
+  }
+
+  void runOnOperation() override {
+    auto *ctx = &getContext();
+    mlir::RewritePatternSet patterns(ctx);
+
+    patterns.insert<TileParallelOp>(ctx);
+
+    (void)mlir::applyPatternsAndFoldGreedily(getOperation(),
+                                             std::move(patterns));
+  }
+};
+
 } // namespace
 
 // Expose the passes to the outside world
@@ -1719,4 +1855,8 @@ std::unique_ptr<mlir::Pass> gpu_runtime::createGPUExPass() {
 
 std::unique_ptr<mlir::Pass> gpu_runtime::createParallelLoopGPUMappingPass() {
   return std::make_unique<ParallelLoopGPUMappingPass>();
+}
+
+std::unique_ptr<mlir::Pass> gpu_runtime::createTileParallelLoopsForGPUPass() {
+  return std::make_unique<TileParallelLoopsForGPUPass>();
 }

--- a/mlir/lib/Conversion/GpuToGpuRuntime.cpp
+++ b/mlir/lib/Conversion/GpuToGpuRuntime.cpp
@@ -1703,7 +1703,7 @@ struct TileParallelOp : public mlir::OpRewritePattern<mlir::scf::ParallelOp> {
     auto oldLoopsCount = static_cast<unsigned>(oldSteps.size());
 
     const unsigned maxLoops = 3;
-    // Only unit step is supported and at most 3 loops.
+    // Only unit step is supported and iteration must start from 0.
     unsigned numLoops = 0;
     for (auto [start, step] : llvm::zip(oldLowerBounds.take_front(maxLoops),
                                         oldSteps.take_front(maxLoops)))
@@ -1716,8 +1716,8 @@ struct TileParallelOp : public mlir::OpRewritePattern<mlir::scf::ParallelOp> {
       return mlir::failure();
 
     auto loc = op->getLoc();
-    auto zero = rewriter.create<mlir::arith::ConstantIndexOp>(loc, 0);
-    auto one = rewriter.create<mlir::arith::ConstantIndexOp>(loc, 1);
+    mlir::Value zero = rewriter.create<mlir::arith::ConstantIndexOp>(loc, 0);
+    mlir::Value one = rewriter.create<mlir::arith::ConstantIndexOp>(loc, 1);
 
     std::array<mlir::Value, 3> globalSize;
     globalSize.fill(one);

--- a/mlir/lib/Conversion/GpuToGpuRuntime.cpp
+++ b/mlir/lib/Conversion/GpuToGpuRuntime.cpp
@@ -1697,6 +1697,10 @@ struct TileParallelOp : public mlir::OpRewritePattern<mlir::scf::ParallelOp> {
         op->hasAttr(mlir::gpu::getMappingAttrName()))
       return mlir::failure();
 
+    // Reductions is not supported yet.
+    if (!op.getBody()->getOps<mlir::scf::ReduceOp>().empty())
+      return mlir::failure();
+
     auto oldLowerBounds = op.getLowerBound();
     auto oldUpperBounds = op.getUpperBound();
     auto oldSteps = op.getStep();

--- a/mlir/lib/Conversion/GpuToGpuRuntime.cpp
+++ b/mlir/lib/Conversion/GpuToGpuRuntime.cpp
@@ -1790,7 +1790,6 @@ struct TileParallelOp : public mlir::OpRewritePattern<mlir::scf::ParallelOp> {
     }
     rewriter.eraseOp(newBlock->getTerminator()); // Erase exisitng yield.
     rewriter.mergeBlocks(originalBlock, newBlock, argMapping);
-    newBlock->dump();
     rewriter.replaceOp(op, newOp->getResults());
 
     auto newLoopsCount = static_cast<unsigned>(newSteps.size());

--- a/mlir/lib/Conversion/GpuToGpuRuntime.cpp
+++ b/mlir/lib/Conversion/GpuToGpuRuntime.cpp
@@ -1790,7 +1790,7 @@ struct TileParallelOp : public mlir::OpRewritePattern<mlir::scf::ParallelOp> {
           val = rewriter.create<mlir::arith::AddIOp>(loc, val, blockId);
           argMapping[i] = val;
           mlir::Value in = rewriter.createOrFold<mlir::arith::CmpIOp>(
-              loc, mlir::arith::CmpIPredicate::ult, val, gridSize);
+              loc, mlir::arith::CmpIPredicate::slt, val, gridSize);
           if (0 == i) {
             inBounds = in;
           } else {

--- a/mlir/lib/Conversion/GpuToGpuRuntime.cpp
+++ b/mlir/lib/Conversion/GpuToGpuRuntime.cpp
@@ -1518,7 +1518,7 @@ struct ExpandSuggestBlockSizeOp
         [&](mlir::OpBuilder &builder, mlir::Location loc, mlir::Value stream,
             mlir::Value kernel) {
           return builder.create<gpu_runtime::GPUSuggestBlockSizeOp>(
-              loc, stream, kernel, op.getGridSize());
+              loc, stream, op.getGridSize(), kernel);
         });
   }
 };

--- a/mlir/lib/Conversion/GpuToGpuRuntime.cpp
+++ b/mlir/lib/Conversion/GpuToGpuRuntime.cpp
@@ -44,6 +44,17 @@
 #include <llvm/ADT/SmallBitVector.h>
 
 namespace {
+static mlir::gpu::Processor getProcessor(unsigned val) {
+  const mlir::gpu::Processor mapping[] = {
+      mlir::gpu::Processor::BlockX,  mlir::gpu::Processor::BlockY,
+      mlir::gpu::Processor::BlockZ,  mlir::gpu::Processor::ThreadX,
+      mlir::gpu::Processor::ThreadY, mlir::gpu::Processor::ThreadZ,
+  };
+  if (val >= std::size(mapping))
+    return mlir::gpu::Processor::Sequential;
+
+  return mapping[val];
+}
 struct ParallelLoopGPUMappingPass
     : public mlir::PassWrapper<ParallelLoopGPUMappingPass,
                                mlir::OperationPass<mlir::func::FuncOp>> {
@@ -61,18 +72,6 @@ struct ParallelLoopGPUMappingPass
         return;
 
       auto &region = envOp.getRegion();
-
-      auto getProcessor = [](unsigned val) -> mlir::gpu::Processor {
-        const mlir::gpu::Processor mapping[] = {
-            mlir::gpu::Processor::BlockX,  mlir::gpu::Processor::BlockY,
-            mlir::gpu::Processor::BlockZ,  mlir::gpu::Processor::ThreadX,
-            mlir::gpu::Processor::ThreadY, mlir::gpu::Processor::ThreadZ,
-        };
-        if (val >= std::size(mapping))
-          return mlir::gpu::Processor::Sequential;
-
-        return mapping[val];
-      };
 
       mlir::OpBuilder builder(&getContext());
       auto identityMap = builder.getDimIdentityMap();

--- a/mlir/lib/Conversion/GpuToGpuRuntime.cpp
+++ b/mlir/lib/Conversion/GpuToGpuRuntime.cpp
@@ -78,7 +78,7 @@ struct ParallelLoopGPUMappingPass
       llvm::SmallVector<mlir::gpu::ParallelLoopDimMappingAttr> mapping;
       for (auto &op : llvm::make_early_inc_range(region.front())) {
         auto parallel = mlir::dyn_cast<mlir::scf::ParallelOp>(op);
-        if (!parallel)
+        if (!parallel || parallel->hasAttr(mlir::gpu::getMappingAttrName()))
           continue;
 
         auto numLoops = parallel.getNumLoops();

--- a/mlir/lib/Dialect/gpu_runtime/IR/GpuRuntimeOps.cpp
+++ b/mlir/lib/Dialect/gpu_runtime/IR/GpuRuntimeOps.cpp
@@ -168,22 +168,45 @@ void LaunchGpuKernelOp::build(::mlir::OpBuilder &builder,
 void GPUSuggestBlockSizeOp::build(::mlir::OpBuilder &odsBuilder,
                                   ::mlir::OperationState &odsState,
                                   ::llvm::Optional<::mlir::Value> stream,
-                                  ::mlir::OpFoldResult kernel,
+                                  ::mlir::ValueRange gridSize,
+                                  ::mlir::Value kernel) {
+  auto dimCount = gridSize.size();
+  assert(dimCount > 0 && dimCount <= 3);
+  llvm::SmallVector<mlir::Type, 3> resTypes(dimCount,
+                                            odsBuilder.getIndexType());
+
+  GPUSuggestBlockSizeOp::build(odsBuilder, odsState, resTypes,
+                               stream.value_or(mlir::Value{}), kernel,
+                               mlir::SymbolRefAttr{}, gridSize);
+}
+
+void GPUSuggestBlockSizeOp::build(::mlir::OpBuilder &odsBuilder,
+                                  ::mlir::OperationState &odsState,
+                                  ::llvm::Optional<::mlir::Value> stream,
+                                  ::mlir::ValueRange gridSize,
+                                  ::mlir::SymbolRefAttr kernel) {
+  auto dimCount = gridSize.size();
+  assert(dimCount > 0 && dimCount <= 3);
+  llvm::SmallVector<mlir::Type, 3> resTypes(dimCount,
+                                            odsBuilder.getIndexType());
+
+  GPUSuggestBlockSizeOp::build(odsBuilder, odsState, resTypes,
+                               stream.value_or(mlir::Value{}), mlir::Value{},
+                               kernel, gridSize);
+}
+
+void GPUSuggestBlockSizeOp::build(::mlir::OpBuilder &odsBuilder,
+                                  ::mlir::OperationState &odsState,
+                                  ::llvm::Optional<::mlir::Value> stream,
                                   ::mlir::ValueRange gridSize) {
   auto dimCount = gridSize.size();
   assert(dimCount > 0 && dimCount <= 3);
   llvm::SmallVector<mlir::Type, 3> resTypes(dimCount,
                                             odsBuilder.getIndexType());
-  mlir::Value kernVal;
-  mlir::SymbolRefAttr kernRef;
-  if (kernel.is<mlir::Value>())
-    kernVal = kernel.get<mlir::Value>();
-  else
-    kernRef = kernel.get<mlir::Attribute>().cast<mlir::SymbolRefAttr>();
 
   GPUSuggestBlockSizeOp::build(odsBuilder, odsState, resTypes,
-                               stream.value_or(mlir::Value{}), kernVal, kernRef,
-                               gridSize);
+                               stream.value_or(mlir::Value{}), mlir::Value{},
+                               mlir::SymbolRefAttr{}, gridSize);
 }
 
 mlir::StringAttr GPUSuggestBlockSizeOp::getKernelModuleName() {

--- a/mlir/test/Transforms/gpux-tile-parallel.mlir
+++ b/mlir/test/Transforms/gpux-tile-parallel.mlir
@@ -32,3 +32,50 @@ func.func @check1D(%arg0: memref<?xf64>, %arg1: memref<?xf64>) {
   }
   return
 }
+
+// -----
+
+// CHECK-LABEL: check3D
+// CHECK-SAME: (%[[MEM1:.*]]: memref<?x?x?xf64>, %[[MEM2:.*]]: memref<?x?x?xf64>)
+// CHECK: %[[C2:.*]] = arith.constant 2 : index
+// CHECK: %[[C1:.*]] = arith.constant 1 : index
+// CHECK: %[[C0:.*]] = arith.constant 0 : index
+// CHECK: %[[DIM1:.*]] = memref.dim %[[MEM1]], %[[C0]] : memref<?x?x?xf64>
+// CHECK: %[[DIM2:.*]] = memref.dim %[[MEM1]], %[[C1]] : memref<?x?x?xf64>
+// CHECK: %[[DIM3:.*]] = memref.dim %[[MEM1]], %[[C2]] : memref<?x?x?xf64>
+// CHECK: imex_util.env_region #gpu_runtime.region_desc<device = "test">
+// CHECK: %[[B:.*]]:3 = gpu_runtime.suggest_block_size, %[[DIM1]], %[[DIM2]], %[[DIM3]] -> index, index, index
+// CHECK: %[[G1:.*]] = arith.ceildivui %[[DIM1]], %[[B]]#0 : index
+// CHECK: %[[G2:.*]] = arith.ceildivui %[[DIM2]], %[[B]]#1 : index
+// CHECK: %[[G3:.*]] = arith.ceildivui %[[DIM3]], %[[B]]#2 : index
+// CHECK: scf.parallel
+// CHECK-SAME: (%[[ARG1:.*]], %[[ARG2:.*]], %[[ARG3:.*]], %[[ARG4:.*]], %[[ARG5:.*]], %[[ARG6:.*]]) =
+// CHECK-SAME: (%[[C0]], %[[C0]], %[[C0]], %[[C0]], %[[C0]], %[[C0]]) to
+// CHECK-SAME: (%[[G1]], %[[G2]], %[[G3]], %[[B]]#0, %[[B]]#1, %[[B]]#2) step
+// CHECK-SAME: (%[[C1]], %[[C1]], %[[C1]], %[[C1]], %[[C1]], %[[C1]])
+// CHECK: %[[IDX1:.*]] = arith.muli %[[ARG1]], %[[B]]#0 : index
+// CHECK: %[[IDX2:.*]] = arith.addi %[[IDX1]], %[[ARG4]] : index
+// CHECK: %[[IDX3:.*]] = arith.muli %[[ARG2]], %[[B]]#1 : index
+// CHECK: %[[IDX4:.*]] = arith.addi %[[IDX3]], %[[ARG5]] : index
+// CHECK: %[[IDX5:.*]] = arith.muli %[[ARG3]], %[[B]]#2 : index
+// CHECK: %[[IDX6:.*]] = arith.addi %[[IDX5]], %[[ARG6]] : index
+// CHECK: %[[VAL:.*]] = memref.load %[[MEM1]][%[[IDX2]], %[[IDX4]], %[[IDX6]]] : memref<?x?x?xf64>
+// CHECK: memref.store %[[VAL]], %[[MEM2]][%[[IDX2]], %[[IDX4]], %[[IDX6]]] : memref<?x?x?xf64>
+// CHECK: {mapping = [#gpu.loop_dim_map<processor = block_x, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = block_y, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = block_z, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = thread_x, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = thread_y, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = thread_z, map = (d0) -> (d0), bound = (d0) -> (d0)>]}
+// CHECK: return
+func.func @check3D(%arg0: memref<?x?x?xf64>, %arg1: memref<?x?x?xf64>) {
+  %c2 = arith.constant 2 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %0 = memref.dim %arg0, %c0 : memref<?x?x?xf64>
+  %1 = memref.dim %arg0, %c1 : memref<?x?x?xf64>
+  %2 = memref.dim %arg0, %c2 : memref<?x?x?xf64>
+  imex_util.env_region #gpu_runtime.region_desc<device = "test"> {
+    scf.parallel (%arg4, %arg5, %arg6) = (%c0, %c0, %c0) to (%0, %1, %2) step (%c1, %c1, %c1) {
+      %3 = memref.load %arg0[%arg4, %arg5, %arg6] : memref<?x?x?xf64>
+      memref.store %3, %arg1[%arg4, %arg5, %arg6] : memref<?x?x?xf64>
+      scf.yield
+    }
+  }
+  return
+}

--- a/mlir/test/Transforms/gpux-tile-parallel.mlir
+++ b/mlir/test/Transforms/gpux-tile-parallel.mlir
@@ -79,3 +79,54 @@ func.func @check3D(%arg0: memref<?x?x?xf64>, %arg1: memref<?x?x?xf64>) {
   }
   return
 }
+
+// -----
+
+// CHECK-LABEL: check4D
+// CHECK-SAME: (%[[MEM1:.*]]: memref<?x?x?x?xf64>, %[[MEM2:.*]]: memref<?x?x?x?xf64>)
+// CHECK: %[[C3:.*]] = arith.constant 3 : index
+// CHECK: %[[C2:.*]] = arith.constant 2 : index
+// CHECK: %[[C1:.*]] = arith.constant 1 : index
+// CHECK: %[[C0:.*]] = arith.constant 0 : index
+// CHECK: %[[DIM1:.*]] = memref.dim %[[MEM1]], %[[C0]] : memref<?x?x?x?xf64>
+// CHECK: %[[DIM2:.*]] = memref.dim %[[MEM1]], %[[C1]] : memref<?x?x?x?xf64>
+// CHECK: %[[DIM3:.*]] = memref.dim %[[MEM1]], %[[C2]] : memref<?x?x?x?xf64>
+// CHECK: %[[DIM4:.*]] = memref.dim %[[MEM1]], %[[C3]] : memref<?x?x?x?xf64>
+// CHECK: imex_util.env_region #gpu_runtime.region_desc<device = "test">
+// CHECK: %[[B:.*]]:3 = gpu_runtime.suggest_block_size, %[[DIM1]], %[[DIM2]], %[[DIM3]] -> index, index, index
+// CHECK: %[[G1:.*]] = arith.ceildivui %[[DIM1]], %[[B]]#0 : index
+// CHECK: %[[G2:.*]] = arith.ceildivui %[[DIM2]], %[[B]]#1 : index
+// CHECK: %[[G3:.*]] = arith.ceildivui %[[DIM3]], %[[B]]#2 : index
+// CHECK: scf.parallel
+// CHECK-SAME: (%[[ARG1:.*]], %[[ARG2:.*]], %[[ARG3:.*]], %[[ARG4:.*]], %[[ARG5:.*]], %[[ARG6:.*]], %[[ARG7:.*]]) =
+// CHECK-SAME: (%[[C0]], %[[C0]], %[[C0]], %[[C0]], %[[C0]], %[[C0]], %[[C0]]) to
+// CHECK-SAME: (%[[G1]], %[[G2]], %[[G3]], %[[B]]#0, %[[B]]#1, %[[B]]#2, %[[DIM4]]) step
+// CHECK-SAME: (%[[C1]], %[[C1]], %[[C1]], %[[C1]], %[[C1]], %[[C1]], %[[C1]])
+// CHECK: %[[IDX1:.*]] = arith.muli %[[ARG1]], %[[B]]#0 : index
+// CHECK: %[[IDX2:.*]] = arith.addi %[[IDX1]], %[[ARG4]] : index
+// CHECK: %[[IDX3:.*]] = arith.muli %[[ARG2]], %[[B]]#1 : index
+// CHECK: %[[IDX4:.*]] = arith.addi %[[IDX3]], %[[ARG5]] : index
+// CHECK: %[[IDX5:.*]] = arith.muli %[[ARG3]], %[[B]]#2 : index
+// CHECK: %[[IDX6:.*]] = arith.addi %[[IDX5]], %[[ARG6]] : index
+// CHECK: %[[VAL:.*]] = memref.load %[[MEM1]][%[[IDX2]], %[[IDX4]], %[[IDX6]], %[[ARG7]]] : memref<?x?x?x?xf64>
+// CHECK: memref.store %[[VAL]], %[[MEM2]][%[[IDX2]], %[[IDX4]], %[[IDX6]], %[[ARG7]]] : memref<?x?x?x?xf64>
+// CHECK: {mapping = [#gpu.loop_dim_map<processor = block_x, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = block_y, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = block_z, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = thread_x, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = thread_y, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = thread_z, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = sequential, map = (d0) -> (d0), bound = (d0) -> (d0)>]}
+// CHECK: return
+func.func @check4D(%arg0: memref<?x?x?x?xf64>, %arg1: memref<?x?x?x?xf64>) {
+  %c3 = arith.constant 3 : index
+  %c2 = arith.constant 2 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %0 = memref.dim %arg0, %c0 : memref<?x?x?x?xf64>
+  %1 = memref.dim %arg0, %c1 : memref<?x?x?x?xf64>
+  %2 = memref.dim %arg0, %c2 : memref<?x?x?x?xf64>
+  %3 = memref.dim %arg0, %c3 : memref<?x?x?x?xf64>
+  imex_util.env_region #gpu_runtime.region_desc<device = "test"> {
+    scf.parallel (%arg4, %arg5, %arg6, %arg7) = (%c0, %c0, %c0, %c0) to (%0, %1, %2, %3) step (%c1, %c1, %c1, %c1) {
+      %4 = memref.load %arg0[%arg4, %arg5, %arg6, %arg7] : memref<?x?x?x?xf64>
+      memref.store %4, %arg1[%arg4, %arg5, %arg6, %arg7] : memref<?x?x?x?xf64>
+      scf.yield
+    }
+  }
+  return
+}

--- a/mlir/test/Transforms/gpux-tile-parallel.mlir
+++ b/mlir/test/Transforms/gpux-tile-parallel.mlir
@@ -1,0 +1,34 @@
+// RUN: imex-opt --gpux-tile-parallel-loops --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: check1D
+// CHECK-SAME: (%[[MEM1:.*]]: memref<?xf64>, %[[MEM2:.*]]: memref<?xf64>)
+// CHECK: %[[C1:.*]] = arith.constant 1 : index
+// CHECK: %[[C0:.*]] = arith.constant 0 : index
+// CHECK: %[[DIM1:.*]] = memref.dim %[[MEM1]], %[[C0]] : memref<?xf64>
+// CHECK: imex_util.env_region #gpu_runtime.region_desc<device = "test">
+// CHECK: %[[B:.*]]:3 = gpu_runtime.suggest_block_size, %[[DIM1]], %[[C1]], %[[C1]] -> index, index, index
+// CHECK: %[[G1:.*]] = arith.ceildivui %[[DIM1]], %[[B]]#0 : index
+// CHECK: scf.parallel
+// CHECK-SAME: (%[[ARG1:.*]], %[[ARG2:.*]], %[[ARG3:.*]], %[[ARG4:.*]], %[[ARG5:.*]], %[[ARG6:.*]]) =
+// CHECK-SAME: (%[[C0]], %[[C0]], %[[C0]], %[[C0]], %[[C0]], %[[C0]]) to
+// CHECK-SAME: (%[[G1]], %[[C1]], %[[C1]], %[[B]]#0, %[[C1]], %[[C1]]) step
+// CHECK-SAME: (%[[C1]], %[[C1]], %[[C1]], %[[C1]], %[[C1]], %[[C1]])
+// CHECK: %[[IDX1:.*]] = arith.muli %[[ARG1]], %[[B]]#0 : index
+// CHECK: %[[IDX2:.*]] = arith.addi %[[IDX1]], %[[ARG4]] : index
+// CHECK: %[[VAL:.*]] = memref.load %[[MEM1]][%[[IDX2]]] : memref<?xf64>
+// CHECK: memref.store %[[VAL]], %[[MEM2]][%[[IDX2]]] : memref<?xf64>
+// CHECK: {mapping = [#gpu.loop_dim_map<processor = block_x, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = block_y, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = block_z, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = thread_x, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = thread_y, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = thread_z, map = (d0) -> (d0), bound = (d0) -> (d0)>]}
+// CHECK: return
+func.func @check1D(%arg0: memref<?xf64>, %arg1: memref<?xf64>) {
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %0 = memref.dim %arg0, %c0 : memref<?xf64>
+  imex_util.env_region #gpu_runtime.region_desc<device = "test"> {
+    scf.parallel (%arg4) = (%c0) to (%0) step (%c1) {
+      %2 = memref.load %arg0[%arg4] : memref<?xf64>
+      memref.store %2, %arg1[%arg4] : memref<?xf64>
+      scf.yield
+    }
+  }
+  return
+}

--- a/mlir/test/Transforms/gpux-tile-parallel.mlir
+++ b/mlir/test/Transforms/gpux-tile-parallel.mlir
@@ -15,6 +15,9 @@
 // CHECK-SAME: (%[[C1]], %[[C1]], %[[C1]], %[[C1]], %[[C1]], %[[C1]])
 // CHECK: %[[IDX1:.*]] = arith.muli %[[ARG1]], %[[B]]#0 : index
 // CHECK: %[[IDX2:.*]] = arith.addi %[[IDX1]], %[[ARG4]] : index
+// CHECK: %[[IN1:.*]] = arith.cmpi ult, %[[IDX2]], %[[DIM1]] : index
+// CHECK: scf.if %[[IN1]] {
+// CHECK-NOT: }
 // CHECK: %[[VAL:.*]] = memref.load %[[MEM1]][%[[IDX2]]] : memref<?xf64>
 // CHECK: memref.store %[[VAL]], %[[MEM2]][%[[IDX2]]] : memref<?xf64>
 // CHECK: {mapping = [#gpu.loop_dim_map<processor = block_x, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = block_y, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = block_z, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = thread_x, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = thread_y, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = thread_z, map = (d0) -> (d0), bound = (d0) -> (d0)>]}
@@ -55,10 +58,17 @@ func.func @check1D(%arg0: memref<?xf64>, %arg1: memref<?xf64>) {
 // CHECK-SAME: (%[[C1]], %[[C1]], %[[C1]], %[[C1]], %[[C1]], %[[C1]])
 // CHECK: %[[IDX1:.*]] = arith.muli %[[ARG1]], %[[B]]#0 : index
 // CHECK: %[[IDX2:.*]] = arith.addi %[[IDX1]], %[[ARG4]] : index
+// CHECK: %[[IN1:.*]] = arith.cmpi ult, %[[IDX2]], %[[DIM1]] : index
 // CHECK: %[[IDX3:.*]] = arith.muli %[[ARG2]], %[[B]]#1 : index
 // CHECK: %[[IDX4:.*]] = arith.addi %[[IDX3]], %[[ARG5]] : index
+// CHECK: %[[IN2:.*]] = arith.cmpi ult, %[[IDX4]], %[[DIM2]] : index
+// CHECK: %[[IN3:.*]] = arith.andi %[[IN1]], %[[IN2]] : i1
 // CHECK: %[[IDX5:.*]] = arith.muli %[[ARG3]], %[[B]]#2 : index
 // CHECK: %[[IDX6:.*]] = arith.addi %[[IDX5]], %[[ARG6]] : index
+// CHECK: %[[IN4:.*]] = arith.cmpi ult, %[[IDX6]], %[[DIM3]] : index
+// CHECK: %[[IN5:.*]] = arith.andi %[[IN3]], %[[IN4]] : i1
+// CHECK: scf.if %[[IN5]] {
+// CHECK-NOT: }
 // CHECK: %[[VAL:.*]] = memref.load %[[MEM1]][%[[IDX2]], %[[IDX4]], %[[IDX6]]] : memref<?x?x?xf64>
 // CHECK: memref.store %[[VAL]], %[[MEM2]][%[[IDX2]], %[[IDX4]], %[[IDX6]]] : memref<?x?x?xf64>
 // CHECK: {mapping = [#gpu.loop_dim_map<processor = block_x, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = block_y, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = block_z, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = thread_x, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = thread_y, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = thread_z, map = (d0) -> (d0), bound = (d0) -> (d0)>]}
@@ -104,10 +114,17 @@ func.func @check3D(%arg0: memref<?x?x?xf64>, %arg1: memref<?x?x?xf64>) {
 // CHECK-SAME: (%[[C1]], %[[C1]], %[[C1]], %[[C1]], %[[C1]], %[[C1]], %[[C1]])
 // CHECK: %[[IDX1:.*]] = arith.muli %[[ARG1]], %[[B]]#0 : index
 // CHECK: %[[IDX2:.*]] = arith.addi %[[IDX1]], %[[ARG4]] : index
+// CHECK: %[[IN1:.*]] = arith.cmpi ult, %[[IDX2]], %[[DIM1]] : index
 // CHECK: %[[IDX3:.*]] = arith.muli %[[ARG2]], %[[B]]#1 : index
 // CHECK: %[[IDX4:.*]] = arith.addi %[[IDX3]], %[[ARG5]] : index
+// CHECK: %[[IN2:.*]] = arith.cmpi ult, %[[IDX4]], %[[DIM2]] : index
+// CHECK: %[[IN3:.*]] = arith.andi %[[IN1]], %[[IN2]] : i1
 // CHECK: %[[IDX5:.*]] = arith.muli %[[ARG3]], %[[B]]#2 : index
 // CHECK: %[[IDX6:.*]] = arith.addi %[[IDX5]], %[[ARG6]] : index
+// CHECK: %[[IN4:.*]] = arith.cmpi ult, %[[IDX6]], %[[DIM3]] : index
+// CHECK: %[[IN5:.*]] = arith.andi %[[IN3]], %[[IN4]] : i1
+// CHECK: scf.if %[[IN5]] {
+// CHECK-NOT: }
 // CHECK: %[[VAL:.*]] = memref.load %[[MEM1]][%[[IDX2]], %[[IDX4]], %[[IDX6]], %[[ARG7]]] : memref<?x?x?x?xf64>
 // CHECK: memref.store %[[VAL]], %[[MEM2]][%[[IDX2]], %[[IDX4]], %[[IDX6]], %[[ARG7]]] : memref<?x?x?x?xf64>
 // CHECK: {mapping = [#gpu.loop_dim_map<processor = block_x, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = block_y, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = block_z, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = thread_x, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = thread_y, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = thread_z, map = (d0) -> (d0), bound = (d0) -> (d0)>, #gpu.loop_dim_map<processor = sequential, map = (d0) -> (d0), bound = (d0) -> (d0)>]}

--- a/mlir/test/Transforms/gpux-tile-parallel.mlir
+++ b/mlir/test/Transforms/gpux-tile-parallel.mlir
@@ -15,7 +15,7 @@
 // CHECK-SAME: (%[[C1]], %[[C1]], %[[C1]], %[[C1]], %[[C1]], %[[C1]])
 // CHECK: %[[IDX1:.*]] = arith.muli %[[ARG1]], %[[B]]#0 : index
 // CHECK: %[[IDX2:.*]] = arith.addi %[[IDX1]], %[[ARG4]] : index
-// CHECK: %[[IN1:.*]] = arith.cmpi ult, %[[IDX2]], %[[DIM1]] : index
+// CHECK: %[[IN1:.*]] = arith.cmpi slt, %[[IDX2]], %[[DIM1]] : index
 // CHECK: scf.if %[[IN1]] {
 // CHECK-NOT: }
 // CHECK: %[[VAL:.*]] = memref.load %[[MEM1]][%[[IDX2]]] : memref<?xf64>
@@ -58,14 +58,14 @@ func.func @check1D(%arg0: memref<?xf64>, %arg1: memref<?xf64>) {
 // CHECK-SAME: (%[[C1]], %[[C1]], %[[C1]], %[[C1]], %[[C1]], %[[C1]])
 // CHECK: %[[IDX1:.*]] = arith.muli %[[ARG1]], %[[B]]#0 : index
 // CHECK: %[[IDX2:.*]] = arith.addi %[[IDX1]], %[[ARG4]] : index
-// CHECK: %[[IN1:.*]] = arith.cmpi ult, %[[IDX2]], %[[DIM1]] : index
+// CHECK: %[[IN1:.*]] = arith.cmpi slt, %[[IDX2]], %[[DIM1]] : index
 // CHECK: %[[IDX3:.*]] = arith.muli %[[ARG2]], %[[B]]#1 : index
 // CHECK: %[[IDX4:.*]] = arith.addi %[[IDX3]], %[[ARG5]] : index
-// CHECK: %[[IN2:.*]] = arith.cmpi ult, %[[IDX4]], %[[DIM2]] : index
+// CHECK: %[[IN2:.*]] = arith.cmpi slt, %[[IDX4]], %[[DIM2]] : index
 // CHECK: %[[IN3:.*]] = arith.andi %[[IN1]], %[[IN2]] : i1
 // CHECK: %[[IDX5:.*]] = arith.muli %[[ARG3]], %[[B]]#2 : index
 // CHECK: %[[IDX6:.*]] = arith.addi %[[IDX5]], %[[ARG6]] : index
-// CHECK: %[[IN4:.*]] = arith.cmpi ult, %[[IDX6]], %[[DIM3]] : index
+// CHECK: %[[IN4:.*]] = arith.cmpi slt, %[[IDX6]], %[[DIM3]] : index
 // CHECK: %[[IN5:.*]] = arith.andi %[[IN3]], %[[IN4]] : i1
 // CHECK: scf.if %[[IN5]] {
 // CHECK-NOT: }
@@ -114,14 +114,14 @@ func.func @check3D(%arg0: memref<?x?x?xf64>, %arg1: memref<?x?x?xf64>) {
 // CHECK-SAME: (%[[C1]], %[[C1]], %[[C1]], %[[C1]], %[[C1]], %[[C1]], %[[C1]])
 // CHECK: %[[IDX1:.*]] = arith.muli %[[ARG1]], %[[B]]#0 : index
 // CHECK: %[[IDX2:.*]] = arith.addi %[[IDX1]], %[[ARG4]] : index
-// CHECK: %[[IN1:.*]] = arith.cmpi ult, %[[IDX2]], %[[DIM1]] : index
+// CHECK: %[[IN1:.*]] = arith.cmpi slt, %[[IDX2]], %[[DIM1]] : index
 // CHECK: %[[IDX3:.*]] = arith.muli %[[ARG2]], %[[B]]#1 : index
 // CHECK: %[[IDX4:.*]] = arith.addi %[[IDX3]], %[[ARG5]] : index
-// CHECK: %[[IN2:.*]] = arith.cmpi ult, %[[IDX4]], %[[DIM2]] : index
+// CHECK: %[[IN2:.*]] = arith.cmpi slt, %[[IDX4]], %[[DIM2]] : index
 // CHECK: %[[IN3:.*]] = arith.andi %[[IN1]], %[[IN2]] : i1
 // CHECK: %[[IDX5:.*]] = arith.muli %[[ARG3]], %[[B]]#2 : index
 // CHECK: %[[IDX6:.*]] = arith.addi %[[IDX5]], %[[ARG6]] : index
-// CHECK: %[[IN4:.*]] = arith.cmpi ult, %[[IDX6]], %[[DIM3]] : index
+// CHECK: %[[IN4:.*]] = arith.cmpi slt, %[[IDX6]], %[[DIM3]] : index
 // CHECK: %[[IN5:.*]] = arith.andi %[[IN3]], %[[IN4]] : i1
 // CHECK: scf.if %[[IN5]] {
 // CHECK-NOT: }

--- a/mlir/tools/imex-opt/Passes.cpp
+++ b/mlir/tools/imex-opt/Passes.cpp
@@ -146,3 +146,9 @@ static mlir::PassPipelineRegistration<> makeBarriersUniform(
     [](mlir::OpPassManager &pm) {
       pm.addPass(gpu_runtime::createMakeBarriersUniformPass());
     });
+
+static mlir::PassPipelineRegistration<> tileParallelLoopsGPU(
+    "gpux-tile-parallel-loops", "Naively tile parallel loops for gpu",
+    [](mlir::OpPassManager &pm) {
+      pm.addPass(gpu_runtime::createTileParallelLoopsForGPUPass());
+    });

--- a/numba_dpcomp/numba_dpcomp/mlir/kernel_impl.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/kernel_impl.py
@@ -110,22 +110,10 @@ def _kernel_body(global_size, local_size, body, *args):
 
 def _kernel_body_def_size(global_size, body, *args):
     x, y, z = global_size
-    lx, ly, lz = _get_default_local_size(x, y, z)
-    gx = (x + lx - 1) // lx
-    gy = (y + ly - 1) // ly
-    gz = (z + lz - 1) // lz
-    for gi in _gpu_range(gx):
-        for gj in _gpu_range(gy):
-            for gk in _gpu_range(gz):
-                for li in _gpu_range(lx):
-                    for lj in _gpu_range(ly):
-                        for lk in _gpu_range(lz):
-                            ibx = (gi * lx + li) < x
-                            iby = (gj * ly + lj) < y
-                            ibz = (gk * lz + lk) < z
-                            in_bounds = ibx and iby and ibz
-                            if in_bounds:
-                                body(*args)
+    for gi in _gpu_range(x):
+        for gj in _gpu_range(y):
+            for gk in _gpu_range(z):
+                body(*args)
 
 
 def _extend_dims(dims):

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpu.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpu.cpp
@@ -362,7 +362,7 @@ struct GPULowerDefaultLocalSize
 
         auto res = builder
                        .create<gpu_runtime::GPUSuggestBlockSizeOp>(
-                           loc, /*stream*/ llvm::None, kernel, globalSize)
+                           loc, /*stream*/ llvm::None, globalSize, kernel)
                        .getResults();
 
         for (auto i : llvm::seq(0u, count)) {


### PR DESCRIPTION
* Converts up to 3 outermost parallel loops into 6 loops, where 3 outermost loops are iterating from 0 to `globalSize/localSize` and 3 inner loops from 0 to `localSize` and assign corresponding gpu mapping.
* Local sizes are calculated using `GPUSuggestBlockSizeOp` which will be eventually lowered to `zeKernelSuggestGroupSize`.
* Switch kernel api to new pass.