### PR TITLE
Refactor llvm lowering

### DIFF
--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpu.hpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpu.hpp
@@ -15,4 +15,5 @@ class StringRef;
 void registerLowerToGPUPipeline(imex::PipelineRegistry &registry);
 
 llvm::StringRef lowerToGPUPipelineNameHigh();
+llvm::StringRef lowerToGPUPipelineNameMed();
 llvm::StringRef lowerToGPUPipelineNameLow();

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToLlvm.hpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToLlvm.hpp
@@ -14,4 +14,5 @@ class StringRef;
 
 void registerLowerToLLVMPipeline(imex::PipelineRegistry &registry);
 
+llvm::StringRef preLowerToLLVMPipelineName();
 llvm::StringRef lowerToLLVMPipelineName();


### PR DESCRIPTION
* Split llvm lowering into 2 stages: 
  * `preLowerToLLVMPipelineName` which does numba-specific abi preparation
  * `lowerToLLVMPipeline` which lowers rest of IR to llvm
* Split gpu lowering into 2 stages:
  * `lowerToGPUPipelineNameMed` which does medium level gpu transformations
  * `lowerToGPUPipelineNameLow` which does gpu -> llvm transformation

This is needed because if gpu -> llvm transformation is runing before pre llvm, it can accidentally break numba abi conventions