### PR TITLE
Cleanup context usage in api

### DIFF
--- a/mlir/include/imex/Conversion/NtensorToLinalg.hpp
+++ b/mlir/include/imex/Conversion/NtensorToLinalg.hpp
@@ -13,8 +13,7 @@ class RewritePatternSet;
 } // namespace mlir
 
 namespace imex {
-void populateNtensorToLinalgPatterns(mlir::MLIRContext &context,
-                                     mlir::RewritePatternSet &patterns);
+void populateNtensorToLinalgPatterns(mlir::RewritePatternSet &patterns);
 
 /// Creates a pass for ntensor alias analysis, required by ntensor-to-linalg.
 std::unique_ptr<mlir::Pass> createNtensorAliasAnalysisPass();

--- a/mlir/include/imex/Conversion/NtensorToMemref.hpp
+++ b/mlir/include/imex/Conversion/NtensorToMemref.hpp
@@ -15,8 +15,7 @@ class TypeConverter;
 } // namespace mlir
 
 namespace imex {
-void populateNtensorToMemrefRewritesAndTarget(mlir::MLIRContext &context,
-                                              mlir::TypeConverter &converter,
+void populateNtensorToMemrefRewritesAndTarget(mlir::TypeConverter &converter,
                                               mlir::RewritePatternSet &patterns,
                                               mlir::ConversionTarget &target);
 

--- a/mlir/include/imex/Conversion/UtilConversion.hpp
+++ b/mlir/include/imex/Conversion/UtilConversion.hpp
@@ -13,8 +13,7 @@ class TypeConverter;
 
 namespace imex {
 /// Convert util ops according to provided type converter.
-void populateUtilConversionPatterns(mlir::MLIRContext &context,
-                                    mlir::TypeConverter &converter,
+void populateUtilConversionPatterns(mlir::TypeConverter &converter,
                                     mlir::RewritePatternSet &patterns,
                                     mlir::ConversionTarget &target);
 } // namespace imex

--- a/mlir/include/imex/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.hpp
+++ b/mlir/include/imex/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.hpp
@@ -13,8 +13,7 @@ class RewritePatternSet;
 } // namespace mlir
 
 namespace gpu_runtime {
-void populateMakeBarriersUniformPatterns(mlir::MLIRContext &context,
-                                         mlir::RewritePatternSet &patterns);
+void populateMakeBarriersUniformPatterns(mlir::RewritePatternSet &patterns);
 
 /// gpu barriers ops require uniform control flow, this pass tries to rearrange
 /// control flow in a way to satisfy this requirement.

--- a/mlir/include/imex/Dialect/ntensor/Transforms/ResolveArrayOps.hpp
+++ b/mlir/include/imex/Dialect/ntensor/Transforms/ResolveArrayOps.hpp
@@ -14,8 +14,7 @@ class RewritePatternSet;
 
 namespace imex {
 namespace ntensor {
-void populateResolveArrayOpsPatterns(mlir::MLIRContext &context,
-                                     mlir::RewritePatternSet &patterns);
+void populateResolveArrayOpsPatterns(mlir::RewritePatternSet &patterns);
 
 /// This pass translates high level array manipulation ops into primitive
 /// ops like `resolve_index`, `subview`, `load`, `store` etc.

--- a/mlir/include/imex/Transforms/CommonOpts.hpp
+++ b/mlir/include/imex/Transforms/CommonOpts.hpp
@@ -13,11 +13,9 @@ class Pass;
 } // namespace mlir
 
 namespace imex {
-void populateCanonicalizationPatterns(mlir::MLIRContext &context,
-                                      mlir::RewritePatternSet &patterns);
+void populateCanonicalizationPatterns(mlir::RewritePatternSet &patterns);
 
-void populateCommonOptsPatterns(mlir::MLIRContext &context,
-                                mlir::RewritePatternSet &patterns);
+void populateCommonOptsPatterns(mlir::RewritePatternSet &patterns);
 
 std::unique_ptr<mlir::Pass> createCommonOptsPass();
 } // namespace imex

--- a/mlir/include/imex/Transforms/IfRewrites.hpp
+++ b/mlir/include/imex/Transforms/IfRewrites.hpp
@@ -10,7 +10,6 @@ class RewritePatternSet;
 } // namespace mlir
 
 namespace imex {
-void populateIfRewritesPatterns(mlir::MLIRContext &context,
-                                mlir::RewritePatternSet &patterns);
+void populateIfRewritesPatterns(mlir::RewritePatternSet &patterns);
 
 } // namespace imex

--- a/mlir/include/imex/Transforms/IndexTypePropagation.hpp
+++ b/mlir/include/imex/Transforms/IndexTypePropagation.hpp
@@ -10,6 +10,5 @@ class MLIRContext;
 } // namespace mlir
 
 namespace imex {
-void populateIndexPropagatePatterns(mlir::MLIRContext &context,
-                                    mlir::RewritePatternSet &patterns);
+void populateIndexPropagatePatterns(mlir::RewritePatternSet &patterns);
 }

--- a/mlir/include/imex/Transforms/LoopRewrites.hpp
+++ b/mlir/include/imex/Transforms/LoopRewrites.hpp
@@ -10,7 +10,6 @@ class RewritePatternSet;
 } // namespace mlir
 
 namespace imex {
-void populateLoopRewritesPatterns(mlir::MLIRContext &context,
-                                  mlir::RewritePatternSet &patterns);
+void populateLoopRewritesPatterns(mlir::RewritePatternSet &patterns);
 
 } // namespace imex

--- a/mlir/include/imex/Transforms/MakeSignless.hpp
+++ b/mlir/include/imex/Transforms/MakeSignless.hpp
@@ -15,8 +15,7 @@ class TypeConverter;
 } // namespace mlir
 
 namespace imex {
-void populateMakeSignlessRewritesAndTarget(mlir::MLIRContext &context,
-                                           mlir::TypeConverter &converter,
+void populateMakeSignlessRewritesAndTarget(mlir::TypeConverter &converter,
                                            mlir::RewritePatternSet &patterns,
                                            mlir::ConversionTarget &target);
 

--- a/mlir/include/imex/Transforms/TypeConversion.hpp
+++ b/mlir/include/imex/Transforms/TypeConversion.hpp
@@ -16,8 +16,7 @@ void populateControlFlowTypeConversionRewritesAndTarget(
     mlir::TypeConverter &typeConverter, mlir::RewritePatternSet &patterns,
     mlir::ConversionTarget &target);
 
-void populateTupleTypeConverter(mlir::MLIRContext &context,
-                                mlir::TypeConverter &typeConverter);
+void populateTupleTypeConverter(mlir::TypeConverter &typeConverter);
 
 void populateTupleTypeConversionRewritesAndTarget(
     mlir::TypeConverter &typeConverter, mlir::RewritePatternSet &patterns,

--- a/mlir/include/imex/Transforms/UpliftMath.hpp
+++ b/mlir/include/imex/Transforms/UpliftMath.hpp
@@ -13,8 +13,7 @@ class Pass;
 } // namespace mlir
 
 namespace imex {
-void populateUpliftmathPatterns(mlir::MLIRContext &context,
-                                mlir::RewritePatternSet &patterns);
+void populateUpliftmathPatterns(mlir::RewritePatternSet &patterns);
 
 std::unique_ptr<mlir::Pass> createUpliftMathPass();
 } // namespace imex

--- a/mlir/lib/Conversion/NtensorToLinalg.cpp
+++ b/mlir/lib/Conversion/NtensorToLinalg.cpp
@@ -373,11 +373,10 @@ struct ConvertDimOp : public mlir::OpRewritePattern<imex::ntensor::DimOp> {
 };
 } // namespace
 
-void imex::populateNtensorToLinalgPatterns(mlir::MLIRContext &context,
-                                           mlir::RewritePatternSet &patterns) {
+void imex::populateNtensorToLinalgPatterns(mlir::RewritePatternSet &patterns) {
   patterns.insert<ConvertCreateOp, ConvertCopyOp, ConvertElementwiseOp,
                   ConvertCastOp, ConvertFromElementsOp, ConvertSubviewOp,
-                  ConvertLoadOp, ConvertDimOp>(&context);
+                  ConvertLoadOp, ConvertDimOp>(patterns.getContext());
 }
 
 namespace {
@@ -471,7 +470,7 @@ struct NtensorToLinalgPass
     auto &ctx = getContext();
     mlir::RewritePatternSet patterns(&ctx);
 
-    imex::populateNtensorToLinalgPatterns(ctx, patterns);
+    imex::populateNtensorToLinalgPatterns(patterns);
 
     (void)mlir::applyPatternsAndFoldGreedily(getOperation(),
                                              std::move(patterns));

--- a/mlir/lib/Conversion/NtensorToMemref.cpp
+++ b/mlir/lib/Conversion/NtensorToMemref.cpp
@@ -374,8 +374,8 @@ struct CopyOpLowering
 } // namespace
 
 void imex::populateNtensorToMemrefRewritesAndTarget(
-    mlir::MLIRContext &context, mlir::TypeConverter &converter,
-    mlir::RewritePatternSet &patterns, mlir::ConversionTarget &target) {
+    mlir::TypeConverter &converter, mlir::RewritePatternSet &patterns,
+    mlir::ConversionTarget &target) {
   converter.addConversion(
       [](imex::ntensor::NTensorType type) -> llvm::Optional<mlir::Type> {
         auto elemType = type.getElementType();
@@ -388,8 +388,8 @@ void imex::populateNtensorToMemrefRewritesAndTarget(
   patterns
       .insert<DimOpLowering, SubviewOpLowering, LoadOpLowering, StoreOpLowering,
               ToTensorOpLowering, FromTensorOpLowering, ToMemrefOpLowering,
-              FromMemrefOpLowering, CastOpLowering, CopyOpLowering>(converter,
-                                                                    &context);
+              FromMemrefOpLowering, CastOpLowering, CopyOpLowering>(
+          converter, patterns.getContext());
 
   target.addIllegalOp<imex::ntensor::DimOp, imex::ntensor::SubviewOp,
                       imex::ntensor::LoadOp, imex::ntensor::StoreOp,
@@ -420,7 +420,7 @@ struct NtensorToMemrefPass
     // Convert unknown types to itself
     converter.addConversion([](mlir::Type type) { return type; });
 
-    imex::populateTupleTypeConverter(context, converter);
+    imex::populateTupleTypeConverter(converter);
 
     auto addUnrealizedCast = [](mlir::OpBuilder &builder, mlir::Type type,
                                 mlir::ValueRange inputs, mlir::Location loc) {
@@ -436,8 +436,7 @@ struct NtensorToMemrefPass
                                                        target);
     imex::populateControlFlowTypeConversionRewritesAndTarget(converter,
                                                              patterns, target);
-    imex::populateNtensorToMemrefRewritesAndTarget(context, converter, patterns,
-                                                   target);
+    imex::populateNtensorToMemrefRewritesAndTarget(converter, patterns, target);
 
     auto op = getOperation();
     if (mlir::failed(

--- a/mlir/lib/Conversion/UtilConversion.cpp
+++ b/mlir/lib/Conversion/UtilConversion.cpp
@@ -37,11 +37,10 @@ struct ConvertTakeContext
 };
 } // namespace
 
-void imex::populateUtilConversionPatterns(mlir::MLIRContext &context,
-                                          mlir::TypeConverter &converter,
+void imex::populateUtilConversionPatterns(mlir::TypeConverter &converter,
                                           mlir::RewritePatternSet &patterns,
                                           mlir::ConversionTarget &target) {
-  patterns.insert<ConvertTakeContext>(converter, &context);
+  patterns.insert<ConvertTakeContext>(converter, patterns.getContext());
 
   target.addDynamicallyLegalOp<imex::util::TakeContextOp>(
       [&](mlir::Operation *op) -> llvm::Optional<bool> {

--- a/mlir/lib/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.cpp
+++ b/mlir/lib/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.cpp
@@ -128,8 +128,8 @@ struct ConvertBarrierOp
 } // namespace
 
 void gpu_runtime::populateMakeBarriersUniformPatterns(
-    mlir::MLIRContext &context, mlir::RewritePatternSet &patterns) {
-  patterns.insert<ConvertBarrierOp>(&context);
+    mlir::RewritePatternSet &patterns) {
+  patterns.insert<ConvertBarrierOp>(patterns.getContext());
 }
 
 namespace {
@@ -150,7 +150,7 @@ struct MakeBarriersUniformPass
     auto &ctx = getContext();
     mlir::RewritePatternSet patterns(&ctx);
 
-    gpu_runtime::populateMakeBarriersUniformPatterns(ctx, patterns);
+    gpu_runtime::populateMakeBarriersUniformPatterns(patterns);
 
     mlir::GreedyRewriteConfig config;
     config.useTopDownTraversal = true; // We need to visit top barriers first

--- a/mlir/lib/Dialect/ntensor/Transforms/ResolveArrayOps.cpp
+++ b/mlir/lib/Dialect/ntensor/Transforms/ResolveArrayOps.cpp
@@ -390,10 +390,10 @@ struct GetitemUnitupleOpLowering
 } // namespace
 
 void imex::ntensor::populateResolveArrayOpsPatterns(
-    mlir::MLIRContext &context, mlir::RewritePatternSet &patterns) {
+    mlir::RewritePatternSet &patterns) {
   patterns
       .insert<SetitemOpLowering, GetitemOpLowering, GetitemUnitupleOpLowering>(
-          &context);
+          patterns.getContext());
 }
 
 namespace {
@@ -412,7 +412,7 @@ struct ResolveArrayOpsPass
     auto &ctx = getContext();
     mlir::RewritePatternSet patterns(&ctx);
 
-    imex::ntensor::populateResolveArrayOpsPatterns(ctx, patterns);
+    imex::ntensor::populateResolveArrayOpsPatterns(patterns);
 
     (void)mlir::applyPatternsAndFoldGreedily(getOperation(),
                                              std::move(patterns));

--- a/mlir/lib/Transforms/CommonOpts.cpp
+++ b/mlir/lib/Transforms/CommonOpts.cpp
@@ -143,7 +143,7 @@ void imex::populateCanonicalizationPatterns(mlir::RewritePatternSet &patterns) {
   for (auto *dialect : context->getLoadedDialects())
     dialect->getCanonicalizationPatterns(patterns);
   for (auto op : context->getRegisteredOperations())
-    op.getCanonicalizationPatterns(patterns, patterns.getContext());
+    op.getCanonicalizationPatterns(patterns, context);
 }
 
 void imex::populateCommonOptsPatterns(mlir::RewritePatternSet &patterns) {

--- a/mlir/lib/Transforms/IfRewrites.cpp
+++ b/mlir/lib/Transforms/IfRewrites.cpp
@@ -68,7 +68,6 @@ IfOpConstCond::matchAndRewrite(mlir::scf::IfOp op,
   return mlir::success();
 }
 
-void imex::populateIfRewritesPatterns(mlir::MLIRContext &context,
-                                      mlir::RewritePatternSet &patterns) {
-  patterns.insert<IfOpConstCond>(&context);
+void imex::populateIfRewritesPatterns(mlir::RewritePatternSet &patterns) {
+  patterns.insert<IfOpConstCond>(patterns.getContext());
 }

--- a/mlir/lib/Transforms/IndexTypePropagation.cpp
+++ b/mlir/lib/Transforms/IndexTypePropagation.cpp
@@ -137,8 +137,7 @@ struct CmpIndexCastSimplify
 };
 } // namespace
 
-void imex::populateIndexPropagatePatterns(mlir::MLIRContext &context,
-                                          mlir::RewritePatternSet &patterns) {
+void imex::populateIndexPropagatePatterns(mlir::RewritePatternSet &patterns) {
   patterns
       .insert<CmpIndexCastSimplify, ArithIndexCastSimplify<mlir::arith::SubIOp>,
               ArithIndexCastSimplify<mlir::arith::AddIOp>,
@@ -146,5 +145,6 @@ void imex::populateIndexPropagatePatterns(mlir::MLIRContext &context,
               ArithIndexCastSimplify<mlir::arith::DivSIOp>,
               ArithIndexCastSimplify<mlir::arith::DivUIOp>,
               ArithIndexCastSimplify<mlir::arith::RemSIOp>,
-              ArithIndexCastSimplify<mlir::arith::RemUIOp>>(&context);
+              ArithIndexCastSimplify<mlir::arith::RemUIOp>>(
+          patterns.getContext());
 }

--- a/mlir/lib/Transforms/LoopRewrites.cpp
+++ b/mlir/lib/Transforms/LoopRewrites.cpp
@@ -134,7 +134,6 @@ struct CmpLoopBoundsSimplify
 };
 } // namespace
 
-void imex::populateLoopRewritesPatterns(mlir::MLIRContext &context,
-                                        mlir::RewritePatternSet &patterns) {
-  patterns.insert<CmpLoopBoundsSimplify>(&context);
+void imex::populateLoopRewritesPatterns(mlir::RewritePatternSet &patterns) {
+  patterns.insert<CmpLoopBoundsSimplify>(patterns.getContext());
 }

--- a/mlir/lib/Transforms/MakeSignless.cpp
+++ b/mlir/lib/Transforms/MakeSignless.cpp
@@ -184,8 +184,8 @@ static llvm::Optional<mlir::Type> makeSignlessType(mlir::Type type) {
 }
 
 void imex::populateMakeSignlessRewritesAndTarget(
-    mlir::MLIRContext &context, mlir::TypeConverter &converter,
-    mlir::RewritePatternSet &patterns, mlir::ConversionTarget &target) {
+    mlir::TypeConverter &converter, mlir::RewritePatternSet &patterns,
+    mlir::ConversionTarget &target) {
   converter.addConversion(&makeSignlessType);
 
   auto materializeSignCast = [](mlir::OpBuilder &builder, mlir::Type type,
@@ -208,7 +208,7 @@ void imex::populateMakeSignlessRewritesAndTarget(
                   ConvertAlloc<mlir::memref::AllocaOp>, ConvertDealloc,
                   ConvertTensorEmpty, ConvertTensorFromElements,
                   ConvertLinalgFill, ConvertLinalgGeneric, ConvertLinalgYield>(
-      converter, &context);
+      converter, patterns.getContext());
 }
 
 namespace {
@@ -233,10 +233,9 @@ struct MakeSignlessPass
     // Convert unknown types to itself
     converter.addConversion([](mlir::Type type) { return type; });
 
-    imex::populateTupleTypeConverter(context, converter);
+    imex::populateTupleTypeConverter(converter);
 
-    imex::populateMakeSignlessRewritesAndTarget(context, converter, patterns,
-                                                target);
+    imex::populateMakeSignlessRewritesAndTarget(converter, patterns, target);
 
     imex::populateTupleTypeConversionRewritesAndTarget(converter, patterns,
                                                        target);

--- a/mlir/lib/Transforms/TypeConversion.cpp
+++ b/mlir/lib/Transforms/TypeConversion.cpp
@@ -267,8 +267,7 @@ struct GetItemTupleConversionPattern
 };
 } // namespace
 
-void imex::populateTupleTypeConverter(mlir::MLIRContext & /*context*/,
-                                      mlir::TypeConverter &typeConverter) {
+void imex::populateTupleTypeConverter(mlir::TypeConverter &typeConverter) {
   typeConverter.addConversion(
       [&typeConverter](mlir::TupleType type) -> llvm::Optional<mlir::Type> {
         auto count = static_cast<unsigned>(type.size());

--- a/mlir/lib/Transforms/UpliftMath.cpp
+++ b/mlir/lib/Transforms/UpliftMath.cpp
@@ -143,9 +143,8 @@ struct UpliftMathPass
           UpliftMathCalls, UpliftFabsCalls, UpliftFma> {};
 } // namespace
 
-void imex::populateUpliftmathPatterns(mlir::MLIRContext &context,
-                                      mlir::RewritePatternSet &patterns) {
-  patterns.insert<UpliftMathCalls>(&context);
+void imex::populateUpliftmathPatterns(mlir::RewritePatternSet &patterns) {
+  patterns.insert<UpliftMathCalls>(patterns.getContext());
 }
 
 std::unique_ptr<mlir::Pass> imex::createUpliftMathPass() {

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpu.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpu.cpp
@@ -1610,7 +1610,7 @@ struct GPUToLLVMPass
 
     gpu_runtime::populateGpuToLLVMPatternsAndLegality(converter, patterns,
                                                       target);
-    imex::populateUtilConversionPatterns(context, converter, patterns, target);
+    imex::populateUtilConversionPatterns(converter, patterns, target);
 
     // TODO: There were some issues with structural conversion, investigate.
     target.addLegalOp<mlir::arith::SelectOp>();

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -638,7 +638,7 @@ struct OptimizeStridedLayoutPass
     auto *context = &getContext();
     mlir::RewritePatternSet patterns(context);
 
-    imex::populateCanonicalizationPatterns(*context, patterns);
+    imex::populateCanonicalizationPatterns(patterns);
 
     patterns.insert<ChangeLayoutReturn>(context);
 
@@ -1156,7 +1156,7 @@ struct PlierToNtensorPass
     // Convert unknown types to itself
     typeConverter.addConversion([](mlir::Type type) { return type; });
 
-    imex::populateTupleTypeConverter(context, typeConverter);
+    imex::populateTupleTypeConverter(typeConverter);
     typeConverter.addConversion(
         [](plier::SliceType type) -> llvm::Optional<mlir::Type> {
           return imex::ntensor::SliceType::get(type.getContext());
@@ -1596,7 +1596,7 @@ struct ResolveNtensorPass
     auto &ctx = getContext();
     mlir::RewritePatternSet patterns(&ctx);
 
-    imex::ntensor::populateResolveArrayOpsPatterns(ctx, patterns);
+    imex::ntensor::populateResolveArrayOpsPatterns(patterns);
 
     patterns
         .insert<GetitemArrayOpLowering, NtensorPrimitiveCallsLowering,
@@ -2140,7 +2140,7 @@ void PostPlierToLinalgPass::runOnOperation() {
   auto &context = getContext();
   mlir::RewritePatternSet patterns(&context);
 
-  imex::populateCommonOptsPatterns(context, patterns);
+  imex::populateCommonOptsPatterns(patterns);
 
   patterns.insert<SimplifyExpandDims>(&context);
 
@@ -2224,7 +2224,7 @@ void LinalgOptPass::runOnOperation() {
   auto &context = getContext();
   mlir::RewritePatternSet patterns(&context);
 
-  imex::populateCommonOptsPatterns(context, patterns);
+  imex::populateCommonOptsPatterns(patterns);
 
   patterns.insert<
       // clang-format off
@@ -2428,7 +2428,7 @@ struct AdditionalBufferize
     auto *context = &getContext();
 
     mlir::bufferization::BufferizeTypeConverter typeConverter;
-    imex::populateTupleTypeConverter(*context, typeConverter);
+    imex::populateTupleTypeConverter(typeConverter);
 
     auto materializeTupleCast =
         [](mlir::OpBuilder &builder, mlir::Type type, mlir::ValueRange inputs,
@@ -2554,7 +2554,7 @@ void PostLinalgOptPass::runOnOperation() {
   auto &context = getContext();
   mlir::RewritePatternSet patterns(&context);
 
-  imex::populateCommonOptsPatterns(context, patterns);
+  imex::populateCommonOptsPatterns(patterns);
 
   patterns.insert<OptimizeGlobalsConstsLoad, OptimizeSingleElemCopy,
                   imex::CanonicalizeReduction, imex::PromoteToParallel,

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToStd.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToStd.cpp
@@ -936,7 +936,7 @@ void PlierToStdPass::runOnOperation() {
 
         return llvm::None;
       });
-  imex::populateTupleTypeConverter(*context, typeConverter);
+  imex::populateTupleTypeConverter(typeConverter);
 
   auto materializeCast = [](mlir::OpBuilder &builder, mlir::Type type,
                             mlir::ValueRange inputs,


### PR DESCRIPTION
* Context is already passed inside `RewritePatternSet`, no need to pass it separately
* No functional changes
