### PR TITLE
ntensor: allow element conversion in `setitem` op

### DIFF
--- a/mlir/include/imex/Transforms/CastUtils.hpp
+++ b/mlir/include/imex/Transforms/CastUtils.hpp
@@ -20,4 +20,8 @@ mlir::Value indexCast(mlir::OpBuilder &builder, mlir::Location loc,
 
 mlir::Type makeSignlessType(mlir::Type type);
 mlir::IntegerType makeSignlessType(mlir::IntegerType type);
+
+bool canConvert(mlir::Type srcType, mlir::Type dstType);
+mlir::Value doConvert(mlir::OpBuilder &rewriter, mlir::Location loc,
+                      mlir::Value val, mlir::Type dstType);
 } // namespace imex

--- a/mlir/lib/Dialect/ntensor/Transforms/ResolveArrayOps.cpp
+++ b/mlir/lib/Dialect/ntensor/Transforms/ResolveArrayOps.cpp
@@ -272,8 +272,11 @@ struct SetitemOpLowering
             dynamicDims.emplace_back(
                 rewriter.create<imex::ntensor::DimOp>(loc, dst, i));
         }
+        auto dstVal =
+            imex::doConvert(rewriter, loc, value, dstType.getElementType());
+        assert(dstVal);
         return rewriter.create<imex::ntensor::CreateArrayOp>(
-            loc, dstType, dynamicDims, value);
+            loc, dstType, dynamicDims, dstVal);
       }();
       rewriter.replaceOpWithNewOp<imex::ntensor::CopyOp>(op, newArray, dst);
     } else {

--- a/mlir/lib/Dialect/ntensor/Transforms/ResolveArrayOps.cpp
+++ b/mlir/lib/Dialect/ntensor/Transforms/ResolveArrayOps.cpp
@@ -6,6 +6,7 @@
 
 #include "imex/Dialect/imex_util/Dialect.hpp"
 #include "imex/Dialect/ntensor/IR/NTensorOps.hpp"
+#include "imex/Transforms/CastUtils.hpp"
 
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Pass/Pass.h>
@@ -199,11 +200,12 @@ toValues(mlir::OpBuilder &builder, mlir::Location loc,
 
 static bool isCompatibleSetitemValue(mlir::Type valueType,
                                      imex::ntensor::NTensorType targetType) {
-  if (targetType.getElementType() == valueType)
+  if (imex::canConvert(targetType.getElementType(), valueType))
     return true;
 
   if (auto valueArray = valueType.dyn_cast<imex::ntensor::NTensorType>())
-    return valueArray.getElementType() == targetType.getElementType();
+    return imex::canConvert(valueArray.getElementType(),
+                            targetType.getElementType());
 
   return false;
 }
@@ -244,8 +246,22 @@ struct SetitemOpLowering
                              dimsIndices);
 
       auto newArray = [&]() -> mlir::Value {
-        if (value.getType().isa<imex::ntensor::NTensorType>())
+        if (auto srcType =
+                value.getType().dyn_cast<imex::ntensor::NTensorType>()) {
+          auto dstElementType = targetType.getElementType();
+          if (srcType.getElementType() != dstElementType) {
+            auto bodyBuilder = [&](mlir::OpBuilder &b, mlir::Location l,
+                                   mlir::Value val) {
+              auto res = imex::doConvert(b, l, val, dstElementType);
+              assert(res);
+              b.create<imex::ntensor::ElementwiseYieldOp>(l, res);
+            };
+
+            return rewriter.create<imex::ntensor::ElementwiseOp>(
+                loc, targetType, value, bodyBuilder);
+          }
           return value;
+        }
 
         auto dstType = dst.getType().cast<imex::ntensor::NTensorType>();
         mlir::SmallVector<mlir::Value> dynamicDims;

--- a/mlir/lib/Transforms/CastUtils.cpp
+++ b/mlir/lib/Transforms/CastUtils.cpp
@@ -56,3 +56,172 @@ mlir::IntegerType imex::makeSignlessType(mlir::IntegerType type) {
 
   return type;
 }
+
+static bool isInt(mlir::Type type) {
+  assert(type);
+  return type.isa<mlir::IntegerType>();
+}
+
+static bool isFloat(mlir::Type type) {
+  assert(type);
+  return type.isa<mlir::FloatType>();
+}
+
+static bool isIndex(mlir::Type type) {
+  assert(type);
+  return type.isa<mlir::IndexType>();
+}
+
+static mlir::Value intCast(mlir::OpBuilder &rewriter, mlir::Location loc,
+                           mlir::Value val, mlir::Type dstType) {
+  auto srcIntType = val.getType().cast<mlir::IntegerType>();
+  auto dstIntType = dstType.cast<mlir::IntegerType>();
+  auto srcSignless = imex::makeSignlessType(srcIntType);
+  auto dstSignless = imex::makeSignlessType(dstIntType);
+  auto srcBits = srcIntType.getWidth();
+  auto dstBits = dstIntType.getWidth();
+
+  if (srcIntType != srcSignless)
+    val = rewriter.createOrFold<imex::util::SignCastOp>(loc, srcSignless, val);
+
+  if (dstBits > srcBits) {
+    if (srcIntType.isSigned()) {
+      val = rewriter.createOrFold<mlir::arith::ExtSIOp>(loc, dstSignless, val);
+    } else {
+      val = rewriter.createOrFold<mlir::arith::ExtUIOp>(loc, dstSignless, val);
+    }
+  } else if (dstBits < srcBits) {
+    if (dstBits == 1) {
+      // Special handling for bool
+      auto zero = rewriter.create<mlir::arith::ConstantIntOp>(loc, 0, srcBits);
+      auto cmp = rewriter.createOrFold<mlir::arith::CmpIOp>(
+          loc, mlir::arith::CmpIPredicate::eq, val, zero);
+      auto trueVal = rewriter.create<mlir::arith::ConstantIntOp>(loc, 1, 1);
+      auto falseVal = rewriter.create<mlir::arith::ConstantIntOp>(loc, 0, 1);
+      val = rewriter.createOrFold<mlir::arith::SelectOp>(loc, cmp, falseVal,
+                                                         trueVal);
+    } else {
+      val = rewriter.createOrFold<mlir::arith::TruncIOp>(loc, dstSignless, val);
+    }
+  }
+
+  if (dstIntType != dstSignless)
+    val = rewriter.createOrFold<imex::util::SignCastOp>(loc, dstIntType, val);
+
+  return val;
+}
+
+static mlir::Value intFloatCast(mlir::OpBuilder &rewriter, mlir::Location loc,
+                                mlir::Value val, mlir::Type dstType) {
+  auto srcIntType = val.getType().cast<mlir::IntegerType>();
+  auto signlessType = imex::makeSignlessType(srcIntType);
+  if (val.getType() != signlessType)
+    val = rewriter.createOrFold<imex::util::SignCastOp>(loc, signlessType, val);
+
+  if (srcIntType.isSigned()) {
+    return rewriter.createOrFold<mlir::arith::SIToFPOp>(loc, dstType, val);
+  } else {
+    return rewriter.createOrFold<mlir::arith::UIToFPOp>(loc, dstType, val);
+  }
+}
+
+static mlir::Value floatIntCast(mlir::OpBuilder &rewriter, mlir::Location loc,
+                                mlir::Value val, mlir::Type dstType) {
+  auto dstIntType = dstType.cast<mlir::IntegerType>();
+  mlir::Value res;
+  auto dstSignlessType = imex::makeSignlessType(dstIntType);
+  if (dstIntType.getWidth() == 1) {
+    // Special handling for bool
+    auto floatType = val.getType().cast<mlir::FloatType>();
+    auto getZeroFloat = [&]() -> llvm::APFloat {
+      if (floatType.isF64())
+        return llvm::APFloat(0.0);
+      if (floatType.isF32())
+        return llvm::APFloat(0.0f);
+      llvm_unreachable("Umhandled float type");
+    };
+    auto zero = rewriter.create<mlir::arith::ConstantFloatOp>(
+        loc, getZeroFloat(), floatType);
+    auto cmp = rewriter.createOrFold<mlir::arith::CmpFOp>(
+        loc, mlir::arith::CmpFPredicate::OEQ, val, zero);
+    auto trueVal = rewriter.create<mlir::arith::ConstantIntOp>(loc, 1, 1);
+    auto falseVal = rewriter.create<mlir::arith::ConstantIntOp>(loc, 0, 1);
+    res = rewriter.createOrFold<mlir::arith::SelectOp>(loc, cmp, falseVal,
+                                                       trueVal);
+  } else if (dstIntType.isSigned()) {
+    res = rewriter.create<mlir::arith::FPToSIOp>(loc, dstSignlessType, val);
+  } else {
+    res = rewriter.create<mlir::arith::FPToUIOp>(loc, dstSignlessType, val);
+  }
+  if (dstSignlessType != dstIntType) {
+    return rewriter.createOrFold<imex::util::SignCastOp>(loc, dstIntType, res);
+  }
+  return res;
+}
+
+static mlir::Value indexCastImpl(mlir::OpBuilder &rewriter, mlir::Location loc,
+                                 mlir::Value val, mlir::Type dstType) {
+  if (val.getType().isa<mlir::FloatType>()) {
+    auto intType = rewriter.getI64Type();
+    val = rewriter.createOrFold<mlir::arith::FPToSIOp>(loc, intType, val);
+  }
+  if (dstType.isa<mlir::FloatType>()) {
+    auto intType = rewriter.getI64Type();
+    val = imex::indexCast(rewriter, loc, val, intType);
+    return rewriter.createOrFold<mlir::arith::SIToFPOp>(loc, dstType, val);
+  }
+  return imex::indexCast(rewriter, loc, val, dstType);
+}
+
+static mlir::Value floatCastImpl(mlir::OpBuilder &rewriter, mlir::Location loc,
+                                 mlir::Value val, mlir::Type dstType) {
+  auto srcFloatType = val.getType().cast<mlir::FloatType>();
+  auto dstFloatType = dstType.cast<mlir::FloatType>();
+  assert(srcFloatType != dstFloatType);
+  if (dstFloatType.getWidth() > srcFloatType.getWidth()) {
+    return rewriter.createOrFold<mlir::arith::ExtFOp>(loc, dstFloatType, val);
+  } else {
+    return rewriter.createOrFold<mlir::arith::TruncFOp>(loc, dstFloatType, val);
+  }
+}
+
+struct CastHandler {
+  using selector_t = bool (*)(mlir::Type);
+  using cast_op_t = mlir::Value (*)(mlir::OpBuilder &, mlir::Location,
+                                    mlir::Value, mlir::Type);
+  selector_t src;
+  selector_t dst;
+  cast_op_t cast_op;
+};
+
+static const CastHandler castHandlers[] = {
+    {&isInt, &isInt, &intCast},           {&isInt, &isFloat, &intFloatCast},
+    {&isFloat, &isInt, &floatIntCast},    {&isIndex, &isInt, &indexCastImpl},
+    {&isInt, &isIndex, &indexCastImpl},   {&isFloat, &isFloat, &floatCastImpl},
+    {&isIndex, &isFloat, &indexCastImpl}, {&isFloat, &isIndex, &indexCastImpl},
+};
+
+bool imex::canConvert(mlir::Type srcType, mlir::Type dstType) {
+  if (srcType == dstType)
+    return true;
+
+  for (auto &h : castHandlers)
+    if (h.src(srcType) && h.dst(dstType))
+      return true;
+
+  return false;
+}
+
+mlir::Value imex::doConvert(mlir::OpBuilder &rewriter, mlir::Location loc,
+                            mlir::Value val, mlir::Type dstType) {
+  assert(dstType);
+  auto srcType = val.getType();
+  if (srcType == dstType)
+    return val;
+
+  for (auto &h : castHandlers)
+    if (h.src(srcType) && h.dst(dstType))
+      return h.cast_op(rewriter, loc, val, dstType);
+
+  return nullptr;
+}

--- a/mlir/test/Dialect/ntensor/resolve-array-ops.mlir
+++ b/mlir/test/Dialect/ntensor/resolve-array-ops.mlir
@@ -232,3 +232,21 @@ func.func @test(%arg1: !ntensor.ntensor<?xf64>, %arg2: !ntensor.slice, %arg3: !n
 //  CHECK-NEXT:   }
 //  CHECK-NEXT:   ntensor.copy %[[RES1]], %[[RES]] : !ntensor.ntensor<?xf64> to !ntensor.ntensor<?xf64>
 //  CHECK-NEXT:   return
+
+// -----
+
+func.func @test(%arg1: !ntensor.ntensor<?xf64>, %arg2: !ntensor.slice, %arg3: f32) {
+  ntensor.setitem(%arg1 : !ntensor.ntensor<?xf64>) [%arg2 : !ntensor.slice] = (%arg3 : f32)
+  return
+}
+// CHECK-LABEL: func @test
+//  CHECK-SAME:   (%[[ARG1:.*]]: !ntensor.ntensor<?xf64>, %[[ARG2:.*]]: !ntensor.slice, %[[ARG3:.*]]: f32)
+//  CHECK-NEXT:   %[[C0:.*]] = arith.constant 0 : index
+//  CHECK-NEXT:   %[[DIM:.*]] = ntensor.dim %[[ARG1]], %[[C0]] : !ntensor.ntensor<?xf64>
+//  CHECK-NEXT:   %[[BEGIN:.*]], %[[END:.*]], %[[STEP:.*]], %[[COUNT:.*]] = ntensor.resolve_slice %[[ARG2]], %[[DIM]]
+//  CHECK-NEXT:   %[[RES:.*]] = ntensor.subview %[[ARG1]][%[[BEGIN]]] [%[[COUNT]]] [%[[STEP]]] : !ntensor.ntensor<?xf64> to !ntensor.ntensor<?xf64>
+//  CHECK-NEXT:   %[[DIM2:.*]] = ntensor.dim %[[RES]], %[[C0]] : !ntensor.ntensor<?xf64>
+//  CHECK-NEXT:   %[[CONV:.*]] = arith.extf %[[ARG3]] : f32 to f64
+//  CHECK-NEXT:   %[[RES2:.*]] = ntensor.create(%[[DIM2]]) = (%[[CONV]] : f64) : !ntensor.ntensor<?xf64>
+//  CHECK-NEXT:   ntensor.copy %[[RES2]], %[[RES]] : !ntensor.ntensor<?xf64> to !ntensor.ntensor<?xf64>
+//  CHECK-NEXT:   return

--- a/mlir/test/Dialect/ntensor/resolve-array-ops.mlir
+++ b/mlir/test/Dialect/ntensor/resolve-array-ops.mlir
@@ -212,3 +212,23 @@ func.func @test(%arg1: tuple<f32, f32>, %arg2: index) -> f32 {
 //  CHECK-NEXT:   %[[IND:.*]] = ntensor.resolve_index %[[ARG2]], %[[DIM]]
 //  CHECK-NEXT:   %[[RES:.*]] = ntensor.load %[[T2]][%[[IND]]] : !ntensor.ntensor<?xf32>
 //  CHECK-NEXT:   return %[[RES]] : f32
+
+// -----
+
+func.func @test(%arg1: !ntensor.ntensor<?xf64>, %arg2: !ntensor.slice, %arg3: !ntensor.ntensor<?xf32>) {
+  ntensor.setitem(%arg1 : !ntensor.ntensor<?xf64>) [%arg2 : !ntensor.slice] = (%arg3 : !ntensor.ntensor<?xf32>)
+  return
+}
+// CHECK-LABEL: func @test
+//  CHECK-SAME:   (%[[ARG1:.*]]: !ntensor.ntensor<?xf64>, %[[ARG2:.*]]: !ntensor.slice, %[[ARG3:.*]]: !ntensor.ntensor<?xf32>)
+//  CHECK-NEXT:   %[[C0:.*]] = arith.constant 0 : index
+//  CHECK-NEXT:   %[[DIM:.*]] = ntensor.dim %[[ARG1]], %[[C0]] : !ntensor.ntensor<?xf64>
+//  CHECK-NEXT:   %[[BEGIN:.*]], %[[END:.*]], %[[STEP:.*]], %[[COUNT:.*]] = ntensor.resolve_slice %[[ARG2]], %[[DIM]]
+//  CHECK-NEXT:   %[[RES:.*]] = ntensor.subview %[[ARG1]][%[[BEGIN]]] [%[[COUNT]]] [%[[STEP]]] : !ntensor.ntensor<?xf64> to !ntensor.ntensor<?xf64>
+//  CHECK-NEXT:   %[[RES1:.*]]  = ntensor.elementwise %[[ARG3]] : !ntensor.ntensor<?xf32> -> !ntensor.ntensor<?xf64> {
+//  CHECK-NEXT:   ^bb0(%[[ARG4:.*]]: f32):
+//  CHECK-NEXT:   %[[V:.*]] = arith.extf %[[ARG4]] : f32 to f64
+//  CHECK-NEXT:   ntensor.elementwise_yield %[[V]]  : f64
+//  CHECK-NEXT:   }
+//  CHECK-NEXT:   ntensor.copy %[[RES1]], %[[RES]] : !ntensor.ntensor<?xf64> to !ntensor.ntensor<?xf64>
+//  CHECK-NEXT:   return

--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_numpy.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_numpy.py
@@ -518,6 +518,26 @@ def test_loop_fusion3():
         assert ir.count("memref.load") == 2, ir
 
 
+def test_copy_fusion():
+    def py_func(a, b):
+        a = a + 1
+        b[:] = a
+
+    jit_func = njit(py_func)
+    a = np.arange(13)
+
+    res_py = np.zeros_like(a)
+    res_jit = np.zeros_like(a)
+
+    with print_pass_ir([], ["PostLinalgOptPass"]):
+        py_func(a, res_py)
+        jit_func(a, res_jit)
+
+        assert_equal(res_py, res_jit)
+        ir = get_print_buffer()
+        assert ir.count("scf.parallel") == 1, ir
+
+
 @pytest.mark.parametrize("dtype", [np.int32, np.int64, np.float32])
 def test_np_reduce(dtype):
     def py_func(arr):


### PR DESCRIPTION
* When source and destination element type is different in `setitem` add a type conversion
* Extract scalar conversion routines from `PlierToStd` to common place