### PR TITLE
Add out parameter support to numpu func builder

### DIFF
--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_numpy.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_numpy.py
@@ -410,6 +410,30 @@ def test_dot(a, b, parallel):
     assert_equal(py_func(a, b), jit_func(a, b))
 
 
+@pytest.mark.parametrize(
+    "a,b",
+    [
+        (
+            np.array([[1, 2, 3], [4, 5, 6]], np.float32),
+            np.array([[1, 2], [3, 4], [5, 6]], np.float32),
+        ),
+    ],
+)
+def test_dot_out(a, b):
+    def py_func(a, b, c):
+        np.dot(a, b, out=c)
+
+    jit_func = njit(py_func)
+
+    tmp = np.dot(a, b)
+    res_py = np.zeros_like(tmp)
+    res_jit = np.zeros_like(tmp)
+
+    py_func(a, b, res_py)
+    jit_func(a, b, res_jit)
+    assert_equal(res_py, res_jit)
+
+
 def test_prange_lowering():
     def py_func(arr):
         res = 0

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/NumpyResolver.hpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/NumpyResolver.hpp
@@ -34,7 +34,8 @@ public:
   resolveFuncArgs(mlir::OpBuilder &builder, mlir::Location loc,
                   llvm::StringRef name, mlir::ValueRange args,
                   mlir::ArrayAttr argsNames,
-                  llvm::SmallVectorImpl<mlir::Value> &resultArgs);
+                  llvm::SmallVectorImpl<mlir::Value> &resultArgs,
+                  llvm::SmallVectorImpl<mlir::Value> &outArgs);
 
 private:
   class Impl;


### PR DESCRIPTION
* Add special `out` argument to `register_func` (part of numpy builder)
* Add out parameters support to `NumpyCallsResolver`, calls with the out parameters will be lowered exactly like functions without but then additional `ntensor.copy` ops will be inserted to copy data from results to out parameters (those copies can be potentially fused with other ops later).
* Add `out` param support to `numpy.dot`