### PR TITLE
Tweak llvm options to reduce cache size and compilation time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,8 +163,8 @@ jobs:
             -DLLVM_BUILD_TOOLS=OFF                                         \
             -DLLVM_ENABLE_ZSTD=OFF                                         \
             -DCMAKE_INSTALL_PREFIX=/home/runner/work/llvm-mlir/_mlir_install || exit 1
-          cmake --build . -j ${np} || exit 1
-          cmake --install-distribution-stripped . || exit 1
+          cmake --build . || exit 1
+          cmake --install . || exit 1
           cp bin/FileCheck /home/runner/work/llvm-mlir/_mlir_install/bin/
           cp bin/count /home/runner/work/llvm-mlir/_mlir_install/bin/
           cp bin/not /home/runner/work/llvm-mlir/_mlir_install/bin/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
         id: cache-llvm-mlir
         uses: actions/cache@v3
         env:
-          LLVM_CACHE_NUMBER: 1  # Increase to reset cache
+          LLVM_CACHE_NUMBER: 2  # Increase to reset cache
         with:
           path: |
             /home/runner/work/llvm-mlir/_mlir_install/**
@@ -158,6 +158,9 @@ jobs:
             -DLLVM_ENABLE_RTTI=ON                                          \
             -DLLVM_USE_LINKER=gold                                         \
             -DLLVM_INSTALL_UTILS=ON                                        \
+            -LLVM_TARGETS_TO_BUILD=x86                                     \
+            -LLVM_ENABLE_BINDINGS=OFF                                      \
+            -LLVM_BUILD_TOOLS=OFF                                          \
             -DLLVM_ENABLE_ZSTD=OFF                                         \
             -DCMAKE_INSTALL_PREFIX=/home/runner/work/llvm-mlir/_mlir_install || exit 1
           cmake --build . -j ${np} || exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,9 +158,9 @@ jobs:
             -DLLVM_ENABLE_RTTI=ON                                          \
             -DLLVM_USE_LINKER=gold                                         \
             -DLLVM_INSTALL_UTILS=ON                                        \
-            -LLVM_TARGETS_TO_BUILD=x86                                     \
-            -LLVM_ENABLE_BINDINGS=OFF                                      \
-            -LLVM_BUILD_TOOLS=OFF                                          \
+            -DLLVM_TARGETS_TO_BUILD=x86                                    \
+            -DLLVM_ENABLE_BINDINGS=OFF                                     \
+            -DLLVM_BUILD_TOOLS=OFF                                         \
             -DLLVM_ENABLE_ZSTD=OFF                                         \
             -DCMAKE_INSTALL_PREFIX=/home/runner/work/llvm-mlir/_mlir_install || exit 1
           cmake --build . -j ${np} || exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,7 +164,7 @@ jobs:
             -DLLVM_ENABLE_ZSTD=OFF                                         \
             -DLLVM_DISTRIBUTION_COMPONENTS=llvm-headers;llvm-libraries;cmake-exports;FileCheck;count;not;mlir-headers;mlir-libraries;mlir-cmake-exports;mlir-tblgen \
             -DCMAKE_INSTALL_PREFIX=/home/runner/work/llvm-mlir/_mlir_install || exit 1
-          cmake --install-distribution-stripped . || exit 1
+          ninja install-distribution-stripped || exit 1
           cp bin/FileCheck /home/runner/work/llvm-mlir/_mlir_install/bin/
           cp bin/count /home/runner/work/llvm-mlir/_mlir_install/bin/
           cp bin/not /home/runner/work/llvm-mlir/_mlir_install/bin/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,7 +158,7 @@ jobs:
             -DLLVM_ENABLE_RTTI=ON                                          \
             -DLLVM_USE_LINKER=gold                                         \
             -DLLVM_INSTALL_UTILS=ON                                        \
-            -DLLVM_TARGETS_TO_BUILD=x86                                    \
+            -DLLVM_TARGETS_TO_BUILD=X86                                    \
             -DLLVM_ENABLE_BINDINGS=OFF                                     \
             -DLLVM_BUILD_TOOLS=OFF                                         \
             -DLLVM_ENABLE_ZSTD=OFF                                         \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,7 @@ jobs:
           pushd /home/runner/work/llvm-mlir
           echo "INFO: Need to rebuild LLVM-MLIR. Previous installation for MLIR not found"
           np=`nproc`
-          git clone https://github.com/llvm/llvm-project --depth 1 || exit 1
+          git clone https://github.com/llvm/llvm-project || exit 1
           cd llvm-project || exit 1
           git checkout $LLVM_SHA || exit 1
           mkdir _build || exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,6 +145,7 @@ jobs:
           pushd /home/runner/work/llvm-mlir
           echo "INFO: Need to rebuild LLVM-MLIR. Previous installation for MLIR not found"
           np=`nproc`
+          echo "INFO: nproc $np"
           git clone https://github.com/llvm/llvm-project || exit 1
           cd llvm-project || exit 1
           git checkout $LLVM_SHA || exit 1
@@ -162,9 +163,9 @@ jobs:
             -DLLVM_ENABLE_BINDINGS=OFF                                     \
             -DLLVM_BUILD_TOOLS=OFF                                         \
             -DLLVM_ENABLE_ZSTD=OFF                                         \
+            -DLLVM_DISTRIBUTION_COMPONENTS=llvm-headers;llvm-libraries;cmake-exports;FileCheck;count;not;mlir-headers;mlir-libraries;mlir-cmake-exports;mlir-tblgen \
             -DCMAKE_INSTALL_PREFIX=/home/runner/work/llvm-mlir/_mlir_install || exit 1
-          cmake --build . || exit 1
-          cmake --install . || exit 1
+          cmake --install-distribution-stripped . || exit 1
           cp bin/FileCheck /home/runner/work/llvm-mlir/_mlir_install/bin/
           cp bin/count /home/runner/work/llvm-mlir/_mlir_install/bin/
           cp bin/not /home/runner/work/llvm-mlir/_mlir_install/bin/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,7 +162,7 @@ jobs:
             -DLLVM_TARGETS_TO_BUILD=X86                                    \
             -DLLVM_ENABLE_BINDINGS=OFF                                     \
             -DLLVM_ENABLE_ZSTD=OFF                                         \
-            -DLLVM_DISTRIBUTION_COMPONENTS=llvm-headers;llvm-libraries;cmake-exports;FileCheck;count;not;mlir-headers;mlir-libraries;mlir-cmake-exports;mlir-tblgen \
+            -DLLVM_DISTRIBUTION_COMPONENTS="llvm-headers;llvm-libraries;cmake-exports;FileCheck;count;not;mlir-headers;mlir-libraries;mlir-cmake-exports;mlir-tblgen" \
             -DCMAKE_INSTALL_PREFIX=/home/runner/work/llvm-mlir/_mlir_install || exit 1
           ninja install-distribution-stripped || exit 1
           cp bin/FileCheck /home/runner/work/llvm-mlir/_mlir_install/bin/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,7 +161,6 @@ jobs:
             -DLLVM_INSTALL_UTILS=ON                                        \
             -DLLVM_TARGETS_TO_BUILD=X86                                    \
             -DLLVM_ENABLE_BINDINGS=OFF                                     \
-            -DLLVM_BUILD_TOOLS=OFF                                         \
             -DLLVM_ENABLE_ZSTD=OFF                                         \
             -DLLVM_DISTRIBUTION_COMPONENTS=llvm-headers;llvm-libraries;cmake-exports;FileCheck;count;not;mlir-headers;mlir-libraries;mlir-cmake-exports;mlir-tblgen \
             -DCMAKE_INSTALL_PREFIX=/home/runner/work/llvm-mlir/_mlir_install || exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,7 @@ jobs:
           pushd /home/runner/work/llvm-mlir
           echo "INFO: Need to rebuild LLVM-MLIR. Previous installation for MLIR not found"
           np=`nproc`
-          git clone https://github.com/llvm/llvm-project || exit 1
+          git clone https://github.com/llvm/llvm-project --depth 1 || exit 1
           cd llvm-project || exit 1
           git checkout $LLVM_SHA || exit 1
           mkdir _build || exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,7 +164,7 @@ jobs:
             -DLLVM_ENABLE_ZSTD=OFF                                         \
             -DCMAKE_INSTALL_PREFIX=/home/runner/work/llvm-mlir/_mlir_install || exit 1
           cmake --build . -j ${np} || exit 1
-          cmake --install . || exit 1
+          cmake --install-distribution-stripped . || exit 1
           cp bin/FileCheck /home/runner/work/llvm-mlir/_mlir_install/bin/
           cp bin/count /home/runner/work/llvm-mlir/_mlir_install/bin/
           cp bin/not /home/runner/work/llvm-mlir/_mlir_install/bin/


### PR DESCRIPTION
* CI was stuck in llvm recompilation again due to cache exhaustion, had to clean it manually
* Reduced cache size 2.7Gb -> 320Mb
* Reduced llvm compilation time 3+ hrs -> 1hr