### PR TITLE
change minimum required cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13...3.18)
+cmake_minimum_required(VERSION 3.13.4...3.18)
 
 # CMP0116: Ninja generators transform `DEPFILE`s from `add_custom_command()`
 # New in CMake 3.20. https://cmake.org/cmake/help/latest/policy/CMP0116.html

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13.4)
+cmake_minimum_required(VERSION 3.13...3.18)
 
 # CMP0116: Ninja generators transform `DEPFILE`s from `add_custom_command()`
 # New in CMake 3.20. https://cmake.org/cmake/help/latest/policy/CMP0116.html


### PR DESCRIPTION
When using Anaconda/miniconda environment, CMake Findpackage finds system python path instead of anaconda environment one, Detection of anaconda is introduced in later version of cmake (possibly >=3.17).CMake older version finds system python which tries to locate lit package in system path as well. Due to this lit tests are not able to find lit module.
  
Changing minimum cmake version results in finding intended python package from configured environment and can run lit tests successfully which used to fail on some environments.

Please review these guidelines to help with the review process:
- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [ ] Have you organized your commits logically and ensured each can be built by itself?
