### PR TITLE
ntensor: lower broadcast op to linalg

### DIFF
--- a/mlir/lib/Conversion/NtensorToLinalg.cpp
+++ b/mlir/lib/Conversion/NtensorToLinalg.cpp
@@ -450,8 +450,10 @@ static mlir::Value expandDim(mlir::OpBuilder &builder, mlir::Location loc,
     builder.create<mlir::scf::YieldOp>(loc, res);
   };
   auto falseBody = [&](mlir::OpBuilder &builder, mlir::Location loc) {
-    auto res = builder.create<mlir::tensor::CastOp>(loc, targetType, src);
-    builder.create<mlir::scf::YieldOp>(loc, res.getResult());
+    mlir::Value res = src;
+    if (res.getType() != targetType)
+      res = builder.create<mlir::tensor::CastOp>(loc, targetType, src);
+    builder.create<mlir::scf::YieldOp>(loc, res);
   };
   return builder
       .create<mlir::scf::IfOp>(loc, targetType, cond, trueBody, falseBody)

--- a/mlir/lib/Conversion/NtensorToLinalg.cpp
+++ b/mlir/lib/Conversion/NtensorToLinalg.cpp
@@ -476,8 +476,9 @@ static mlir::Value expandDims(mlir::OpBuilder &builder, mlir::Location loc,
   for (unsigned i = 0; i < numDims; ++i)
     current = expandDim(builder, loc, val, current, i, targetShape);
 
-  current =
-      builder.create<imex::util::EnforceShapeOp>(loc, current, targetShape);
+  if (!targetShape.empty())
+    current =
+        builder.create<imex::util::EnforceShapeOp>(loc, current, targetShape);
   return current;
 }
 

--- a/mlir/test/Dialect/ntensor/ntensor-to-linalg.mlir
+++ b/mlir/test/Dialect/ntensor/ntensor-to-linalg.mlir
@@ -433,3 +433,45 @@ func.func @test(%arg1: !ntensor.ntensor<?x?xf32>, %arg2: !ntensor.ntensor<?xf32>
 //       CHECK:   } -> tensor<?x?xf32>
 //       CHECK:   %[[RES5:.*]] = ntensor.from_tensor %[[RES4]] : tensor<?x?xf32> to !ntensor.ntensor<?x?xf32>
 //       CHECK:   return %[[RES2]], %[[RES5]]
+
+// -----
+
+func.func @test(%arg1: !ntensor.ntensor<?x?xf32>, %arg2: !ntensor.ntensor<f32>) -> (!ntensor.ntensor<?x?xf32>, !ntensor.ntensor<?x?xf32>) {
+  %0:2 = ntensor.broadcast (%arg1, %arg2) : !ntensor.ntensor<?x?xf32>, !ntensor.ntensor<f32> -> !ntensor.ntensor<?x?xf32>, !ntensor.ntensor<?x?xf32>
+  return %0#0, %0#1 : !ntensor.ntensor<?x?xf32>, !ntensor.ntensor<?x?xf32>
+}
+// CHECK-LABEL: func @test
+//  CHECK-SAME:   (%[[ARG1:.*]]: !ntensor.ntensor<?x?xf32>, %[[ARG2:.*]]: !ntensor.ntensor<f32>)
+//       CHECK:   %[[SRC1:.*]] = ntensor.to_tensor %[[ARG1]] : !ntensor.ntensor<?x?xf32> to tensor<?x?xf32>
+//       CHECK:   %[[SRC2:.*]] = ntensor.to_tensor %[[ARG2]] : !ntensor.ntensor<f32> to tensor<f32>
+
+//       CHECK:   %[[SRC1D1:.*]] = scf.if %{{.*}} -> (tensor<?x?xf32>) {
+//       CHECK:     %[[TMP1:.*]] = tensor.empty(%{{.*}}, %{{.*}}) : tensor<?x?xf32>
+//       CHECK:     %[[TMP2:.*]] = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel"]} ins(%[[SRC1]] : tensor<?x?xf32>) outs(%[[TMP1]] : tensor<?x?xf32>) {
+//       CHECK:     ^bb0(%in: f32, %out: f32):
+//       CHECK:       linalg.yield %in : f32
+//       CHECK:     } -> tensor<?x?xf32>
+//       CHECK:     scf.yield %[[TMP2]] : tensor<?x?xf32>
+//       CHECK:   } else {
+//       CHECK:     scf.yield %[[SRC1]] : tensor<?x?xf32>
+//       CHECK:   }
+
+//       CHECK:   %[[SRC1D2:.*]] = scf.if %{{.*}} -> (tensor<?x?xf32>) {
+//       CHECK:     %[[TMP3:.*]] = tensor.empty(%{{.*}}, %{{.*}}) : tensor<?x?xf32>
+//       CHECK:     %[[TMP4:.*]] = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel"]} ins(%[[SRC1D1]] : tensor<?x?xf32>) outs(%[[TMP3]] : tensor<?x?xf32>) {
+//       CHECK:     ^bb0(%in: f32, %out: f32):
+//       CHECK:       linalg.yield %in : f32
+//       CHECK:     } -> tensor<?x?xf32>
+//       CHECK:     scf.yield %[[TMP4]] : tensor<?x?xf32>
+//       CHECK:   } else {
+//       CHECK:     scf.yield %[[SRC1D1]] : tensor<?x?xf32>
+//       CHECK:   }
+//       CHECK:   %[[RES1:.*]] = imex_util.enforce_shape %[[SRC1D2]] : tensor<?x?xf32>(%{{.*}}, %{{.*}}) -> tensor<?x?xf32>
+//       CHECK:   %[[RES2:.*]] = ntensor.from_tensor %[[RES1]] : tensor<?x?xf32> to !ntensor.ntensor<?x?xf32>
+
+//       CHECK:   %[[RES3:.*]] = linalg.generic {indexing_maps = [#map3, #map1], iterator_types = ["parallel", "parallel"]} ins(%[[SRC2]] : tensor<f32>) outs(%{{.*}} : tensor<?x?xf32>) {
+//       CHECK:   ^bb0(%in: f32, %out: f32):
+//       CHECK:     linalg.yield %in : f32
+//       CHECK:   } -> tensor<?x?xf32>
+//       CHECK:   %[[RES4:.*]] = ntensor.from_tensor %[[RES3]] : tensor<?x?xf32> to !ntensor.ntensor<?x?xf32>
+//       CHECK:   return %[[RES2]], %[[RES4]]

--- a/mlir/test/Dialect/ntensor/ntensor-to-linalg.mlir
+++ b/mlir/test/Dialect/ntensor/ntensor-to-linalg.mlir
@@ -379,3 +379,57 @@ func.func @test(%arg1: !ntensor.ntensor<?x?xf32>, %arg2: !ntensor.ntensor<?x?xf3
 //       CHECK:   %[[RES3:.*]] = imex_util.enforce_shape %[[SRC2D2]] : tensor<?x?xf32>(%{{.*}}, %{{.*}}) -> tensor<?x?xf32>
 //       CHECK:   %[[RES4:.*]] = ntensor.from_tensor %[[RES3]] : tensor<?x?xf32> to !ntensor.ntensor<?x?xf32>
 //       CHECK:   return %[[RES2]], %[[RES4]]
+
+// -----
+
+func.func @test(%arg1: !ntensor.ntensor<?x?xf32>, %arg2: !ntensor.ntensor<?xf32>) -> (!ntensor.ntensor<?x?xf32>, !ntensor.ntensor<?x?xf32>) {
+  %0:2 = ntensor.broadcast (%arg1, %arg2) : !ntensor.ntensor<?x?xf32>, !ntensor.ntensor<?xf32> -> !ntensor.ntensor<?x?xf32>, !ntensor.ntensor<?x?xf32>
+  return %0#0, %0#1 : !ntensor.ntensor<?x?xf32>, !ntensor.ntensor<?x?xf32>
+}
+// CHECK-LABEL: func @test
+//  CHECK-SAME:   (%[[ARG1:.*]]: !ntensor.ntensor<?x?xf32>, %[[ARG2:.*]]: !ntensor.ntensor<?xf32>)
+//       CHECK:   %[[SRC1:.*]] = ntensor.to_tensor %[[ARG1]] : !ntensor.ntensor<?x?xf32> to tensor<?x?xf32>
+//       CHECK:   %[[SRC2:.*]] = ntensor.to_tensor %[[ARG2]] : !ntensor.ntensor<?xf32> to tensor<?xf32>
+
+//       CHECK:   %[[SRC1D1:.*]] = scf.if %{{.*}} -> (tensor<?x?xf32>) {
+//       CHECK:     %[[TMP1:.*]] = tensor.empty(%{{.*}}, %{{.*}}) : tensor<?x?xf32>
+//       CHECK:     %[[TMP2:.*]] = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel"]} ins(%[[SRC1]] : tensor<?x?xf32>) outs(%[[TMP1]] : tensor<?x?xf32>) {
+//       CHECK:     ^bb0(%in: f32, %out: f32):
+//       CHECK:       linalg.yield %in : f32
+//       CHECK:     } -> tensor<?x?xf32>
+//       CHECK:     scf.yield %[[TMP2]] : tensor<?x?xf32>
+//       CHECK:   } else {
+//       CHECK:     scf.yield %[[SRC1]] : tensor<?x?xf32>
+//       CHECK:   }
+
+//       CHECK:   %[[SRC1D2:.*]] = scf.if %{{.*}} -> (tensor<?x?xf32>) {
+//       CHECK:     %[[TMP3:.*]] = tensor.empty(%{{.*}}, %{{.*}}) : tensor<?x?xf32>
+//       CHECK:     %[[TMP4:.*]] = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel"]} ins(%[[SRC1D1]] : tensor<?x?xf32>) outs(%[[TMP3]] : tensor<?x?xf32>) {
+//       CHECK:     ^bb0(%in: f32, %out: f32):
+//       CHECK:       linalg.yield %in : f32
+//       CHECK:     } -> tensor<?x?xf32>
+//       CHECK:     scf.yield %[[TMP4]] : tensor<?x?xf32>
+//       CHECK:   } else {
+//       CHECK:     scf.yield %[[SRC1D1]] : tensor<?x?xf32>
+//       CHECK:   }
+//       CHECK:   %[[RES1:.*]] = imex_util.enforce_shape %[[SRC1D2]] : tensor<?x?xf32>(%{{.*}}, %{{.*}}) -> tensor<?x?xf32>
+//       CHECK:   %[[RES2:.*]] = ntensor.from_tensor %[[RES1]] : tensor<?x?xf32> to !ntensor.ntensor<?x?xf32>
+
+//       CHECK:   %[[SRC2D1:.*]] = scf.if %{{.*}} -> (tensor<?xf32>) {
+//       CHECK:     %[[TMP1:.*]] = tensor.empty(%{{.*}}) : tensor<?xf32>
+//       CHECK:     %[[TMP2:.*]] = linalg.generic {indexing_maps = [#map3, #map4], iterator_types = ["parallel"]} ins(%[[SRC2]] : tensor<?xf32>) outs(%[[TMP1]] : tensor<?xf32>) {
+//       CHECK:     ^bb0(%in: f32, %out: f32):
+//       CHECK:       linalg.yield %in : f32
+//       CHECK:     } -> tensor<?xf32>
+//       CHECK:     scf.yield %[[TMP2]] : tensor<?xf32>
+//       CHECK:   } else {
+//       CHECK:     scf.yield %[[SRC2]] : tensor<?xf32>
+//       CHECK:   }
+//       CHECK:   %[[RES3:.*]] = imex_util.enforce_shape %[[SRC2D1]] : tensor<?xf32>(%{{.*}}) -> tensor<?xf32>
+
+//       CHECK:   %[[RES4:.*]] = linalg.generic {indexing_maps = [#map5, #map1], iterator_types = ["parallel", "parallel"]} ins(%[[RES3]] : tensor<?xf32>) outs(%{{.*}} : tensor<?x?xf32>) {
+//       CHECK:   ^bb0(%in: f32, %out: f32):
+//       CHECK:     linalg.yield %in : f32
+//       CHECK:   } -> tensor<?x?xf32>
+//       CHECK:   %[[RES5:.*]] = ntensor.from_tensor %[[RES4]] : tensor<?x?xf32> to !ntensor.ntensor<?x?xf32>
+//       CHECK:   return %[[RES2]], %[[RES5]]

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/PyLinalgResolver.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/PyLinalgResolver.cpp
@@ -589,10 +589,6 @@ static auto genericOpBodyResultTypes(mlir::ValueRange outputs) {
 
 static py::object broadcastImpl(py::capsule context, py::tuple args,
                                 py::handle resultType) {
-  // TODO: remove this
-  if (1 == args.size())
-    return args[0];
-
   auto &ctx = getPyContext(context);
   auto loc = ctx.loc;
   auto &builder = ctx.builder;

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/PyLinalgResolver.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/PyLinalgResolver.cpp
@@ -24,6 +24,7 @@
 #include "imex/Dialect/imex_util/Dialect.hpp"
 #include "imex/Dialect/ntensor/IR/NTensorOps.hpp"
 #include "imex/Dialect/plier/Dialect.hpp"
+#include "imex/Transforms/CastUtils.hpp"
 #include "imex/Transforms/ConstUtils.hpp"
 #include "imex/Transforms/FuncUtils.hpp"
 #include "imex/Utils.hpp"
@@ -428,6 +429,34 @@ static mlir::Value toTensor(mlir::Location loc, mlir::OpBuilder &builder,
   return val;
 }
 
+static mlir::Type toNTensorType(mlir::ShapedType type) {
+  return imex::ntensor::NTensorType::get(type.getShape(),
+                                         type.getElementType());
+}
+
+static mlir::Value toNTensor(mlir::Location loc, mlir::OpBuilder &builder,
+                             mlir::Value val) {
+  auto srcType = val.getType();
+  if (auto memrefType = srcType.dyn_cast<mlir::MemRefType>())
+    return builder.create<imex::ntensor::FromMemrefOp>(
+        loc, toNTensorType(memrefType), val);
+
+  if (auto tensorType = srcType.dyn_cast<mlir::RankedTensorType>())
+    return builder.create<imex::ntensor::FromTensorOp>(
+        loc, toNTensorType(tensorType), val);
+
+  if (srcType.isa<imex::ntensor::NTensorType>())
+    return val;
+
+  if (imex::ntensor::NTensorType::isValidElementType(srcType)) {
+    auto retType = imex::ntensor::NTensorType::get(llvm::None, srcType);
+    return builder.create<imex::ntensor::FromElementsOp>(loc, retType, val);
+  }
+
+  imex::reportError(llvm::Twine("toNTensor: invalid source type ") +
+                    toStr(srcType));
+}
+
 static py::object
 getArgs(py::handle inspect, py::handle func,
         llvm::function_ref<py::object(mlir::Value)> createVar,
@@ -567,108 +596,9 @@ static auto genericOpBodyResultTypes(mlir::ValueRange outputs) {
   return ret;
 }
 
-static mlir::Value broadcastDim(mlir::OpBuilder &builder, mlir::Location loc,
-                                mlir::Value val1, mlir::Value val2) {
-  assert(val1.getType().isa<mlir::IndexType>());
-  assert(val2.getType().isa<mlir::IndexType>());
-  auto one = builder.create<mlir::arith::ConstantIndexOp>(loc, 1);
-  auto isOne = builder.create<mlir::arith::CmpIOp>(
-      loc, mlir::arith::CmpIPredicate::eq, val1, one);
-  auto tmp = builder.create<mlir::arith::SelectOp>(loc, isOne, val2, val1);
-  auto isSame = builder.create<mlir::arith::CmpIOp>(
-      loc, mlir::arith::CmpIPredicate::eq, val1, val2);
-  return builder.create<mlir::arith::SelectOp>(loc, isSame, val1, tmp);
-}
-
-static mlir::Value expandDim(mlir::OpBuilder &builder, mlir::Location loc,
-                             mlir::Value initial, mlir::Value src, unsigned dim,
-                             mlir::ValueRange targetShape) {
-  assert(initial.getType().isa<mlir::RankedTensorType>());
-  assert(src.getType().isa<mlir::RankedTensorType>());
-  auto context = builder.getContext();
-  auto srcType = src.getType().cast<mlir::ShapedType>();
-  auto numDims = static_cast<unsigned>(srcType.getRank());
-  auto shape = llvm::to_vector<8>(srcType.getShape());
-  shape[dim] = mlir::ShapedType::kDynamicSize;
-  mlir::Type targetType =
-      mlir::RankedTensorType::get(shape, srcType.getElementType());
-  auto dimVal = builder.create<mlir::tensor::DimOp>(loc, initial, dim);
-  auto one = builder.create<mlir::arith::ConstantIndexOp>(loc, 1);
-  mlir::Value cond = builder.create<mlir::arith::CmpIOp>(
-      loc, mlir::arith::CmpIPredicate::eq, one, dimVal);
-  mlir::Value cond2 = builder.create<mlir::arith::CmpIOp>(
-      loc, mlir::arith::CmpIPredicate::ne, targetShape[dim], dimVal);
-  cond = builder.create<mlir::arith::AndIOp>(loc, cond, cond2);
-  llvm::SmallVector<mlir::OpFoldResult> newShape(numDims);
-  for (unsigned i = 0; i < numDims; ++i) {
-    if (i == dim) {
-      newShape[i] = targetShape[i];
-    } else {
-      newShape[i] =
-          builder.create<mlir::tensor::DimOp>(loc, src, i).getResult();
-    }
-  }
-  auto trueBody = [&](mlir::OpBuilder &builder, mlir::Location loc) {
-    assert(dim < shape.size());
-    shape[dim] = 1;
-    auto casted = src; // TODO
-    auto init = builder
-                    .create<mlir::tensor::EmptyOp>(loc, newShape,
-                                                   srcType.getElementType())
-                    .getResult();
-    llvm::SmallVector<mlir::AffineExpr> exprs(numDims);
-    for (unsigned i = 0; i < numDims; ++i) {
-      if (i == dim) {
-        exprs[i] = mlir::getAffineConstantExpr(0, context);
-      } else {
-        exprs[i] = mlir::getAffineDimExpr(i, context);
-      }
-    }
-    const mlir::AffineMap maps[] = {
-        mlir::AffineMap::get(numDims, 0, exprs, context),
-        mlir::AffineMap::getMultiDimIdentityMap(numDims, context),
-    };
-    llvm::SmallVector<mlir::StringRef> iterators(numDims, "parallel");
-
-    auto body = [&](mlir::OpBuilder &builder, mlir::Location loc,
-                    mlir::ValueRange values) {
-      assert(values.size() == 2);
-      builder.create<mlir::linalg::YieldOp>(loc, values[0]);
-    };
-
-    auto expanded = builder.create<mlir::linalg::GenericOp>(
-        loc, init.getType(), casted, init, maps, iterators, body);
-    auto res = builder.createOrFold<mlir::tensor::CastOp>(
-        loc, targetType, expanded.getResult(0));
-    builder.create<mlir::scf::YieldOp>(loc, res);
-  };
-  auto falseBody = [&](mlir::OpBuilder &builder, mlir::Location loc) {
-    auto res = builder.create<mlir::tensor::CastOp>(loc, targetType, src);
-    builder.create<mlir::scf::YieldOp>(loc, res.getResult());
-  };
-  return builder
-      .create<mlir::scf::IfOp>(loc, targetType, cond, trueBody, falseBody)
-      .getResult(0);
-}
-
-static mlir::Value expandDims(mlir::OpBuilder &builder, mlir::Location loc,
-                              mlir::Value val, unsigned numDims,
-                              mlir::ValueRange targetShape) {
-  assert(numDims <= targetShape.size());
-  if (numDims < targetShape.size())
-    targetShape = targetShape.drop_front(targetShape.size() - numDims);
-
-  mlir::Value current = val;
-  for (unsigned i = 0; i < numDims; ++i)
-    current = expandDim(builder, loc, val, current, i, targetShape);
-
-  current =
-      builder.create<imex::util::EnforceShapeOp>(loc, current, targetShape);
-  return current;
-}
-
 static py::object broadcastImpl(py::capsule context, py::tuple args,
                                 py::handle resultType) {
+  // TODO: remove this
   if (1 == args.size())
     return args[0];
 
@@ -677,154 +607,64 @@ static py::object broadcastImpl(py::capsule context, py::tuple args,
   auto &builder = ctx.builder;
 
   llvm::SmallVector<mlir::Value> mlirArgs(args.size());
-  for (auto it : llvm::enumerate(args)) {
+
+  int64_t rank = 0;
+  for (auto [i, obj] : llvm::enumerate(args)) {
     auto val =
-        toTensor(loc, builder, ctx.context.unwrapVal(loc, builder, it.value()));
-    mlirArgs[it.index()] = val;
+        toNTensor(loc, builder, ctx.context.unwrapVal(loc, builder, obj));
+
+    rank = std::max(rank, val.getType().cast<mlir::ShapedType>().getRank());
+    mlirArgs[i] = val;
   }
-  using shape_t = llvm::SmallVector<mlir::Value>;
-  auto getShape =
-      [&](mlir::Value val) -> llvm::Optional<std::pair<shape_t, mlir::Type>> {
-    auto type = val.getType();
-    if (auto shaped = type.dyn_cast<mlir::ShapedType>()) {
-      if (!shaped.hasRank())
-        return {};
 
-      shape_t ret(static_cast<size_t>(shaped.getRank()));
-      for (auto it : llvm::enumerate(ret)) {
-        auto dim = builder.create<mlir::tensor::DimOp>(loc, val, it.index());
-        ret[it.index()] = dim;
+  llvm::SmallVector<mlir::Type> resTypes(args.size());
+  llvm::SmallVector<int64_t> resShape(static_cast<size_t>(rank),
+                                      mlir::ShapedType::kDynamicSize);
+  for (auto [i, arg] : llvm::enumerate(mlirArgs))
+    resTypes[i] = arg.getType().cast<mlir::ShapedType>().clone(resShape);
+
+  auto broadcast =
+      builder.create<imex::ntensor::BroadcastOp>(loc, resTypes, mlirArgs);
+
+  llvm::SmallVector<mlir::Value> results(broadcast->getNumResults());
+  if (!resultType.is_none()) {
+    auto resType = unwrapType(resultType);
+    for (auto [i, res] :
+         llvm::enumerate(mlir::ValueRange(broadcast.getResults()))) {
+      auto srcType = res.getType().cast<mlir::ShapedType>();
+      auto dstType = srcType.clone(resType);
+      if (srcType != dstType) {
+        if (!imex::canConvert(srcType.getElementType(), resType))
+          imex::reportError(llvm::Twine("Cannont convert from ") +
+                            toStr(srcType.getElementType()) + " to " +
+                            toStr(resType));
+
+        auto bodyBuilder = [&](mlir::OpBuilder &b, mlir::Location l,
+                               mlir::Value val) {
+          auto res = imex::doConvert(b, l, val, resType);
+          assert(res);
+          b.create<imex::ntensor::ElementwiseYieldOp>(l, res);
+        };
+
+        res = builder.create<imex::ntensor::ElementwiseOp>(loc, dstType, res,
+                                                           bodyBuilder);
       }
-      return std::make_pair(ret, shaped.getElementType());
+      results[i] = res;
     }
-    if (type.isa<mlir::IntegerType, mlir::IndexType, mlir::FloatType>())
-      return std::make_pair(shape_t{}, type);
-
-    return {};
-  };
-  mlir::SmallVector<mlir::Value> shapeVals;
-  if (auto shapeAndType = getShape(mlirArgs.front())) {
-    shapeVals = shapeAndType->first;
   } else {
-    return py::none();
+    auto res = broadcast.getResults();
+    results.assign(res.begin(), res.end());
   }
 
-  for (auto arg : llvm::drop_begin(mlirArgs)) {
-    auto shapeAndType = getShape(arg);
-    if (!shapeAndType)
-      return py::none();
-
-    auto newShapeVals = shapeAndType->first;
-    for (auto it :
-         llvm::zip(llvm::reverse(shapeVals), llvm::reverse(newShapeVals))) {
-      auto &oldVal = std::get<0>(it);
-      auto newVal = std::get<1>(it);
-      oldVal = broadcastDim(builder, loc, oldVal, newVal);
-    }
-    if (newShapeVals.size() > shapeVals.size()) {
-      auto front = llvm::makeArrayRef(newShapeVals).drop_back(shapeVals.size());
-      assert(!front.empty());
-      shapeVals.insert(shapeVals.begin(), front.begin(), front.end());
-    }
+  py::tuple ret(results.size());
+  for (auto [i, res] : llvm::enumerate(results)) {
+    auto srcType = res.getType().cast<mlir::ShapedType>();
+    auto dstType = mlir::RankedTensorType::get(srcType.getShape(),
+                                               srcType.getElementType());
+    res = builder.create<imex::ntensor::ToTensorOp>(loc, dstType, res);
+    ret[i] = ctx.context.createVar(context, res);
   }
 
-  mlir::Type resType;
-  auto haveResultType = !resultType.is_none();
-  if (haveResultType)
-    resType = unwrapType(resultType);
-
-  py::tuple ret(mlirArgs.size());
-  if (shapeVals.empty()) {
-    for (auto it : llvm::enumerate(mlirArgs)) {
-      mlir::Value val = it.value();
-      if (haveResultType && val.getType() != resType)
-        val = builder.create<plier::CastOp>(loc, resType, val);
-
-      ret[it.index()] = ctx.context.createVar(context, val);
-    }
-    return std::move(ret);
-  }
-
-  llvm::SmallVector<int64_t> shape(static_cast<size_t>(shapeVals.size()),
-                                   mlir::ShapedType::kDynamicSize);
-  for (auto it : llvm::enumerate(mlirArgs)) {
-    mlir::Value val = it.value();
-    auto i = it.index();
-    auto tensorElemType =
-        haveResultType ? resType : getShape(mlirArgs[i])->second;
-    auto tensorType = mlir::RankedTensorType::get(shape, tensorElemType);
-    auto signlessResType = makeSignlessType(tensorElemType);
-    auto signlessTensorType =
-        mlir::RankedTensorType::get(shape, signlessResType);
-    val = doSignCast(builder, loc, val);
-    if (auto srcType = val.getType().dyn_cast<mlir::ShapedType>()) {
-      assert(srcType.hasRank());
-      val = expandDims(builder, loc, val,
-                       static_cast<unsigned>(srcType.getRank()), shapeVals);
-    }
-    if (val.getType() != signlessTensorType) {
-      auto type = val.getType();
-      if (auto srcType = type.dyn_cast<mlir::ShapedType>()) {
-        assert(srcType.hasRank());
-        auto srcNumDims = static_cast<unsigned>(srcType.getRank());
-        auto numDims = static_cast<unsigned>(signlessTensorType.getRank());
-        auto init = builder
-                        .create<mlir::tensor::EmptyOp>(
-                            loc, getTempShape(shapeVals),
-                            signlessTensorType.getElementType())
-                        .getResult();
-        mlir::AffineMap maps[] = {
-            mlir::AffineMap::getMinorIdentityMap(numDims, srcNumDims,
-                                                 builder.getContext()),
-            mlir::AffineMap::getMultiDimIdentityMap(numDims,
-                                                    builder.getContext()),
-        };
-        llvm::SmallVector<llvm::StringRef> iterators(numDims, "parallel");
-        auto body = [&](mlir::OpBuilder &builder, mlir::Location loc,
-                        mlir::ValueRange values) {
-          assert(values.size() == 2);
-          auto res = builder.create<plier::CastOp>(
-              loc, signlessTensorType.getElementType(), values[0]);
-          builder.create<mlir::linalg::YieldOp>(loc, res.getResult());
-        };
-        val = builder
-                  .create<mlir::linalg::GenericOp>(loc, signlessTensorType, val,
-                                                   init, maps, iterators, body)
-                  .getResult(0);
-      } else {
-        if (signlessTensorType.getElementType() != type)
-          val = builder.create<plier::CastOp>(
-              loc, signlessTensorType.getElementType(), val);
-
-        val = builder.create<mlir::tensor::FromElementsOp>(loc, val);
-        auto numDims = static_cast<unsigned>(signlessTensorType.getRank());
-        auto init = builder
-                        .create<mlir::tensor::EmptyOp>(
-                            loc, getTempShape(shapeVals),
-                            signlessTensorType.getElementType())
-                        .getResult();
-        mlir::AffineMap maps[] = {
-            mlir::AffineMap::get(
-                numDims, 0,
-                mlir::getAffineConstantExpr(0, builder.getContext())),
-            mlir::AffineMap::getMultiDimIdentityMap(numDims,
-                                                    builder.getContext()),
-        };
-        llvm::SmallVector<llvm::StringRef> iterators(numDims, "parallel");
-        auto body = [&](mlir::OpBuilder &builder, mlir::Location loc,
-                        mlir::ValueRange values) {
-          assert(values.size() == 2);
-          builder.create<mlir::linalg::YieldOp>(loc, values[0]);
-        };
-        val = builder
-                  .create<mlir::linalg::GenericOp>(loc, signlessTensorType, val,
-                                                   init, maps, iterators, body)
-                  .getResult(0);
-      }
-    }
-    val = doSignCast(builder, loc, val, tensorType);
-    ret[i] = ctx.context.createVar(context, val);
-  }
   return std::move(ret);
 }
 


### PR DESCRIPTION
Broadcasting is implemented in 2 stages:
* Compute broadcasted shape based on arrays shapes, shapes are assumed valid for broadcast purposes, no checks for validity yet.
* For each input array optionally expand each individual dimension using `linalg.generic` according to calculated shape, for statically known dimensions it is assumed those expansions will be simplified and fused later in pipeline.

Also, remove all broadcast-related code from `PyLinalgResolver.cpp` and use `ntensor.broadcast` there