### PR TITLE
Rename GPUXToSPIRV Pass to GPUToSPIRVExt

### DIFF
--- a/include/imex/Conversion/GPUToSPIRV/GPUToSPIRVPass.h
+++ b/include/imex/Conversion/GPUToSPIRV/GPUToSPIRVPass.h
@@ -29,7 +29,7 @@ template <typename T> class OperationPass;
 namespace imex {
 /// Create a pass
 std::unique_ptr<::mlir::OperationPass<::mlir::ModuleOp>>
-createConvertGPUXToSPIRVPass(bool mapMemorySpace = true);
+createConvertGPUToSPIRVExtPass(bool mapMemorySpace = true);
 
 } // namespace imex
 

--- a/include/imex/Conversion/Passes.td
+++ b/include/imex/Conversion/Passes.td
@@ -90,7 +90,7 @@ def ConvertDistToStandard: Pass<"convert-dist-to-standard", "::mlir::ModuleOp"> 
 // GPUToSPIRV
 //===----------------------------------------------------------------------===//
 
-def ConvertGPUXToSPIRV : Pass<"imex-convert-gpu-to-spirv", "::mlir::ModuleOp"> {
+def ConvertGPUToSPIRVExt : Pass<"imex-convert-gpu-to-spirv", "::mlir::ModuleOp"> {
   let summary = "Convert GPU dialect to SPIR-V dialect";
   let description = [{
     This pass extends upstream GPU dialect to SPIR-V dialect pass by adding more
@@ -247,7 +247,7 @@ memref, arith and math.
     }
     ```
   }];
-  let constructor = "imex::createConvertGPUXToSPIRVPass()";
+  let constructor = "imex::createConvertGPUToSPIRVExtPass()";
   let dependentDialects = ["::mlir::spirv::SPIRVDialect"];
 }
 

--- a/lib/Conversion/GPUToSPIRV/GPUToSPIRVPass.cpp
+++ b/lib/Conversion/GPUToSPIRV/GPUToSPIRVPass.cpp
@@ -40,9 +40,12 @@ namespace imex {
 /// replace it).
 ///
 /// 2) Lower the body of the spirv::ModuleOp.
-class GPUXToSPIRVPass : public ::imex::ConvertGPUXToSPIRVBase<GPUXToSPIRVPass> {
+/// This pass extends upstream GPU dialect to SPIR-V dialect pass by adding more
+/// conversion patterns like SCF, math and control flow.
+class GPUToSPIRVExtPass
+    : public ::imex::ConvertGPUToSPIRVExtBase<GPUToSPIRVExtPass> {
 public:
-  explicit GPUXToSPIRVPass(bool mapMemorySpace)
+  explicit GPUToSPIRVExtPass(bool mapMemorySpace)
       : mapMemorySpace(mapMemorySpace) {}
   void runOnOperation() override;
 
@@ -50,7 +53,7 @@ private:
   bool mapMemorySpace;
 };
 
-void GPUXToSPIRVPass::runOnOperation() {
+void GPUToSPIRVExtPass::runOnOperation() {
   mlir::MLIRContext *context = &getContext();
   mlir::ModuleOp module = getOperation();
 
@@ -108,7 +111,7 @@ void GPUXToSPIRVPass::runOnOperation() {
 }
 
 std::unique_ptr<::mlir::OperationPass<::mlir::ModuleOp>>
-createConvertGPUXToSPIRVPass(bool mapMemorySpace) {
-  return std::make_unique<GPUXToSPIRVPass>(mapMemorySpace);
+createConvertGPUToSPIRVExtPass(bool mapMemorySpace) {
+  return std::make_unique<GPUToSPIRVExtPass>(mapMemorySpace);
 }
 } // namespace imex


### PR DESCRIPTION
GPUXToSPIRV pass is just extension to upstream GPUTOSPIRV pass, it does not use with GPUX dialect, so this patch is correcting the misleading pass name.

Please review these guidelines to help with the review process:
- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [ ] Have you organized your commits logically and ensured each can be built by itself?
