### PR TITLE
Enable e2e CFD gpu numpy tests

### DIFF
--- a/mlir/lib/Dialect/ntensor/Transforms/PropagateEnvironment.cpp
+++ b/mlir/lib/Dialect/ntensor/Transforms/PropagateEnvironment.cpp
@@ -203,7 +203,9 @@ struct PropagateEnvironmentPass
                         mlir::ValueRange(op->getResults())}) {
         for (auto arg : args) {
           auto *state = solver.lookupState<EnvValueLattice>(arg);
-          assert(state && "Invalid state");
+          if (!state)
+            continue;
+
           auto &val = state->getValue();
           if (val.isUninitialized())
             continue;

--- a/numba_dpcomp/numba_dpcomp/decorators.py
+++ b/numba_dpcomp/numba_dpcomp/decorators.py
@@ -34,7 +34,7 @@ def mlir_jit(
 
     pipeline = (
         mlir_compiler_gpu_pipeline
-        if options.get("enable_gpu_pipeline")
+        if options.get("enable_gpu_pipeline", True)
         else mlir_compiler_pipeline
     )
     options.pop("enable_gpu_pipeline", None)

--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_gpu.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_gpu.py
@@ -881,7 +881,7 @@ def test_cfd_simple1():
             )
             > 0
         ), ir
-        assert ir.count("gpu.launch blocks") == 0, ir
+        assert ir.count("gpu.launch blocks") == 1, ir
 
     _to_host(dgpu_res, gpu_res)
     assert_equal(gpu_res, sim_res)

--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_gpu.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_gpu.py
@@ -883,7 +883,7 @@ def test_cfd_simple1():
             )
             > 0
         ), ir
-        assert ir.count("gpu.launch blocks") == 1, ir
+        assert ir.count("gpu.launch blocks") > 0, ir
 
     _to_host(dgpu_res, gpu_res)
     assert_equal(gpu_res, sim_res)

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpu.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpu.cpp
@@ -1612,6 +1612,9 @@ struct GPUToLLVMPass
                                                       target);
     imex::populateUtilConversionPatterns(context, converter, patterns, target);
 
+    // TODO: There were some issues with structural conversion, investigate.
+    target.addLegalOp<mlir::arith::SelectOp>();
+
     auto mod = getOperation();
     if (mlir::failed(
             mlir::applyPartialConversion(mod, target, std::move(patterns))))

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -38,6 +38,7 @@
 #include "imex/Conversion/NtensorToMemref.hpp"
 #include "imex/Dialect/imex_util/Dialect.hpp"
 #include "imex/Dialect/ntensor/IR/NTensorOps.hpp"
+#include "imex/Dialect/ntensor/Transforms/PropagateEnvironment.hpp"
 #include "imex/Dialect/ntensor/Transforms/ResolveArrayOps.hpp"
 #include "imex/Dialect/plier/Dialect.hpp"
 #include "imex/Transforms/CanonicalizeReductions.hpp"
@@ -2531,6 +2532,7 @@ static void populatePlierToLinalgGenPipeline(mlir::OpPassManager &pm) {
   pm.addPass(std::make_unique<PlierToNtensorPass>());
   pm.addPass(mlir::createCanonicalizerPass());
   pm.addPass(std::make_unique<ResolveNumpyFuncsPass>());
+  pm.addPass(imex::ntensor::createPropagateEnvironmentPass());
   pm.addPass(std::make_unique<ResolveNtensorPass>());
   pm.addPass(mlir::createCanonicalizerPass());
   pm.addNestedPass<mlir::func::FuncOp>(imex::createNtensorAliasAnalysisPass());


### PR DESCRIPTION
* 2 simple elementwise tests
* Only numpy calls offloading is supported for now, explicit parfors are not supported yet
* Add device type inference to `plier-to-linalg` pipeline
* Add device region support to `NtensorPrimitiveCallsLowering`
* Workaround some bugs in `populateSCFStructuralTypeConversionsAndLegality`
* Some `InsertGPUAllocs` cleanup and `arith.select` support
* Enable gpu pipeline by default in our `njit` decorator (as it now checks for the device regions instead of lowering all loops unconditionally)