### PR TITLE
[Transform] add outer parallel loop if necessary before gpu-map-parallel

### DIFF
--- a/include/imex/Transforms/Passes.h
+++ b/include/imex/Transforms/Passes.h
@@ -24,6 +24,7 @@ std::unique_ptr<mlir::Pass> createSerializeSPIRVPass();
 std::unique_ptr<mlir::Pass> createInsertGPUAllocsPass();
 std::unique_ptr<mlir::Pass> createSetSPIRVCapabilitiesPass();
 std::unique_ptr<mlir::Pass> createSetSPIRVAbiAttributePass();
+std::unique_ptr<mlir::Pass> createAddOuterParallelLoopPass();
 
 #define GEN_PASS_DECL
 #include "imex/Transforms/Passes.h.inc"

--- a/include/imex/Transforms/Passes.td
+++ b/include/imex/Transforms/Passes.td
@@ -71,7 +71,6 @@ def AddOuterParallelLoop : Pass<"imex-add-outer-parallel-loop", "::mlir::func::F
   }];
   let constructor = "imex::createAddOuterParallelLoopPass()";
   let dependentDialects = [
-    "::mlir::gpu::GPUDialect",
     "::mlir::scf::SCFDialect"
     ];
 }

--- a/include/imex/Transforms/Passes.td
+++ b/include/imex/Transforms/Passes.td
@@ -63,4 +63,17 @@ def SetSPIRVAbiAttribute : Pass<"set-spirv-abi-attrs", "::mlir::gpu::GPUModuleOp
   ];
 }
 
+def AddOuterParallelLoop : Pass<"imex-add-outer-parallel-loop", "::mlir::func::FuncOp"> {
+  let summary = "add an outer parallel loop when there is not";
+  let description = [{
+    When the original func does not have an outer parallel loop, this pass adds
+    one so that the immediately followed pass gpu-map-parallel-loops can work.
+  }];
+  let constructor = "imex::createAddOuterParallelLoopPass()";
+  let dependentDialects = [
+    "::mlir::gpu::GPUDialect",
+    "::mlir::scf::SCFDialect"
+    ];
+}
+
 #endif // _IMEX_TRANSFORMS_PASSES_TD_INCLUDED_

--- a/lib/Transforms/AddOuterParallelLoop.cpp
+++ b/lib/Transforms/AddOuterParallelLoop.cpp
@@ -1,0 +1,58 @@
+//===- AddOuterParallelLoop.cpp - add outer parallel loop pass--*- C++ -*-===//
+//
+// Copyright 2022 Intel Corporation
+// Part of the IMEX Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// When the original func does not have an outer parallel loop, this pass adds
+/// one so that the immediately followed pass gpu-map-parallel-loops can work.
+///
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+
+using namespace mlir;
+using namespace imex;
+
+namespace {
+struct AddOuterParallelLoopPass
+    : public AddOuterParallelLoopBase<AddOuterParallelLoopPass> {
+public:
+  void runOnOperation() override {
+    auto func = getOperation();
+    llvm::SmallVector<scf::ForOp, 4> ops;
+    func.walk<WalkOrder::PreOrder>([&](scf::ForOp op) {
+      if (op->getParentOp() == func) {
+        ops.push_back(op);
+        return WalkResult::skip();
+      }
+      return WalkResult::advance();
+    });
+    mlir::OpBuilder builder(func.getContext());
+    for (scf::ForOp op : ops) {
+      builder.setInsertionPoint(op);
+      mlir::Value cst0 = builder.create<arith::ConstantOp>(
+          op.getLoc(), builder.getIndexAttr(0));
+      mlir::Value cst1 = builder.create<arith::ConstantOp>(
+          op.getLoc(), builder.getIndexAttr(1));
+      scf::ParallelOp outer = builder.create<scf::ParallelOp>(
+          op.getLoc(), SmallVector<Value, 2>{cst0}, SmallVector<Value, 2>{cst1},
+          SmallVector<Value, 2>{cst1});
+      op->moveBefore(&outer.getBody()->front());
+    }
+  }
+};
+} // namespace
+
+namespace imex {
+std::unique_ptr<mlir::Pass> createAddOuterParallelLoopPass() {
+  return std::make_unique<AddOuterParallelLoopPass>();
+}
+} // namespace imex

--- a/lib/Transforms/AddOuterParallelLoop.cpp
+++ b/lib/Transforms/AddOuterParallelLoop.cpp
@@ -40,13 +40,13 @@ public:
     // move the for-loop inside the newly created parallel-loop
     for (scf::ForOp op : ops) {
       builder.setInsertionPoint(op);
-      mlir::Value cst0 = builder.create<arith::ConstantOp>(
-          op.getLoc(), builder.getIndexAttr(0));
-      mlir::Value cst1 = builder.create<arith::ConstantOp>(
-          op.getLoc(), builder.getIndexAttr(1));
-      scf::ParallelOp outer = builder.create<scf::ParallelOp>(
-          op.getLoc(), SmallVector<Value, 2>{cst0}, SmallVector<Value, 2>{cst1},
-          SmallVector<Value, 2>{cst1});
+      auto loc = op.getLoc();
+      mlir::Value cst0 =
+          builder.create<arith::ConstantOp>(loc, builder.getIndexAttr(0));
+      mlir::Value cst1 =
+          builder.create<arith::ConstantOp>(loc, builder.getIndexAttr(1));
+      scf::ParallelOp outer =
+          builder.create<scf::ParallelOp>(loc, cst0, cst1, cst1);
       op->moveBefore(&outer.getBody()->front());
     }
   }

--- a/lib/Transforms/AddOuterParallelLoop.cpp
+++ b/lib/Transforms/AddOuterParallelLoop.cpp
@@ -28,6 +28,7 @@ public:
   void runOnOperation() override {
     auto func = getOperation();
     llvm::SmallVector<scf::ForOp, 4> ops;
+    // populate the top level for-loop
     func.walk<WalkOrder::PreOrder>([&](scf::ForOp op) {
       if (op->getParentOp() == func) {
         ops.push_back(op);
@@ -36,6 +37,7 @@ public:
       return WalkResult::advance();
     });
     mlir::OpBuilder builder(func.getContext());
+    // move the for-loop inside the newly created parallel-loop
     for (scf::ForOp op : ops) {
       builder.setInsertionPoint(op);
       mlir::Value cst0 = builder.create<arith::ConstantOp>(

--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -3,11 +3,13 @@ add_mlir_library(IMEXTransforms
   InsertGPUAllocs.cpp
   SetSPIRVCapabilities.cpp
   SetSPIRVAbiAttribute.cpp
+  AddOuterParallelLoop.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/imex/Transforms
 
   LINK_LIBS PUBLIC
+  MLIRSCFDialect
   MLIRGPUOps
   MLIRSPIRVDialect
   MLIRFuncDialect

--- a/lib/Transforms/PassDetail.h
+++ b/lib/Transforms/PassDetail.h
@@ -27,6 +27,9 @@ namespace spirv {
 class SPIRVDialect;
 }
 
+namespace scf {
+class SCFDialect;
+}
 } // end namespace mlir
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"

--- a/test/PlaidML/linalg-to-llvm.pp
+++ b/test/PlaidML/linalg-to-llvm.pp
@@ -12,6 +12,7 @@ func.func(empty-tensor-to-alloc-tensor
 func-bufferize
 func.func(finalizing-bufferize
           convert-linalg-to-parallel-loops
+          imex-add-outer-parallel-loop
           gpu-map-parallel-loops
           convert-parallel-loops-to-gpu)
 # insert-gpu-allocs pass can have client-api = opencl or vulkan args

--- a/test/Transforms/add-outer-parallel-loop.mlir
+++ b/test/Transforms/add-outer-parallel-loop.mlir
@@ -1,22 +1,50 @@
 // RUN: imex-opt --imex-add-outer-parallel-loop %s | FileCheck %s
-func.func @test(%arg0: memref<10x20xf32>) -> memref<f32> {
+func.func @single_loop(%arg0: memref<10x20xf32>) {
+  // CHECK-LABEL: func @single_loop
   %c0 = arith.constant 0 : index
   %c10 = arith.constant 10 : index
   %c1 = arith.constant 1 : index
   %c20 = arith.constant 20 : index
   %cst = arith.constant 0.000000e+00 : f32
-  %alloc = memref.alloc() {alignment = 128 : i64} : memref<f32>
-  memref.store %cst, %alloc[] : memref<f32>
-  %alloc_0 = memref.alloc() {alignment = 128 : i64} : memref<f32>
-  memref.copy %alloc, %alloc_0 : memref<f32> to memref<f32>
   // CHECK: scf.parallel
+  // CHECK-NEXT: scf.for
+  // CHECK-NEXT: scf.for
   scf.for %arg1 = %c0 to %c10 step %c1 {
     scf.for %arg2 = %c0 to %c20 step %c1 {
       %0 = memref.load %arg0[%arg1, %arg2] : memref<10x20xf32>
-      %1 = memref.load %alloc_0[] : memref<f32>
-      %2 = arith.addf %1, %0 : f32
-      memref.store %2, %alloc_0[] : memref<f32>
+      %1 = arith.addf %cst, %0 : f32
+      memref.store %1, %arg0[%arg1, %arg2] : memref<10x20xf32>
     }
   }
-  return %alloc_0 : memref<f32>
+  return
+}
+
+func.func @two_loops(%arg0: memref<10x20xf32>) {
+  // CHECK-LABEL: func @two_loops
+  %c0 = arith.constant 0 : index
+  %c10 = arith.constant 10 : index
+  %c1 = arith.constant 1 : index
+  %c20 = arith.constant 20 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  // CHECK: scf.parallel
+  // CHECK-NEXT: scf.for
+  // CHECK-NEXT: scf.for
+  scf.for %arg1 = %c0 to %c10 step %c1 {
+    scf.for %arg2 = %c0 to %c20 step %c1 {
+      %0 = memref.load %arg0[%arg1, %arg2] : memref<10x20xf32>
+      %1 = arith.addf %cst, %0 : f32
+      memref.store %1, %arg0[%arg1, %arg2] : memref<10x20xf32>
+    }
+  }
+  // CHECK: scf.parallel
+  // CHECK-NEXT: scf.for
+  // CHECK-NEXT: scf.for
+  scf.for %arg1 = %c0 to %c10 step %c1 {
+    scf.for %arg2 = %c0 to %c20 step %c1 {
+      %0 = memref.load %arg0[%arg1, %arg2] : memref<10x20xf32>
+      %1 = arith.addf %cst, %0 : f32
+      memref.store %1, %arg0[%arg1, %arg2] : memref<10x20xf32>
+    }
+  }
+  return
 }

--- a/test/Transforms/add-outer-parallel-loop.mlir
+++ b/test/Transforms/add-outer-parallel-loop.mlir
@@ -1,0 +1,22 @@
+// RUN: imex-opt --imex-add-outer-parallel-loop %s | FileCheck %s
+func.func @test(%arg0: memref<10x20xf32>) -> memref<f32> {
+  %c0 = arith.constant 0 : index
+  %c10 = arith.constant 10 : index
+  %c1 = arith.constant 1 : index
+  %c20 = arith.constant 20 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  %alloc = memref.alloc() {alignment = 128 : i64} : memref<f32>
+  memref.store %cst, %alloc[] : memref<f32>
+  %alloc_0 = memref.alloc() {alignment = 128 : i64} : memref<f32>
+  memref.copy %alloc, %alloc_0 : memref<f32> to memref<f32>
+  // CHECK: scf.parallel
+  scf.for %arg1 = %c0 to %c10 step %c1 {
+    scf.for %arg2 = %c0 to %c20 step %c1 {
+      %0 = memref.load %arg0[%arg1, %arg2] : memref<10x20xf32>
+      %1 = memref.load %alloc_0[] : memref<f32>
+      %2 = arith.addf %1, %0 : f32
+      memref.store %2, %alloc_0[] : memref<f32>
+    }
+  }
+  return %alloc_0 : memref<f32>
+}

--- a/test/Transforms/add-outer-parallel-loop.mlir
+++ b/test/Transforms/add-outer-parallel-loop.mlir
@@ -1,4 +1,5 @@
 // RUN: imex-opt --imex-add-outer-parallel-loop %s | FileCheck %s
+
 func.func @single_loop(%arg0: memref<10x20xf32>) {
   // CHECK-LABEL: func @single_loop
   %c0 = arith.constant 0 : index
@@ -19,8 +20,8 @@ func.func @single_loop(%arg0: memref<10x20xf32>) {
   return
 }
 
-func.func @two_loops(%arg0: memref<10x20xf32>) {
-  // CHECK-LABEL: func @two_loops
+func.func @two_independent_loops(%arg0: memref<10x20xf32>) {
+  // CHECK-LABEL: func @two_independent_loops
   %c0 = arith.constant 0 : index
   %c10 = arith.constant 10 : index
   %c1 = arith.constant 1 : index
@@ -47,4 +48,34 @@ func.func @two_loops(%arg0: memref<10x20xf32>) {
     }
   }
   return
+}
+
+func.func @two_dependent_loops_with_iterargs(%arg0: memref<10x20xf32>) -> memref<f32> {
+  // CHECK-LABEL: func @two_dependent_loops_with_iterargs
+  %c0 = arith.constant 0 : index
+  %c10 = arith.constant 10 : index
+  %c1 = arith.constant 1 : index
+  %c20 = arith.constant 20 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  %cst1 = arith.constant 1.000000e+00 : f32
+  %alloc = memref.alloc() {alignment = 128 : i64} : memref<f32>
+  // CHECK: scf.parallel
+  // CHECK-NEXT: scf.for
+  // CHECK-NEXT: scf.for
+  // CHECK: scf.for
+  // CHECK: scf.yield
+  %res = scf.for %arg1 = %c0 to %c10 step %c1 iter_args (%it = %cst) -> f32 {
+    scf.for %arg2 = %c0 to %c20 step %c1 {
+      %0 = memref.load %arg0[%arg1, %arg2] : memref<10x20xf32>
+      %1 = arith.addf %it, %0 : f32
+      memref.store %1, %arg0[%arg1, %arg2] : memref<10x20xf32>
+    }
+    %new = arith.addf %cst1, %it : f32
+    scf.yield  %new : f32
+  }
+  scf.for %arg4 = %c0 to %c20 step %c1 {
+    %1 = arith.addf %cst1, %res : f32
+    memref.store %1, %alloc[] : memref<f32>
+  }
+  return %alloc : memref<f32>
 }


### PR DESCRIPTION
When the original function does not have an outer parallel loop, this pass adds one so that the immediately followed pass gpu-map-parallel-loops can work and generate the gpu.module.
this pass is strongly based on the assumption that the kernel code we want to offload has a top-level for-loop and the host code do not have a for-loop.
Alternatively, an annotated function with somewhat attribute which specifies this is a kernel function would also help.



Please review these guidelines to help with the review process:
- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [ ] Have you organized your commits logically and ensured each can be built by itself?
