### PR TITLE
Add spirv capability attribute to the gpu.module

### DIFF
--- a/lib/Transforms/SetSPIRVCapabilities.cpp
+++ b/lib/Transforms/SetSPIRVCapabilities.cpp
@@ -15,6 +15,8 @@
 
 #include <imex/Transforms/Passes.h>
 
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVDialect.h"
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SPIRV/IR/TargetAndABI.h>
 #include <mlir/Pass/Pass.h>
@@ -53,8 +55,10 @@ struct SetSPIRVCapabilitiesPass
         triple, spirv::Vendor::Unknown, spirv::DeviceType::Unknown,
         spirv::TargetEnvAttr::kUnknownDeviceID,
         spirv::getDefaultResourceLimits(context));
-    auto module = getOperation();
-    module->setAttr(spirv::getTargetEnvAttrName(), attr);
+    auto op = getOperation();
+    op->walk([&](mlir::gpu::GPUModuleOp op) {
+      op->setAttr(spirv::getTargetEnvAttrName(), attr);
+    });
   }
 };
 

--- a/test/Transforms/set-spirv-capability.mlir
+++ b/test/Transforms/set-spirv-capability.mlir
@@ -2,8 +2,8 @@
 
 module attributes {gpu.container_module} {
 
-// CHECK: module attributes {gpu.container_module, spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume]>, #spirv.resource_limits<>>} {
-
+// CHECK: module attributes {gpu.container_module} {
+// CHECK: gpu.module @main_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume]>, #spirv.resource_limits<>>} {
   gpu.module @main_kernel {
     gpu.func @main_kernel(%arg0: memref<8xf32>, %arg1: memref<8xf32>, %arg2: memref<8xf32>) kernel attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
       cf.br ^bb1


### PR DESCRIPTION
Please review these guidelines to help with the review process:
- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
- [x] Have you organized your commits logically and ensured each can be built by itself?

Add the spirv capabitity attribute only to the gpu.modules