### PR TITLE
Add basic alias analysis to ntensor-to-linalg conversion

### DIFF
--- a/mlir/include/imex/Conversion/NtensorToLinalg.hpp
+++ b/mlir/include/imex/Conversion/NtensorToLinalg.hpp
@@ -26,7 +26,7 @@ namespace imex {
 void populateNtensorToLinalgPatterns(mlir::MLIRContext &context,
                                      mlir::RewritePatternSet &patterns);
 
-/// Creates a pass for ntensor alias analysis, reauired by ntensor-to-linalg.
+/// Creates a pass for ntensor alias analysis, required by ntensor-to-linalg.
 std::unique_ptr<mlir::Pass> createNtensorAliasAnalysisPass();
 
 /// Creates a pass to convert ntensor array ops to linalg.

--- a/mlir/include/imex/Conversion/NtensorToLinalg.hpp
+++ b/mlir/include/imex/Conversion/NtensorToLinalg.hpp
@@ -26,6 +26,9 @@ namespace imex {
 void populateNtensorToLinalgPatterns(mlir::MLIRContext &context,
                                      mlir::RewritePatternSet &patterns);
 
+/// Creates a pass for ntensor alias analysis, reauired by ntensor-to-linalg.
+std::unique_ptr<mlir::Pass> createNtensorAliasAnalysisPass();
+
 /// Creates a pass to convert ntensor array ops to linalg.
 std::unique_ptr<mlir::Pass> createNtensorToLinalgPass();
 } // namespace imex

--- a/mlir/include/imex/Dialect/ntensor/IR/NTensorOps.td
+++ b/mlir/include/imex/Dialect/ntensor/IR/NTensorOps.td
@@ -223,7 +223,8 @@ class NTensor_OpWithOffsetSizesAndStrides<string mnemonic,
 def SubviewOp : NTensor_OpWithOffsetSizesAndStrides<"subview", [
     Pure, AttrSizedOperandSegments,
     DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
-    OffsetSizeAndStrideOpInterface
+    OffsetSizeAndStrideOpInterface,
+    ViewLikeOpInterface
   ]> {
   let summary = "array subview operation";
   let description = [{
@@ -375,7 +376,9 @@ def SubviewOp : NTensor_OpWithOffsetSizesAndStrides<"subview", [
 
     /// Return the dimensions of the source that are dropped in the
     /// result when the result is rank-reduced.
-    llvm::SmallBitVector getDroppedDims();
+    ::llvm::SmallBitVector getDroppedDims();
+
+    ::mlir::Value getViewSource() { return getSource(); }
   }];
 }
 
@@ -535,7 +538,7 @@ def PrimitiveOp : NTensor_OpBase<"primitive", [Pure]> {
 
   let arguments = (ins Variadic<AnyType>:$args, StrAttr:$op);
 
-  let results = (outs Variadic<AnyType>:$results);
+  let results = (outs Res<Variadic<AnyType>, "", [MemAlloc<DefaultResource>]>:$results);
 
   let assemblyFormat = "$op ` ` attr-dict `(` $args `)` (`:` type($args)^)? (`->` type($results)^)?";
 }
@@ -553,7 +556,7 @@ def CreateArrayOp : NTensor_OpBase<"create", [AttrSizedOperandSegments, Pure]> {
 
   let arguments = (ins Variadic<Index>:$dynamicSizes, Optional<AnyType>:$initValue);
 
-  let results = (outs NTensor_Tensor:$result);
+  let results = (outs Res<NTensor_Tensor, "", [MemAlloc<DefaultResource>]>:$result);
 
   let assemblyFormat = "`(`$dynamicSizes`)` (`=` `(` $initValue^ `:` type($initValue) `)`)? attr-dict `:` qualified(type($result))";
 }
@@ -566,7 +569,7 @@ def FromTensorOp : NTensor_OpBase<"from_tensor",
   }];
 
   let arguments = (ins AnyRankedTensor:$tensor);
-  let results = (outs NTensor_Tensor:$result);
+  let results = (outs Res<NTensor_Tensor, "", [MemAlloc<DefaultResource>]>:$result);
 
   let assemblyFormat = "$tensor attr-dict `:` type($tensor) `to` qualified(type($result))";
 
@@ -590,7 +593,7 @@ def ToTensorOp : NTensor_OpBase<"to_tensor",
 }
 
 def FromMemrefOp : NTensor_OpBase<"from_memref",
-    [Pure, SameOperandsShape, SameOperandsElementType]> {
+    [Pure, SameOperandsShape, SameOperandsElementType, ViewLikeOpInterface]> {
   let summary = "converts memref to ntensor array.";
   let description = [{
     Converts from memref to ntensor array. Shape and element type must match.
@@ -602,10 +605,14 @@ def FromMemrefOp : NTensor_OpBase<"from_memref",
   let assemblyFormat = "$memref attr-dict `:` type($memref) `to` qualified(type($result))";
 
   let hasFolder = 1;
+
+  let extraClassDeclaration = [{
+      ::mlir::Value getViewSource() { return getMemref(); }
+  }];
 }
 
 def ToMemrefOp : NTensor_OpBase<"to_memref",
-    [Pure, SameOperandsShape, SameOperandsElementType]> {
+    [Pure, SameOperandsShape, SameOperandsElementType, ViewLikeOpInterface]> {
   let summary = "converts ntensor array to memref.";
   let description = [{
     Converts from ntensor array to memref. Shape and element type must match.
@@ -617,6 +624,10 @@ def ToMemrefOp : NTensor_OpBase<"to_memref",
   let assemblyFormat = "$array attr-dict `:` qualified(type($array)) `to` type($result)";
 
   let hasFolder = 1;
+
+  let extraClassDeclaration = [{
+      ::mlir::Value getViewSource() { return getArray(); }
+  }];
 }
 
 def ElementwiseOp : NTensor_OpBase<"elementwise", [
@@ -629,8 +640,8 @@ def ElementwiseOp : NTensor_OpBase<"elementwise", [
   }];
 
 
-  let arguments = (ins NTensor_Tensor:$source);
-  let results = (outs NTensor_Tensor:$result);
+  let arguments = (ins Arg<NTensor_Tensor, "", [MemRead]>:$source);
+  let results = (outs Res<NTensor_Tensor, "", [MemAlloc<DefaultResource>]>:$result);
 
   let regions = (region SizedRegion<1>:$region);
 
@@ -666,6 +677,7 @@ def ElementwiseYieldOp : NTensor_OpBase<"elementwise_yield", [
 
 def CastOp : NTensor_OpBase<"cast", [
     DeclareOpInterfaceMethods<CastOpInterface>,
+    ViewLikeOpInterface,
     Pure
   ]> {
   let summary = "Array cast operation";
@@ -679,6 +691,10 @@ def CastOp : NTensor_OpBase<"cast", [
   let arguments = (ins NTensor_Tensor:$source);
   let results = (outs NTensor_Tensor:$dest);
   let assemblyFormat = "$source attr-dict `:` qualified(type($source)) `to` qualified(type($dest))";
+
+  let extraClassDeclaration = [{
+      ::mlir::Value getViewSource() { return getSource(); }
+  }];
 }
 
 def FromElementsOp : NTensor_OpBase<"from_elements", [
@@ -696,7 +712,7 @@ def FromElementsOp : NTensor_OpBase<"from_elements", [
   }];
 
   let arguments = (ins Variadic<AnyType>:$elements);
-  let results = (outs NTensor_Tensor:$result);
+  let results = (outs Res<NTensor_Tensor, "", [MemAlloc<DefaultResource>]>:$result);
 
   let assemblyFormat = "$elements attr-dict `:` qualified(type($result))";
 }

--- a/mlir/lib/Conversion/NtensorToLinalg.cpp
+++ b/mlir/lib/Conversion/NtensorToLinalg.cpp
@@ -22,6 +22,7 @@
 #include <mlir/Dialect/Linalg/IR/Linalg.h>
 #include <mlir/Dialect/Tensor/IR/Tensor.h>
 #include <mlir/IR/FunctionInterfaces.h>
+#include <mlir/Interfaces/CallInterfaces.h>
 #include <mlir/Pass/Pass.h>
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 
@@ -407,6 +408,11 @@ struct NtensorAliasAnalysisPass
 
     llvm::SmallVector<mlir::Operation *, 0> writers;
     func->walk([&](mlir::Operation *op) {
+      if (mlir::isa<mlir::CallOpInterface>(op)) {
+        writers.emplace_back(op);
+        return;
+      }
+
       if (op->getDialect() != ntensorDialect)
         return;
 

--- a/mlir/lib/Conversion/NtensorToLinalg.cpp
+++ b/mlir/lib/Conversion/NtensorToLinalg.cpp
@@ -446,7 +446,12 @@ struct NtensorAliasAnalysisPass
           assert(analysis);
           for (auto writer : writers) {
             assert(writer);
-            if (analysis->getModRef(writer, tens).isMod())
+            if (auto call = mlir::dyn_cast<mlir::CallOpInterface>(writer)) {
+              for (auto arg : call.getArgOperands())
+                if (!analysis->alias(tens, arg).isNo())
+                  return;
+
+            } else if (analysis->getModRef(writer, tens).isMod())
               return;
           }
         }

--- a/mlir/lib/Conversion/NtensorToLinalg.cpp
+++ b/mlir/lib/Conversion/NtensorToLinalg.cpp
@@ -285,6 +285,9 @@ struct ConvertSubviewOp
   mlir::LogicalResult
   matchAndRewrite(imex::ntensor::SubviewOp op,
                   mlir::PatternRewriter &rewriter) const override {
+    if (!op->hasAttr(kReadonly))
+      return mlir::failure();
+
     auto src = op.getSource();
     auto srcType = src.getType().dyn_cast<imex::ntensor::NTensorType>();
     if (!srcType)

--- a/mlir/lib/Conversion/NtensorToLinalg.cpp
+++ b/mlir/lib/Conversion/NtensorToLinalg.cpp
@@ -18,10 +18,14 @@
 #include "imex/Dialect/imex_util/Utils.hpp"
 #include "imex/Dialect/ntensor/IR/NTensorOps.hpp"
 
+#include <mlir/Analysis/AliasAnalysis.h>
 #include <mlir/Dialect/Linalg/IR/Linalg.h>
 #include <mlir/Dialect/Tensor/IR/Tensor.h>
+#include <mlir/IR/FunctionInterfaces.h>
 #include <mlir/Pass/Pass.h>
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
+
+static const constexpr llvm::StringLiteral kReadonly("ntensor_readonly");
 
 static mlir::RankedTensorType toTensorType(mlir::ShapedType type) {
   return mlir::RankedTensorType::get(type.getShape(), type.getElementType());
@@ -383,6 +387,70 @@ void imex::populateNtensorToLinalgPatterns(mlir::MLIRContext &context,
 }
 
 namespace {
+struct NtensorAliasAnalysisPass
+    : public mlir::PassWrapper<NtensorAliasAnalysisPass,
+                               mlir::InterfacePass<mlir::FunctionOpInterface>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(NtensorAliasAnalysisPass)
+
+  virtual void
+  getDependentDialects(mlir::DialectRegistry &registry) const override {
+    registry.insert<imex::ntensor::NTensorDialect>();
+  }
+
+  void runOnOperation() override {
+    auto &context = getContext();
+    auto func = getOperation();
+
+    auto *ntensorDialect =
+        context.getOrLoadDialect<imex::ntensor::NTensorDialect>();
+    assert(ntensorDialect);
+
+    llvm::SmallVector<mlir::Operation *, 0> writers;
+    func->walk([&](mlir::Operation *op) {
+      if (op->getDialect() != ntensorDialect)
+        return;
+
+      auto memInterface = mlir::dyn_cast<mlir::MemoryEffectOpInterface>(op);
+      if (!memInterface || memInterface.hasEffect<mlir::MemoryEffects::Write>())
+        writers.emplace_back(op);
+    });
+
+    bool hasWriters = !writers.empty();
+    auto *analysis = [&]() -> mlir::AliasAnalysis * {
+      if (!hasWriters)
+        return nullptr;
+
+      return &getAnalysis<mlir::AliasAnalysis>();
+    }();
+
+    auto getTensor = [](mlir::Operation *op) -> mlir::Value {
+      assert(op);
+      if (auto subview = mlir::dyn_cast<imex::ntensor::SubviewOp>(op))
+        return subview.getResult();
+
+      return {};
+    };
+
+    auto attrName = mlir::StringAttr::get(&context, kReadonly);
+    auto unitAttr = mlir::UnitAttr::get(&context);
+    func->walk([&](mlir::Operation *op) {
+      if (auto tens = getTensor(op)) {
+        if (hasWriters) {
+          op->removeAttr(attrName);
+          assert(analysis);
+          for (auto writer : writers) {
+            assert(writer);
+            if (analysis->getModRef(writer, tens).isMod())
+              return;
+          }
+        }
+        op->setAttr(attrName, unitAttr);
+      }
+    });
+    markAllAnalysesPreserved();
+  }
+};
+
 struct NtensorToLinalgPass
     : public mlir::PassWrapper<NtensorToLinalgPass, mlir::OperationPass<void>> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(NtensorToLinalgPass)
@@ -406,6 +474,10 @@ struct NtensorToLinalgPass
   }
 };
 } // namespace
+
+std::unique_ptr<mlir::Pass> imex::createNtensorAliasAnalysisPass() {
+  return std::make_unique<NtensorAliasAnalysisPass>();
+}
 
 std::unique_ptr<mlir::Pass> imex::createNtensorToLinalgPass() {
   return std::make_unique<NtensorToLinalgPass>();

--- a/mlir/test/Dialect/ntensor/ntensor-alias-analysis.mlir
+++ b/mlir/test/Dialect/ntensor/ntensor-alias-analysis.mlir
@@ -12,3 +12,35 @@ func.func @test(%t: !ntensor.ntensor<8x16x4xf32>, %idx : index) {
 
   return
 }
+
+// -----
+
+// CHECK-LABEL: func @test({{.*}}) {
+func.func @test(%t: !ntensor.ntensor<?xf32>, %idx : index, %val : f32) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+
+  // CHECK: ntensor.subview
+  // CHECK-SAME: %{{.*}}[%{{.*}}] [%{{.*}}] [%{{.*}}] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32>
+  %1 = ntensor.subview %t[%c0] [%idx] [%c1] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32>
+
+  ntensor.store %val, %1[%idx] : !ntensor.ntensor<?xf32>
+
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @test({{.*}}) {
+func.func @test(%t: !ntensor.ntensor<?xf32>, %idx : index, %val : f32) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+
+  // CHECK: ntensor.subview
+  // CHECK-SAME: %{{.*}}[%{{.*}}] [%{{.*}}] [%{{.*}}] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32>
+  %1 = ntensor.subview %t[%c0] [%idx] [%c1] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32>
+
+  ntensor.store %val, %t[%idx] : !ntensor.ntensor<?xf32>
+
+  return
+}

--- a/mlir/test/Dialect/ntensor/ntensor-alias-analysis.mlir
+++ b/mlir/test/Dialect/ntensor/ntensor-alias-analysis.mlir
@@ -24,6 +24,7 @@ func.func @test(%t: !ntensor.ntensor<?xf32>, %idx : index, %val : f32) {
   // CHECK-SAME: %{{.*}}[%{{.*}}] [%{{.*}}] [%{{.*}}] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32>
   %1 = ntensor.subview %t[%c0] [%idx] [%c1] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32>
 
+  // CHECK: ntensor.store
   ntensor.store %val, %1[%idx] : !ntensor.ntensor<?xf32>
 
   return
@@ -40,6 +41,7 @@ func.func @test(%t: !ntensor.ntensor<?xf32>, %idx : index, %val : f32) {
   // CHECK-SAME: %{{.*}}[%{{.*}}] [%{{.*}}] [%{{.*}}] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32>
   %1 = ntensor.subview %t[%c0] [%idx] [%c1] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32>
 
+  // CHECK: ntensor.store
   ntensor.store %val, %t[%idx] : !ntensor.ntensor<?xf32>
 
   return
@@ -56,8 +58,45 @@ func.func @test(%t: !ntensor.ntensor<?xf32>, %idx : index, %val : f32) {
   // CHECK-SAME: {ntensor_readonly}
   %1 = ntensor.subview %t[%c0] [%idx] [%c1] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32>
 
+  // CHECK: ntensor.create
   %2 = ntensor.create(%c1) : !ntensor.ntensor<?xf32>
+  // CHECK: ntensor.store
   ntensor.store %val, %2[%idx] : !ntensor.ntensor<?xf32>
 
   return
 }
+
+// -----
+
+// CHECK-LABEL: func @test({{.*}}) {
+func.func @test(%t1: !ntensor.ntensor<?xf32>, %t2: !ntensor.ntensor<?xf32>, %idx : index, %val : f32) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+
+  // CHECK: ntensor.subview
+  // CHECK-SAME: %{{.*}}[%{{.*}}] [%{{.*}}] [%{{.*}}] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32>
+  %1 = ntensor.subview %t1[%c0] [%idx] [%c1] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32>
+
+  // CHECK: ntensor.store
+  ntensor.store %val, %t2[%idx] : !ntensor.ntensor<?xf32>
+
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @test({{.*}}) {
+func.func @test(%t: !ntensor.ntensor<?xf32>, %idx : index, %val : f32) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+
+  // CHECK: ntensor.subview
+  // CHECK-SAME: %{{.*}}[%{{.*}}] [%{{.*}}] [%{{.*}}] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32>
+  %1 = ntensor.subview %t[%c0] [%idx] [%c1] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32>
+
+  func.call @use(%t) : (!ntensor.ntensor<?xf32>) -> ()
+
+  return
+}
+
+func.func private @use(%0: !ntensor.ntensor<?xf32>)

--- a/mlir/test/Dialect/ntensor/ntensor-alias-analysis.mlir
+++ b/mlir/test/Dialect/ntensor/ntensor-alias-analysis.mlir
@@ -1,0 +1,14 @@
+// RUN: imex-opt %s -pass-pipeline='func.func(ntensor-alias-analysis)' --split-input-file | FileCheck %s
+
+// CHECK-LABEL: func @test({{.*}}) {
+func.func @test(%t: !ntensor.ntensor<8x16x4xf32>, %idx : index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+
+  // CHECK: ntensor.subview
+  // CHECK-SAME: {ntensor_readonly}
+  %1 = ntensor.subview %t[%c0, %c0, %c0][%idx, %idx, %idx][%c1, %c1, %c1]
+    : !ntensor.ntensor<8x16x4xf32> to !ntensor.ntensor<?x?x?xf32>
+
+  return
+}

--- a/mlir/test/Dialect/ntensor/ntensor-alias-analysis.mlir
+++ b/mlir/test/Dialect/ntensor/ntensor-alias-analysis.mlir
@@ -44,3 +44,20 @@ func.func @test(%t: !ntensor.ntensor<?xf32>, %idx : index, %val : f32) {
 
   return
 }
+
+// -----
+
+// CHECK-LABEL: func @test({{.*}}) {
+func.func @test(%t: !ntensor.ntensor<?xf32>, %idx : index, %val : f32) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+
+  // CHECK: ntensor.subview
+  // CHECK-SAME: {ntensor_readonly}
+  %1 = ntensor.subview %t[%c0] [%idx] [%c1] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32>
+
+  %2 = ntensor.create(%c1) : !ntensor.ntensor<?xf32>
+  ntensor.store %val, %2[%idx] : !ntensor.ntensor<?xf32>
+
+  return
+}

--- a/mlir/test/Dialect/ntensor/ntensor-alias-analysis.mlir
+++ b/mlir/test/Dialect/ntensor/ntensor-alias-analysis.mlir
@@ -120,3 +120,20 @@ func.func @test(%t: !ntensor.ntensor<?xf32>, %idx : index, %val : f32) {
 }
 
 func.func private @use()
+
+// -----
+
+// CHECK-LABEL: func @test({{.*}}) {
+func.func @test(%t: !ntensor.ntensor<8x16x4xf32>, %idx : index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+
+  %0 = ntensor.primitive "foo" (%t) : !ntensor.ntensor<8x16x4xf32> -> !ntensor.ntensor<8x16x4xf32>
+
+  // CHECK: ntensor.subview
+  // CHECK-SAME: {ntensor_readonly}
+  %1 = ntensor.subview %0[%c0, %c0, %c0][%idx, %idx, %idx][%c1, %c1, %c1]
+    : !ntensor.ntensor<8x16x4xf32> to !ntensor.ntensor<?x?x?xf32>
+
+  return
+}

--- a/mlir/test/Dialect/ntensor/ntensor-alias-analysis.mlir
+++ b/mlir/test/Dialect/ntensor/ntensor-alias-analysis.mlir
@@ -94,9 +94,29 @@ func.func @test(%t: !ntensor.ntensor<?xf32>, %idx : index, %val : f32) {
   // CHECK-SAME: %{{.*}}[%{{.*}}] [%{{.*}}] [%{{.*}}] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32>
   %1 = ntensor.subview %t[%c0] [%idx] [%c1] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32>
 
+  // CHECK: call @use
   func.call @use(%t) : (!ntensor.ntensor<?xf32>) -> ()
 
   return
 }
 
 func.func private @use(%0: !ntensor.ntensor<?xf32>)
+
+// -----
+
+// CHECK-LABEL: func @test({{.*}}) {
+func.func @test(%t: !ntensor.ntensor<?xf32>, %idx : index, %val : f32) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+
+  // CHECK: ntensor.subview
+  // CHECK-SAME: {ntensor_readonly}
+  %1 = ntensor.subview %t[%c0] [%idx] [%c1] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32>
+
+  // CHECK: call @use
+  func.call @use() : () -> ()
+
+  return
+}
+
+func.func private @use()

--- a/mlir/tools/imex-opt/Passes.cpp
+++ b/mlir/tools/imex-opt/Passes.cpp
@@ -123,6 +123,13 @@ static mlir::PassPipelineRegistration<> ntensorResolveArrayOps(
     });
 
 static mlir::PassPipelineRegistration<>
+    ntensorAliasAnalysis("ntensor-alias-analysis",
+                         "Run alias analysis on ntensor ops",
+                         [](mlir::OpPassManager &pm) {
+                           pm.addPass(imex::createNtensorAliasAnalysisPass());
+                         });
+
+static mlir::PassPipelineRegistration<>
     ntensorToMemref("ntensor-to-memref", "Convert ntensor array ops to memref",
                     [](mlir::OpPassManager &pm) {
                       pm.addPass(imex::createNtensorToMemrefPass());

--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_numpy.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_numpy.py
@@ -1205,6 +1205,19 @@ def test_size_ret():
     a = np.array([[[1], [2], [3]], [[4], [5], [6]]])
     assert_equal(py_func(a, 3), jit_func(a, 3))
 
+def test_alias1():
+    def py_func():
+        a = np.zeros(7)
+        b = a[2:4]
+        b[1] = 5
+        return a
+
+    jit_func = njit(py_func)
+
+    a = np.ones(1)
+
+    assert_equal(py_func(), jit_func())
+
 
 @pytest.mark.xfail
 def test_inplace_alias():

--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_numpy.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_numpy.py
@@ -1206,6 +1206,7 @@ def test_size_ret():
     assert_equal(py_func(a, 3), jit_func(a, 3))
 
 
+@pytest.mark.xfail
 def test_inplace_alias():
     def py_func(a):
         a += 1
@@ -1214,7 +1215,12 @@ def test_inplace_alias():
     jit_func = njit(py_func)
 
     a = np.ones(1)
-    assert_equal(py_func(a.copy()), jit_func(a.copy()))
+
+    py_arg = a.copy()
+    jit_arg = a.copy()
+    py_func(py_arg)
+    jit_func(jit_arg)
+    assert_equal(py_arg, jit_arg)
 
 
 @pytest.mark.parametrize("a", [np.array([[1, 2], [4, 5]])])

--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_numpy.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_numpy.py
@@ -1205,6 +1205,7 @@ def test_size_ret():
     a = np.array([[[1], [2], [3]], [[4], [5], [6]]])
     assert_equal(py_func(a, 3), jit_func(a, 3))
 
+
 def test_alias1():
     def py_func():
         a = np.zeros(7)
@@ -1217,6 +1218,19 @@ def test_alias1():
     a = np.ones(1)
 
     assert_equal(py_func(), jit_func())
+
+
+def test_alias2():
+    def py_func(n):
+        b = np.zeros((n, n))
+        a = b[0]
+        for j in range(n):
+            a[j] = j + 1
+        return b.sum()
+
+    jit_func = njit(py_func)
+
+    assert_equal(py_func(4), jit_func(4))
 
 
 @pytest.mark.xfail

--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_numpy.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_numpy.py
@@ -1206,6 +1206,15 @@ def test_size_ret():
     assert_equal(py_func(a, 3), jit_func(a, 3))
 
 
+def test_inplace_alias():
+    def py_func(a):
+        a += 1
+        a[:] = 3
+
+    x = np.ones(1)
+    assert_equal(py_func(a.copy()), jit_func(a.copy(), 3))
+
+
 @pytest.mark.parametrize("a", [np.array([[1, 2], [4, 5]])])
 @pytest.mark.parametrize("b", [True, False])
 def test_tensor_if(a, b):

--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_numpy.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_numpy.py
@@ -1211,8 +1211,10 @@ def test_inplace_alias():
         a += 1
         a[:] = 3
 
-    x = np.ones(1)
-    assert_equal(py_func(a.copy()), jit_func(a.copy(), 3))
+    jit_func = njit(py_func)
+
+    a = np.ones(1)
+    assert_equal(py_func(a.copy()), jit_func(a.copy()))
 
 
 @pytest.mark.parametrize("a", [np.array([[1, 2], [4, 5]])])

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -2546,8 +2546,9 @@ static void populatePlierToLinalgGenPipeline(mlir::OpPassManager &pm) {
   pm.addPass(std::make_unique<ResolveNumpyFuncsPass>());
   pm.addPass(std::make_unique<ResolveNtensorPass>());
   pm.addPass(mlir::createCanonicalizerPass());
-  pm.addPass(imex::createNtensorToLinalgPass());
-  pm.addPass(mlir::createCanonicalizerPass());
+  pm.addNestedPass<mlir::func::FuncOp>(imex::createNtensorAliasAnalysisPass());
+  pm.addNestedPass<mlir::func::FuncOp>(imex::createNtensorToLinalgPass());
+  pm.addNestedPass<mlir::func::FuncOp>(mlir::createCanonicalizerPass());
   pm.addPass(imex::createForceInlinePass());
   pm.addPass(mlir::createSymbolDCEPass());
   pm.addNestedPass<mlir::func::FuncOp>(

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -2557,17 +2557,15 @@ static void populatePlierToLinalgGenPipeline(mlir::OpPassManager &pm) {
 }
 
 static void populatePlierToLinalgOptPipeline(mlir::OpPassManager &pm) {
-  pm.addPass(imex::createNtensorToMemrefPass());
   pm.addPass(mlir::createCanonicalizerPass());
+  pm.addPass(std::make_unique<LinalgOptPass>());
 
   pm.addPass(imex::createMakeSignlessPass());
   pm.addPass(mlir::createCanonicalizerPass());
 
   pm.addPass(mlir::createReconcileUnrealizedCastsPass());
 
-  pm.addPass(mlir::createCanonicalizerPass());
-  pm.addPass(std::make_unique<LinalgOptPass>());
-
+  pm.addPass(imex::createNtensorToMemrefPass());
   pm.addPass(mlir::arith::createConstantBufferizePass());
   pm.addNestedPass<mlir::func::FuncOp>(
       mlir::bufferization::createEmptyTensorToAllocTensorPass());

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -2560,12 +2560,14 @@ static void populatePlierToLinalgOptPipeline(mlir::OpPassManager &pm) {
   pm.addPass(mlir::createCanonicalizerPass());
   pm.addPass(std::make_unique<LinalgOptPass>());
 
+  pm.addPass(imex::createNtensorToMemrefPass());
+  pm.addPass(mlir::createCanonicalizerPass());
+
   pm.addPass(imex::createMakeSignlessPass());
   pm.addPass(mlir::createCanonicalizerPass());
 
   pm.addPass(mlir::createReconcileUnrealizedCastsPass());
 
-  pm.addPass(imex::createNtensorToMemrefPass());
   pm.addPass(mlir::arith::createConstantBufferizePass());
   pm.addNestedPass<mlir::func::FuncOp>(
       mlir::bufferization::createEmptyTensorToAllocTensorPass());


### PR DESCRIPTION
I'm using upstream `mlir::AliasAnalysis` which requires proper ops attribution with `ViewLikeOpInterface` and MemEffects.
Only `ntensor.subview` op is checked for now.

See https://github.com/intel/mlir-extensions/pull/389#discussion_r999320093 for the reason why it is needed.