### PR TITLE
EnforceShapeOp refactor

### DIFF
--- a/mlir/include/imex/Dialect/imex_util/ImexUtilOps.td
+++ b/mlir/include/imex/Dialect/imex_util/ImexUtilOps.td
@@ -51,16 +51,19 @@ class ImexUtil_Op<string mnemonic, list<Trait> traits = []>
     : Op<ImexUtil_Dialect, mnemonic, traits>;
 
 def EnforceShapeOp : ImexUtil_Op<"enforce_shape"> {
-  let arguments = (ins AnyRankedTensor : $value, Variadic<Index> : $sizes);
 
-  let results = (outs AnyRankedTensor : $result);
+  let arguments = (ins AnyShaped:$value, Variadic<Index>:$sizes);
+  let results = (outs AnyShaped:$result);
 
-  let builders = [OpBuilder<(ins "::mlir::Value"
-                             : $value, "::mlir::ValueRange"
-                             : $shape)>];
+  let builders = [OpBuilder<(ins
+    "::mlir::Value":$value,
+    "::mlir::ValueRange":$shape)
+  >];
 
   let hasFolder = 1;
   let hasCanonicalizer = 1;
+
+  let assemblyFormat = "attr-dict $value `:` type($value) `(` $sizes `)` `->` type($result)";
 }
 
 def ParallelOp : ImexUtil_Op<"parallel", [

--- a/mlir/test/Dialect/imex_util/canonicalize.mlir
+++ b/mlir/test/Dialect/imex_util/canonicalize.mlir
@@ -116,3 +116,39 @@ func.func @merge_adjacent_region2() {
 //  CHECK-NEXT:   "test.test3"(%[[VAL2]]) : (i64) -> ()
 //  CHECK-NEXT:   }
 //  CHECK-NEXT:   return
+
+// -----
+
+// CHECK-LABEL: func @test
+//  CHECK-SAME:   (%[[ARG1:.*]]: tensor<?x?xf32>, %[[ARG2:.*]]: index, %[[ARG3:.*]]: index)
+//       CHECK:   return %[[ARG3]]
+func.func @test(%arg1: tensor<?x?xf32>, %arg2: index, %arg3: index) -> index {
+  %cst = arith.constant 1 : index
+  %0 = imex_util.enforce_shape %arg1 : tensor<?x?xf32>(%arg2, %arg3) -> tensor<?x?xf32>
+  %1 = tensor.dim %0, %cst : tensor<?x?xf32>
+  return %1: index
+}
+
+// -----
+
+// CHECK-LABEL: func @test
+//  CHECK-SAME:   (%[[ARG1:.*]]: memref<?x?xf32>, %[[ARG2:.*]]: index, %[[ARG3:.*]]: index)
+//       CHECK:   return %[[ARG3]]
+func.func @test(%arg1: memref<?x?xf32>, %arg2: index, %arg3: index) -> index {
+  %cst = arith.constant 1 : index
+  %0 = imex_util.enforce_shape %arg1 : memref<?x?xf32>(%arg2, %arg3) -> memref<?x?xf32>
+  %1 = memref.dim %0, %cst : memref<?x?xf32>
+  return %1: index
+}
+
+// -----
+
+// CHECK-LABEL: func @test
+//  CHECK-SAME:   (%[[ARG1:.*]]: !ntensor.ntensor<?x?xf32>, %[[ARG2:.*]]: index, %[[ARG3:.*]]: index)
+//       CHECK:   return %[[ARG3]]
+func.func @test(%arg1: !ntensor.ntensor<?x?xf32>, %arg2: index, %arg3: index) -> index {
+  %cst = arith.constant 1 : index
+  %0 = imex_util.enforce_shape %arg1 : !ntensor.ntensor<?x?xf32>(%arg2, %arg3) -> !ntensor.ntensor<?x?xf32>
+  %1 = ntensor.dim %0, %cst : !ntensor.ntensor<?x?xf32>
+  return %1: index
+}

--- a/mlir/test/Dialect/imex_util/ops.mlir
+++ b/mlir/test/Dialect/imex_util/ops.mlir
@@ -114,3 +114,14 @@ func.func @test(%arg1: index) -> index {
 //  CHECK-NEXT:     imex_util.env_region_yield %[[ARG1]] : index
 //  CHECK-NEXT:   }
 //  CHECK-NEXT:   return %[[RES]] : index
+
+// -----
+
+// CHECK-LABEL: func @test
+//  CHECK-SAME:   (%[[ARG1:.*]]: tensor<?xf32>, %[[ARG2:.*]]: index)
+//  CHECK-NEXT:   %[[RES:.*]] = imex_util.enforce_shape %[[ARG1]] : tensor<?xf32>(%[[ARG2]]) -> tensor<?xf32>
+//  CHECK-NEXT:   return %[[RES]]
+func.func @test(%arg1: tensor<?xf32>, %arg2: index) -> tensor<?xf32> {
+  %0 = imex_util.enforce_shape %arg1 : tensor<?xf32>(%arg2) -> tensor<?xf32>
+  return %0: tensor<?xf32>
+}


### PR DESCRIPTION
* Add assembly format to the op
* Make canonicalization operate on general `ShapedDimOpInterface` instead of individual `DimOp`s from different dialects
* Add tests
