### PR TITLE
NTensor: propagate enviroment pass

### DIFF
--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -56,6 +56,7 @@ set(SOURCES_LIST
     lib/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.cpp
     lib/Dialect/imex_util/Dialect.cpp
     lib/Dialect/ntensor/IR/NTensorOps.cpp
+    lib/Dialect/ntensor/Transforms/PropagateEnvironment.cpp
     lib/Dialect/ntensor/Transforms/ResolveArrayOps.cpp
     lib/Dialect/plier/Dialect.cpp
     lib/ExecutionEngine/ExecutionEngine.cpp
@@ -101,6 +102,7 @@ set(HEADERS_LIST
     include/imex/Dialect/imex_util/Dialect.hpp
     include/imex/Dialect/imex_util/Utils.hpp
     include/imex/Dialect/ntensor/IR/NTensorOps.hpp
+    include/imex/Dialect/ntensor/Transforms/PropagateEnvironment.hpp
     include/imex/Dialect/ntensor/Transforms/ResolveArrayOps.hpp
     include/imex/Dialect/plier/Dialect.hpp
     include/imex/ExecutionEngine/ExecutionEngine.hpp

--- a/mlir/include/imex/Dialect/ntensor/Transforms/PropagateEnvironment.hpp
+++ b/mlir/include/imex/Dialect/ntensor/Transforms/PropagateEnvironment.hpp
@@ -22,6 +22,8 @@ class Pass;
 
 namespace imex {
 namespace ntensor {
+/// Propagate enviroment attribute through the ntensor ops using dataflow
+/// analysis.
 std::unique_ptr<mlir::Pass> createPropagateEnvironmentPass();
 } // namespace ntensor
 } // namespace imex

--- a/mlir/include/imex/Dialect/ntensor/Transforms/PropagateEnvironment.hpp
+++ b/mlir/include/imex/Dialect/ntensor/Transforms/PropagateEnvironment.hpp
@@ -1,0 +1,27 @@
+// Copyright 2022 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+namespace mlir {
+class Pass;
+} // namespace mlir
+
+namespace imex {
+namespace ntensor {
+std::unique_ptr<mlir::Pass> createPropagateEnvironmentPass();
+} // namespace ntensor
+} // namespace imex

--- a/mlir/lib/Dialect/ntensor/Transforms/PropagateEnvironment.cpp
+++ b/mlir/lib/Dialect/ntensor/Transforms/PropagateEnvironment.cpp
@@ -109,7 +109,7 @@ public:
     if (isUninitialized()) {
       os << "None";
     } else if (isInvalid()) {
-      os << "Invalid";
+      os << "Invalid: " << getInvalidReason();
     } else {
       os << env.get<mlir::Attribute>();
     }

--- a/mlir/lib/Dialect/ntensor/Transforms/PropagateEnvironment.cpp
+++ b/mlir/lib/Dialect/ntensor/Transforms/PropagateEnvironment.cpp
@@ -17,6 +17,7 @@
 #include "imex/Dialect/ntensor/IR/NTensorOps.hpp"
 
 #include <llvm/Support/Debug.h>
+#include <mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h>
 #include <mlir/Analysis/DataFlow/DeadCodeAnalysis.h>
 #include <mlir/Analysis/DataFlow/SparseAnalysis.h>
 #include <mlir/Pass/Pass.h>
@@ -146,10 +147,12 @@ struct PropagateEnvironmentPass
   }
 
   void runOnOperation() override {
+    LLVM_DEBUG(llvm::dbgs() << "PropagateEnvironmentPass:\n");
     auto *root = getOperation();
 
     mlir::DataFlowSolver solver;
     solver.load<mlir::dataflow::DeadCodeAnalysis>();
+    solver.load<mlir::dataflow::SparseConstantPropagation>();
     solver.load<EnvValueAnalysis>();
     if (mlir::failed(solver.initializeAndRun(root)))
       return signalPassFailure();

--- a/mlir/lib/Dialect/ntensor/Transforms/PropagateEnvironment.cpp
+++ b/mlir/lib/Dialect/ntensor/Transforms/PropagateEnvironment.cpp
@@ -167,10 +167,8 @@ struct PropagateEnvironmentPass
           auto *state = solver.lookupState<EnvValueLattice>(arg);
           assert(state && "Invalid state");
           auto &val = state->getValue();
-          if (val.isUninitialized()) {
-            op->emitError("Cannot deduce environment type");
-            return;
-          }
+          if (val.isUninitialized())
+            continue;
 
           if (auto newEnv = val.getEnv()) {
             if (!env) {
@@ -178,6 +176,7 @@ struct PropagateEnvironmentPass
             } else if (env != newEnv) {
               op->emitError("Enviroment type conflict: ")
                   << env << " " << newEnv;
+              signalPassFailure();
               return;
             }
           }

--- a/mlir/lib/Dialect/ntensor/Transforms/PropagateEnvironment.cpp
+++ b/mlir/lib/Dialect/ntensor/Transforms/PropagateEnvironment.cpp
@@ -28,7 +28,7 @@
 namespace {
 static bool needUpdate(mlir::Operation *op) {
   assert(op && "Invalid op");
-  return mlir::isa<imex::ntensor::PrimitiveOp, imex::ntensor::CastOp>(op);
+  return mlir::isa<imex::ntensor::NTensorDialect>(op->getDialect());
 }
 
 static bool needPropagation(mlir::Operation *op) {

--- a/mlir/lib/Dialect/ntensor/Transforms/PropagateEnvironment.cpp
+++ b/mlir/lib/Dialect/ntensor/Transforms/PropagateEnvironment.cpp
@@ -137,7 +137,6 @@ class EnvValueAnalysis
 public:
   using SparseDataFlowAnalysis::SparseDataFlowAnalysis;
 
-  /// The underlying value of the results of an operation are not known.
   void visitOperation(mlir::Operation *op,
                       llvm::ArrayRef<const EnvValueLattice *> operands,
                       llvm::ArrayRef<EnvValueLattice *> results) override {

--- a/mlir/lib/Dialect/ntensor/Transforms/PropagateEnvironment.cpp
+++ b/mlir/lib/Dialect/ntensor/Transforms/PropagateEnvironment.cpp
@@ -176,7 +176,6 @@ public:
     }
   }
 
-  /// At an entry point, the underlying value of a value is itself.
   void setToEntryState(EnvValueLattice *lattice) override {
     propagateIfChanged(lattice, lattice->join(EnvValue{}));
   }

--- a/mlir/test/Dialect/ntensor/propagate-env.mlir
+++ b/mlir/test/Dialect/ntensor/propagate-env.mlir
@@ -13,8 +13,9 @@ func.func @test(%arg1: !ntensor.ntensor<?xf32>) -> !ntensor.ntensor<?xf32> {
 
 // CHECK-LABEL: func @test
 //  CHECK-SAME: (%[[ARG:.*]]: !ntensor.ntensor<?xf32, "test">)
-//       CHECK: %[[RES:.*]] = ntensor.primitive "foo" (%[[ARG]]) : !ntensor.ntensor<?xf32> -> !ntensor.ntensor<?xf32>
-//       CHECK: return %[[RES]]
+//       CHECK: %[[RES1:.*]] = ntensor.primitive "foo" (%[[ARG]]) : !ntensor.ntensor<?xf32, "test"> -> !ntensor.ntensor<?xf32, "test">
+//       CHECK: %[[RES2:.*]] = ntensor.cast %[[RES1]] : !ntensor.ntensor<?xf32, "test"> to !ntensor.ntensor<?xf32>
+//       CHECK: return %[[RES2]]
 func.func @test(%arg1: !ntensor.ntensor<?xf32, "test">) -> !ntensor.ntensor<?xf32> {
   %0 = ntensor.cast %arg1 : !ntensor.ntensor<?xf32, "test"> to !ntensor.ntensor<?xf32>
   %1 = ntensor.primitive "foo" (%0) : !ntensor.ntensor<?xf32> -> !ntensor.ntensor<?xf32>

--- a/mlir/test/Dialect/ntensor/propagate-env.mlir
+++ b/mlir/test/Dialect/ntensor/propagate-env.mlir
@@ -1,0 +1,22 @@
+// RUN: imex-opt --ntensor-propagate-env --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: func @test
+//  CHECK-SAME: (%[[ARG:.*]]: !ntensor.ntensor<?xf32>)
+//       CHECK: %[[RES:.*]] = ntensor.primitive "foo" (%[[ARG]]) : !ntensor.ntensor<?xf32> -> !ntensor.ntensor<?xf32>
+//       CHECK: return %[[RES]]
+func.func @test(%arg1: !ntensor.ntensor<?xf32>) -> !ntensor.ntensor<?xf32> {
+  %0 = ntensor.primitive "foo" (%arg1) : !ntensor.ntensor<?xf32> -> !ntensor.ntensor<?xf32>
+  return %0 : !ntensor.ntensor<?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @test
+//  CHECK-SAME: (%[[ARG:.*]]: !ntensor.ntensor<?xf32, "test">)
+//       CHECK: %[[RES:.*]] = ntensor.primitive "foo" (%[[ARG]]) : !ntensor.ntensor<?xf32> -> !ntensor.ntensor<?xf32>
+//       CHECK: return %[[RES]]
+func.func @test(%arg1: !ntensor.ntensor<?xf32, "test">) -> !ntensor.ntensor<?xf32> {
+  %0 = ntensor.cast %arg1 : !ntensor.ntensor<?xf32, "test"> to !ntensor.ntensor<?xf32>
+  %1 = ntensor.primitive "foo" (%0) : !ntensor.ntensor<?xf32> -> !ntensor.ntensor<?xf32>
+  return %1 : !ntensor.ntensor<?xf32>
+}

--- a/mlir/test/Dialect/ntensor/propagate-env.mlir
+++ b/mlir/test/Dialect/ntensor/propagate-env.mlir
@@ -25,7 +25,7 @@ func.func @test(%arg1: !ntensor.ntensor<?xf32, "test">) -> !ntensor.ntensor<?xf3
 // -----
 
 // CHECK-LABEL: func @test
-//       CHECK: %[[RES1:.*]] = scf.if {{.*}} -> (!ntensor.ntensor<?xf32>)
+//       CHECK: %[[RES1:.*]] = scf.if %{{.*}} -> (!ntensor.ntensor<?xf32>)
 //       CHECK: %[[RES2:.*]] = ntensor.cast %[[RES1]] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32, "test1">
 //       CHECK: %[[RES3:.*]] = ntensor.primitive "foo" (%[[RES2]]) : !ntensor.ntensor<?xf32, "test1"> -> !ntensor.ntensor<?xf32, "test1">
 //       CHECK: %[[RES4:.*]] = ntensor.cast %[[RES3]] : !ntensor.ntensor<?xf32, "test1"> to !ntensor.ntensor<?xf32>
@@ -38,6 +38,22 @@ func.func @test(%arg1: !ntensor.ntensor<?xf32, "test1">, %arg2: !ntensor.ntensor
   } else {
     scf.yield %1 : !ntensor.ntensor<?xf32>
   }
+  %4 = ntensor.primitive "foo" (%3) : !ntensor.ntensor<?xf32> -> !ntensor.ntensor<?xf32>
+  return %4 : !ntensor.ntensor<?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @test
+//       CHECK: %[[RES1:.*]] = arith.select %{{.*}}, %{{.*}}, %{{.*}} : !ntensor.ntensor<?xf32>
+//       CHECK: %[[RES2:.*]] = ntensor.cast %[[RES1]] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32, "test1">
+//       CHECK: %[[RES3:.*]] = ntensor.primitive "foo" (%[[RES2]]) : !ntensor.ntensor<?xf32, "test1"> -> !ntensor.ntensor<?xf32, "test1">
+//       CHECK: %[[RES4:.*]] = ntensor.cast %[[RES3]] : !ntensor.ntensor<?xf32, "test1"> to !ntensor.ntensor<?xf32>
+//       CHECK: return %[[RES4]]
+func.func @test(%arg1: !ntensor.ntensor<?xf32, "test1">, %arg2: !ntensor.ntensor<?xf32, "test1">, %arg3: i1) -> !ntensor.ntensor<?xf32> {
+  %0 = ntensor.cast %arg1 : !ntensor.ntensor<?xf32, "test1"> to !ntensor.ntensor<?xf32>
+  %1 = ntensor.cast %arg2 : !ntensor.ntensor<?xf32, "test1"> to !ntensor.ntensor<?xf32>
+  %3 = arith.select %arg3, %0, %1 : !ntensor.ntensor<?xf32>
   %4 = ntensor.primitive "foo" (%3) : !ntensor.ntensor<?xf32> -> !ntensor.ntensor<?xf32>
   return %4 : !ntensor.ntensor<?xf32>
 }

--- a/mlir/test/Dialect/ntensor/propagate-env.mlir
+++ b/mlir/test/Dialect/ntensor/propagate-env.mlir
@@ -21,3 +21,23 @@ func.func @test(%arg1: !ntensor.ntensor<?xf32, "test">) -> !ntensor.ntensor<?xf3
   %1 = ntensor.primitive "foo" (%0) : !ntensor.ntensor<?xf32> -> !ntensor.ntensor<?xf32>
   return %1 : !ntensor.ntensor<?xf32>
 }
+
+// -----
+
+// CHECK-LABEL: func @test
+//       CHECK: %[[RES1:.*]] = scf.if {{.*}} -> (!ntensor.ntensor<?xf32>)
+//       CHECK: %[[RES2:.*]] = ntensor.cast %[[RES1]] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32, "test1">
+//       CHECK: %[[RES3:.*]] = ntensor.primitive "foo" (%[[RES2]]) : !ntensor.ntensor<?xf32, "test1"> -> !ntensor.ntensor<?xf32, "test1">
+//       CHECK: %[[RES4:.*]] = ntensor.cast %[[RES3]] : !ntensor.ntensor<?xf32, "test1"> to !ntensor.ntensor<?xf32>
+//       CHECK: return %[[RES4]]
+func.func @test(%arg1: !ntensor.ntensor<?xf32, "test1">, %arg2: !ntensor.ntensor<?xf32, "test1">, %arg3: i1) -> !ntensor.ntensor<?xf32> {
+  %0 = ntensor.cast %arg1 : !ntensor.ntensor<?xf32, "test1"> to !ntensor.ntensor<?xf32>
+  %1 = ntensor.cast %arg2 : !ntensor.ntensor<?xf32, "test1"> to !ntensor.ntensor<?xf32>
+  %3 = scf.if %arg3 -> !ntensor.ntensor<?xf32> {
+    scf.yield %0 : !ntensor.ntensor<?xf32>
+  } else {
+    scf.yield %1 : !ntensor.ntensor<?xf32>
+  }
+  %4 = ntensor.primitive "foo" (%3) : !ntensor.ntensor<?xf32> -> !ntensor.ntensor<?xf32>
+  return %4 : !ntensor.ntensor<?xf32>
+}

--- a/mlir/tools/imex-opt/Passes.cpp
+++ b/mlir/tools/imex-opt/Passes.cpp
@@ -29,6 +29,7 @@
 #include "imex/Conversion/NtensorToMemref.hpp"
 #include "imex/Conversion/SCFToAffine/SCFToAffine.h"
 #include "imex/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.hpp"
+#include "imex/Dialect/ntensor/Transforms/PropagateEnvironment.hpp"
 #include "imex/Dialect/ntensor/Transforms/ResolveArrayOps.hpp"
 #include "imex/Transforms/ExpandTuple.hpp"
 #include "imex/Transforms/MakeSignless.hpp"
@@ -120,6 +121,12 @@ static mlir::PassPipelineRegistration<> ntensorResolveArrayOps(
     "ntensor-resolve-array-ops", "Resolve ntensor array ops into primitive ops",
     [](mlir::OpPassManager &pm) {
       pm.addPass(imex::ntensor::createResolveArrayOpsPass());
+    });
+
+static mlir::PassPipelineRegistration<> ntensorPropagateEnv(
+    "ntensor-propagate-env", "Propagate ntensor environment",
+    [](mlir::OpPassManager &pm) {
+      pm.addPass(imex::ntensor::createPropagateEnvironmentPass());
     });
 
 static mlir::PassPipelineRegistration<>


### PR DESCRIPTION
* This is essentially a type inference for `ntensor` environment attribute, needed to propagate env through entire program (usually from function arguments).
* Uses upstream `SparseDataFlowAnalysis`.
* Only doing forward propagation (i.e. from op results to users) for now.
* For backward propagation some additional work needed to be done in upstream first.