### PR TITLE
Add additional canonicalizations to `ntensor.dim`

### DIFF
--- a/mlir/include/imex/Dialect/ntensor/IR/NTensorOps.td
+++ b/mlir/include/imex/Dialect/ntensor/IR/NTensorOps.td
@@ -44,7 +44,9 @@ def NTensor_Dialect : Dialect {
   }];
 
   let dependentDialects = [
-    "::mlir::memref::MemRefDialect", "::mlir::tensor::TensorDialect"];
+    "::mlir::memref::MemRefDialect",
+    "::mlir::tensor::TensorDialect",
+    "::mlir::linalg::LinalgDialect"];
 
   let hasConstantMaterializer = 1;
   let useDefaultTypePrinterParser = 1;

--- a/mlir/include/imex/Dialect/ntensor/IR/NTensorOps.td
+++ b/mlir/include/imex/Dialect/ntensor/IR/NTensorOps.td
@@ -43,6 +43,9 @@ def NTensor_Dialect : Dialect {
     translated to `setitem` calls on tensor.
   }];
 
+  let dependentDialects = [
+    "::mlir::memref::MemRefDialect", "::mlir::tensor::TensorDialect"];
+
   let hasConstantMaterializer = 1;
   let useDefaultTypePrinterParser = 1;
 }
@@ -516,6 +519,7 @@ def DimOp : NTensor_OpBase<"dim", [
   }];
 
   let hasVerifier = 1;
+  let hasCanonicalizer = 1;
 }
 
 def CallOp : NTensor_OpBase<"call", []> {

--- a/mlir/test/Dialect/ntensor/canonicalize.mlir
+++ b/mlir/test/Dialect/ntensor/canonicalize.mlir
@@ -181,3 +181,31 @@ func.func @test(%arg1: !ntensor.ntensor<?xf32>) -> !ntensor.ntensor<?xf32> {
 // CHECK-LABEL: func @test
 //  CHECK-SAME:   (%[[ARG:.*]]: !ntensor.ntensor<?xf32>)
 //  CHECK-NEXT:   return %[[ARG]]
+
+// -----
+
+func.func @test(%arg1: tensor<?x?xf32>) -> index {
+  %0 = arith.constant 1 : index
+  %1 = ntensor.from_tensor %arg1 : tensor<?x?xf32> to !ntensor.ntensor<?x?xf32>
+  %2 = ntensor.dim %1, %0 : !ntensor.ntensor<?x?xf32>
+  return %2 : index
+}
+// CHECK-LABEL: func @test
+//  CHECK-SAME:   (%[[ARG:.*]]: tensor<?x?xf32>)
+//       CHECK:   %[[IND:.*]] = arith.constant 1 : index
+//       CHECK:   %[[DIM:.*]] = tensor.dim %[[ARG]], %[[IND]] : tensor<?x?xf32>
+//       CHECK:   return %[[DIM]] : index
+
+// -----
+
+func.func @test(%arg1: !ntensor.ntensor<?x?xf32>) -> index {
+  %0 = arith.constant 1 : index
+  %1 = ntensor.to_tensor %arg1 : !ntensor.ntensor<?x?xf32> to tensor<?x?xf32>
+  %2 = tensor.dim %1, %0 : tensor<?x?xf32>
+  return %2 : index
+}
+// CHECK-LABEL: func @test
+//  CHECK-SAME:   (%[[ARG:.*]]: !ntensor.ntensor<?x?xf32>)
+//       CHECK:   %[[IND:.*]] = arith.constant 1 : index
+//       CHECK:   %[[DIM:.*]] = ntensor.dim %[[ARG]], %[[IND]] : !ntensor.ntensor<?x?xf32>
+//       CHECK:   return %[[DIM]] : index

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -22,6 +22,7 @@
 #include <mlir/Dialect/Tensor/IR/Tensor.h>
 #include <mlir/Dialect/Tensor/Transforms/Passes.h>
 #include <mlir/IR/Dialect.h>
+#include <mlir/IR/Dominance.h>
 #include <mlir/Pass/Pass.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Transforms/DialectConversion.h>
@@ -1820,6 +1821,11 @@ struct SliceOfGeneric : public mlir::OpRewritePattern<mlir::linalg::GenericOp> {
     mlir::Operation *user = *(res.getUsers().begin());
     if (!mlir::isa<mlir::tensor::ExtractSliceOp, mlir::tensor::ExtractOp>(user))
       return mlir::failure();
+
+    mlir::DominanceInfo dom;
+    for (auto arg : user->getOperands())
+      if (!dom.dominates(arg, op))
+        return mlir::failure();
 
     auto output = op.getOutputs().front();
 


### PR DESCRIPTION
* Propgate DimOp through ntensor to/from tensor
* Add add some dim propagation to `tensor.dim` (TODO: upstream)
* Fix uncovered issue in `SliceOfGeneric` pattern, which could generate invalid IR, check dominance properties will still hold after this transform
