### PR TITLE
Pass device name to gpu runtime

### DIFF
--- a/dpcomp_gpu_runtime/CMakeLists.txt
+++ b/dpcomp_gpu_runtime/CMakeLists.txt
@@ -17,9 +17,11 @@ project(dpcomp-gpu-runtime LANGUAGES CXX C)
 include(GenerateExportHeader)
 
 set(SOURCES_LIST
+    lib/FilterStringParser.cpp
     lib/GpuRuntime.cpp
 )
 set(HEADERS_LIST
+    lib/FilterStringParser.hpp
     lib/LevelZeroPrinting.hpp
     lib/LevelZeroWrapper.hpp
 )

--- a/dpcomp_gpu_runtime/lib/FilterStringParser.cpp
+++ b/dpcomp_gpu_runtime/lib/FilterStringParser.cpp
@@ -1,0 +1,63 @@
+// Copyright 2022 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "FilterStringParser.hpp"
+
+#include <array>
+#include <charconv>
+
+static std::optional<std::array<std::string_view, 3>>
+tokenize(std::string_view filterString) {
+  std::array<std::string_view, 3> tokens;
+  auto pos = filterString.find(":");
+  if (pos == std::string_view::npos)
+    return {};
+
+  tokens[0] = filterString.substr(0, pos);
+  filterString = filterString.substr(pos + 1);
+
+  pos = filterString.find(":");
+  if (pos == std::string_view::npos)
+    return {};
+
+  tokens[1] = filterString.substr(0, pos);
+  filterString = filterString.substr(pos + 1);
+
+  pos = filterString.find(":");
+  if (pos != std::string_view::npos)
+    return {};
+
+  tokens[2] = filterString;
+  return tokens;
+}
+
+std::optional<DeviceDesc> parseFilterString(std::string_view filterString) {
+  auto tk = tokenize(filterString);
+  if (!tk)
+    return {};
+
+  auto &tokens = *tk;
+
+  DeviceDesc ret;
+  auto idx = tokens[2];
+  auto begin = idx.data();
+  auto end = begin + idx.size();
+  auto [ptr, ec] = std::from_chars(begin, end, ret.index);
+  if (ec != std::errc() || ptr != end)
+    return {};
+
+  ret.backend = tokens[0];
+  ret.name = tokens[1];
+  return ret;
+}

--- a/dpcomp_gpu_runtime/lib/FilterStringParser.hpp
+++ b/dpcomp_gpu_runtime/lib/FilterStringParser.hpp
@@ -1,0 +1,26 @@
+// Copyright 2022 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <optional>
+#include <string_view>
+
+struct DeviceDesc {
+  std::string_view backend;
+  std::string_view name;
+  int index = -1;
+};
+
+std::optional<DeviceDesc> parseFilterString(std::string_view filterString);

--- a/dpcomp_gpu_runtime/lib/GpuRuntime.cpp
+++ b/dpcomp_gpu_runtime/lib/GpuRuntime.cpp
@@ -565,13 +565,15 @@ struct OffloadDeviceCapabilities {
 
 // TODO: device name
 extern "C" DPCOMP_GPU_RUNTIME_EXPORT bool
-dpcompGetDeviceCapabilities(OffloadDeviceCapabilities *ret) {
+dpcompGetDeviceCapabilities(OffloadDeviceCapabilities *ret,
+                            const char *deviceName) {
   LOG_FUNC();
   assert(ret);
+  assert(deviceName);
 
   bool result = true;
   catchAll([&]() {
-    auto driverAndDevice = getDefDevice();
+    auto driverAndDevice = getDevice(deviceName);
     if (!driverAndDevice.driver || !driverAndDevice.device) {
       result = false;
       return;

--- a/dpcomp_gpu_runtime/lib/GpuRuntime.cpp
+++ b/dpcomp_gpu_runtime/lib/GpuRuntime.cpp
@@ -571,11 +571,11 @@ dpcompGetDeviceCapabilities(OffloadDeviceCapabilities *ret,
   assert(ret);
   assert(deviceName);
 
-  bool result = true;
+  bool success = true;
   catchAll([&]() {
     auto driverAndDevice = getDevice(deviceName);
     if (!driverAndDevice.driver || !driverAndDevice.device) {
-      result = false;
+      success = false;
       return;
     }
     ze_device_module_properties_t props = {};
@@ -592,5 +592,5 @@ dpcompGetDeviceCapabilities(OffloadDeviceCapabilities *ret,
     result.hasFP64 = props.flags & ZE_DEVICE_MODULE_FLAG_FP64;
     *ret = result;
   });
-  return result;
+  return success;
 }

--- a/dpcomp_gpu_runtime/lib/GpuRuntime.cpp
+++ b/dpcomp_gpu_runtime/lib/GpuRuntime.cpp
@@ -195,7 +195,6 @@ enum class GpuAllocType { Device = 0, Shared = 1, Local = 2 };
 
 struct Stream {
   Stream(size_t eventsCount, const char *deviceName) {
-    assert(deviceName);
     (void)deviceName;
 
     auto driverAndDevice = getDevice();

--- a/dpcomp_gpu_runtime/lib/GpuRuntime.cpp
+++ b/dpcomp_gpu_runtime/lib/GpuRuntime.cpp
@@ -24,6 +24,7 @@
 
 #include "dpcomp-gpu-runtime_export.h"
 
+#include "FilterStringParser.hpp"
 #include "LevelZeroPrinting.hpp"
 #include "LevelZeroWrapper.hpp"
 
@@ -77,7 +78,7 @@ template <typename F> auto catchAll(F &&func) {
 
 static AllocFuncT AllocFunc = nullptr;
 
-struct DeviceDesc {
+struct DriverAndDevice {
   ze_driver_handle_t driver = nullptr;
   ze_device_handle_t device = nullptr;
 };
@@ -103,7 +104,9 @@ template <typename T> size_t countUntil(T *ptr, T &&elem) {
 }
 
 template <typename CheckFunc>
-static DeviceDesc getDevice(CheckFunc &&checkFunc) {
+static DriverAndDevice getDeviceImpl(CheckFunc &&checkFunc) {
+  CHECK_ZE_RESULT(zeInit(0));
+
   uint32_t driverCount = 0;
   CHECK_ZE_RESULT(zeDriverGet(&driverCount, nullptr));
 
@@ -126,15 +129,42 @@ static DeviceDesc getDevice(CheckFunc &&checkFunc) {
         return {driver, device};
     }
   }
-  return {nullptr, nullptr};
+  return {};
 }
 
-static DeviceDesc getDevice() {
-  CHECK_ZE_RESULT(zeInit(0));
-  return getDevice([](ze_device_handle_t device) {
+static DriverAndDevice getDefDevice() {
+  return getDeviceImpl([](ze_device_handle_t device) {
     ze_device_properties_t props = {};
     CHECK_ZE_RESULT(zeDeviceGetProperties(device, &props));
     return props.type == ZE_DEVICE_TYPE_GPU;
+  });
+}
+
+static DriverAndDevice getDevice(std::string_view name) {
+  auto desc = parseFilterString(name);
+  if (!desc || desc->backend != "level_zero")
+    return {};
+
+  ze_device_type_t devType;
+  if (desc->name == "cpu") {
+    devType = ZE_DEVICE_TYPE_CPU;
+  } else if (desc->name == "gpu") {
+    devType = ZE_DEVICE_TYPE_GPU;
+  } else {
+    return {};
+  }
+
+  int counter = 0;
+  return getDeviceImpl([&](ze_device_handle_t device) {
+    ze_device_properties_t props = {};
+    CHECK_ZE_RESULT(zeDeviceGetProperties(device, &props));
+    if (props.type == devType) {
+      if (desc->index == counter)
+        return true;
+
+      ++counter;
+    }
+    return false;
   });
 }
 
@@ -195,9 +225,13 @@ enum class GpuAllocType { Device = 0, Shared = 1, Local = 2 };
 
 struct Stream {
   Stream(size_t eventsCount, const char *deviceName) {
-    (void)deviceName;
+    DriverAndDevice driverAndDevice;
+    if (deviceName) {
+      driverAndDevice = getDevice(deviceName);
+    } else {
+      driverAndDevice = getDefDevice();
+    }
 
-    auto driverAndDevice = getDevice();
     if (!driverAndDevice.driver || !driverAndDevice.device)
       throw std::runtime_error("getDevice failed");
 
@@ -534,11 +568,14 @@ extern "C" DPCOMP_GPU_RUNTIME_EXPORT bool
 dpcompGetDeviceCapabilities(OffloadDeviceCapabilities *ret) {
   LOG_FUNC();
   assert(ret);
-  auto driverAndDevice = getDevice();
-  if (!driverAndDevice.driver || !driverAndDevice.device)
-    return false;
 
+  bool result = true;
   catchAll([&]() {
+    auto driverAndDevice = getDefDevice();
+    if (!driverAndDevice.driver || !driverAndDevice.device) {
+      result = false;
+      return;
+    }
     ze_device_module_properties_t props = {};
     props.stype = ZE_STRUCTURE_TYPE_DEVICE_MODULE_PROPERTIES;
     CHECK_ZE_RESULT(
@@ -553,5 +590,5 @@ dpcompGetDeviceCapabilities(OffloadDeviceCapabilities *ret) {
     result.hasFP64 = props.flags & ZE_DEVICE_MODULE_FLAG_FP64;
     *ret = result;
   });
-  return true;
+  return result;
 }

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/CheckGpuCaps.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/CheckGpuCaps.cpp
@@ -18,7 +18,7 @@
 
 namespace py = pybind11;
 
-using ResolveFptr = bool (*)(OffloadDeviceCapabilities *);
+using ResolveFptr = bool (*)(OffloadDeviceCapabilities *, const char *);
 
 static ResolveFptr getResolver() {
   static ResolveFptr resolver = []() {
@@ -29,13 +29,14 @@ static ResolveFptr getResolver() {
   return resolver;
 }
 
-llvm::Optional<OffloadDeviceCapabilities> getOffloadDeviceCapabilities() {
+llvm::Optional<OffloadDeviceCapabilities>
+getOffloadDeviceCapabilities(const std::string &name) {
   auto resolver = getResolver();
   if (!resolver)
     return llvm::None;
 
   OffloadDeviceCapabilities ret;
-  if (!resolver(&ret))
+  if (!resolver(&ret, name.c_str()))
     return llvm::None;
 
   if (ret.spirvMajorVersion == 0 && ret.spirvMinorVersion == 0)

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/CheckGpuCaps.hpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/CheckGpuCaps.hpp
@@ -28,6 +28,7 @@ struct OffloadDeviceCapabilities {
 };
 
 // TODO: device name
-llvm::Optional<OffloadDeviceCapabilities> getOffloadDeviceCapabilities();
+llvm::Optional<OffloadDeviceCapabilities>
+getOffloadDeviceCapabilities(const std::string &name);
 
 llvm::Optional<std::string> getDefaultDevice();

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpu.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpu.cpp
@@ -1649,7 +1649,8 @@ static mlir::spirv::TargetEnvAttr deviceCapsMapper(mlir::gpu::GPUModuleOp op) {
   if (!deviceAttr)
     return {};
 
-  auto deviceCapsRet = getOffloadDeviceCapabilities();
+  auto deviceCapsRet =
+      getOffloadDeviceCapabilities(deviceAttr.getValue().str());
   if (!deviceCapsRet)
     return nullptr;
 

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpu.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpu.cpp
@@ -1488,6 +1488,47 @@ public:
   }
 };
 
+static const constexpr llvm::StringLiteral
+    kGpuModuleDeviceName("gpu_module_device");
+
+class NameGpuModulesPass
+    : public mlir::PassWrapper<NameGpuModulesPass,
+                               mlir::OperationPass<mlir::ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(NameGpuModulesPass)
+
+  void runOnOperation() override {
+    auto mod = getOperation();
+    mod->walk([&](mlir::gpu::LaunchFuncOp launch) {
+      auto env = launch->getParentOfType<imex::util::EnvironmentRegionOp>();
+      if (!env)
+        return;
+
+      auto gpuEnv =
+          env.getEnvironment().dyn_cast<gpu_runtime::GPURegionDescAttr>();
+      if (!gpuEnv)
+        return;
+
+      auto deviceName = gpuEnv.getDevice();
+
+      auto kernel = launch.getKernel();
+      auto gpuModName = kernel.getRootReference();
+      auto gpuMod = mod.lookupSymbol<mlir::gpu::GPUModuleOp>(gpuModName);
+      if (!gpuMod)
+        return;
+
+      auto gpuModAttr =
+          gpuMod->getAttrOfType<mlir::StringAttr>(kGpuModuleDeviceName);
+      if (gpuModAttr && gpuModAttr != deviceName) {
+        gpuMod->emitError("Incompatible gpu module devices: ")
+            << gpuModAttr.getValue() << " and " << deviceName;
+        return signalPassFailure();
+      }
+      gpuMod->setAttr(kGpuModuleDeviceName, deviceName);
+    });
+  }
+};
+
 struct SinkGpuDims : public mlir::OpRewritePattern<mlir::gpu::LaunchOp> {
   using OpRewritePattern::OpRewritePattern;
 
@@ -1604,6 +1645,10 @@ static llvm::Optional<mlir::spirv::Version> mapSpirvVersion(uint16_t major,
 }
 
 static mlir::spirv::TargetEnvAttr deviceCapsMapper(mlir::gpu::GPUModuleOp op) {
+  auto deviceAttr = op->getAttrOfType<mlir::StringAttr>(kGpuModuleDeviceName);
+  if (!deviceAttr)
+    return {};
+
   auto deviceCapsRet = getOffloadDeviceCapabilities();
   if (!deviceCapsRet)
     return nullptr;
@@ -1699,6 +1744,7 @@ static void populateLowerToGPUPipelineLow(mlir::OpPassManager &pm) {
   funcPM.addPass(std::make_unique<SinkGpuDimsPass>());
   funcPM.addPass(std::make_unique<GpuLaunchSinkOpsPass>());
   pm.addPass(mlir::createGpuKernelOutliningPass());
+  pm.addPass(std::make_unique<NameGpuModulesPass>());
   pm.addPass(mlir::createSymbolDCEPass());
 
   pm.addNestedPass<mlir::func::FuncOp>(


### PR DESCRIPTION
As we still using L0 runtime we need to parse filter string manually. The only supported backend is `level_zero` and the only supported devices are `cpu` and `gpu`.
