### PR TITLE
Handle memref returned from callOp in InsertGpuAlloc Pass

### DIFF
--- a/test/Transforms/InsertGpuAllocs/memref-returned-from-call.mlir
+++ b/test/Transforms/InsertGpuAllocs/memref-returned-from-call.mlir
@@ -15,23 +15,16 @@ func.func @main() {
   // OPENCL: memref.copy %0, %[[MEMREF:.*]] : memref<8xf32> to memref<8xf32>
   %1 = memref.alloc() : memref<8xf32>
   %2 = memref.alloc() : memref<8xf32>
-  // OPENCL: %[[MEMREF1:.*]]= gpu.alloc  () : memref<8xf32>
-  // OPENCL: %[[MEMREF2:.*]]= gpu.alloc  () : memref<8xf32>
-  // VULKAN: %[[MEMREF0:.*]]= memref.alloc() : memref<8xf32>
-  // VULKAN: %[[MEMREF1:.*]]= memref.alloc() : memref<8xf32>
   gpu.launch blocks(%arg0, %arg1, %arg2) in (%arg6 = %c8, %arg7 = %c1, %arg8 = %c1) threads(%arg3, %arg4, %arg5) in (%arg9 = %c1, %arg10 = %c1, %arg11 = %c1) {
     // OPENCL: gpu.launch {{.*}}
     // VULKAN: gpu.launch {{.*}}
     %7 = gpu.block_id  x
     // OPENCL: [[VAR0:.*]] = gpu.block_id  x
     // VULKAN: [[VAR0:.*]] = gpu.block_id  x
+
+    // OPENCL: [[VAR1:.*]] = memref.load %[[MEMREF:.*]][[[VAR0:.*]]] : memref<8xf32>
     %8 = memref.load %0[%7] : memref<8xf32>
     %9 = memref.load %1[%7] : memref<8xf32>
-
-    // OPENCL: [[VAR1:.*]] = memref.load %[[MEMREF0:.*]][[[VAR0:.*]]] : memref<8xf32>
-    // OPENCL: [[VAR2:.*]] = memref.load %[[MEMREF1:.*]][[[VAR0:.*]]] : memref<8xf32>
-    // VULKAN: [[VAR1:.*]] = memref.load %[[MEMREF0:.*]][[[VAR0:.*]]] : memref<8xf32>
-    // VULKAN: [[VAR2:.*]] = memref.load %[[MEMREF1:.*]][[[VAR0:.*]]] : memref<8xf32>
     %10 = func.call @addf(%8, %9) : (f32, f32) -> f32
     memref.store %10, %2[%7] : memref<8xf32>
     %11 = func.call @cast(%2) : (memref<8xf32>) -> memref<?xf32>

--- a/test/Transforms/InsertGpuAllocs/memref-returned-from-call.mlir
+++ b/test/Transforms/InsertGpuAllocs/memref-returned-from-call.mlir
@@ -1,0 +1,47 @@
+// RUN: imex-opt --insert-gpu-allocs='client-api=opencl' %s | FileCheck %s --check-prefix=OPENCL
+// RUN: imex-opt --insert-gpu-allocs='client-api=vulkan' %s | FileCheck %s --check-prefix=VULKAN
+
+func.func @alloc_buffer() -> memref<8xf32> {
+%buf = memref.alloc() : memref<8xf32>
+return %buf : memref<8xf32>
+}
+
+func.func @main() {
+  %c8 = arith.constant 8 : index
+  %c1 = arith.constant 1 : index
+  // OPENCL: func.func @main()
+  %0 = func.call @alloc_buffer() :  () -> memref<8xf32>
+  // OPENCL: %[[MEMREF:.*]] = gpu.alloc  host_shared () : memref<8xf32>
+  // OPENCL: memref.copy %0, %[[MEMREF:.*]] : memref<8xf32> to memref<8xf32>
+  %1 = memref.alloc() : memref<8xf32>
+  %2 = memref.alloc() : memref<8xf32>
+  // OPENCL: %[[MEMREF1:.*]]= gpu.alloc  () : memref<8xf32>
+  // OPENCL: %[[MEMREF2:.*]]= gpu.alloc  () : memref<8xf32>
+  // VULKAN: %[[MEMREF0:.*]]= memref.alloc() : memref<8xf32>
+  // VULKAN: %[[MEMREF1:.*]]= memref.alloc() : memref<8xf32>
+  gpu.launch blocks(%arg0, %arg1, %arg2) in (%arg6 = %c8, %arg7 = %c1, %arg8 = %c1) threads(%arg3, %arg4, %arg5) in (%arg9 = %c1, %arg10 = %c1, %arg11 = %c1) {
+    // OPENCL: gpu.launch {{.*}}
+    // VULKAN: gpu.launch {{.*}}
+    %7 = gpu.block_id  x
+    // OPENCL: [[VAR0:.*]] = gpu.block_id  x
+    // VULKAN: [[VAR0:.*]] = gpu.block_id  x
+    %8 = memref.load %0[%7] : memref<8xf32>
+    %9 = memref.load %1[%7] : memref<8xf32>
+
+    // OPENCL: [[VAR1:.*]] = memref.load %[[MEMREF0:.*]][[[VAR0:.*]]] : memref<8xf32>
+    // OPENCL: [[VAR2:.*]] = memref.load %[[MEMREF1:.*]][[[VAR0:.*]]] : memref<8xf32>
+    // VULKAN: [[VAR1:.*]] = memref.load %[[MEMREF0:.*]][[[VAR0:.*]]] : memref<8xf32>
+    // VULKAN: [[VAR2:.*]] = memref.load %[[MEMREF1:.*]][[[VAR0:.*]]] : memref<8xf32>
+    %10 = func.call @addf(%8, %9) : (f32, f32) -> f32
+    memref.store %10, %2[%7] : memref<8xf32>
+    %11 = func.call @cast(%2) : (memref<8xf32>) -> memref<?xf32>
+    gpu.terminator
+    // OPENCL: gpu.terminator
+    // VULKAN: gpu.terminator
+  }
+  %6 = memref.cast %2 : memref<8xf32> to memref<*xf32>
+  return
+}
+
+func.func private @addf(%input1 : f32, %input2 : f32) -> f32
+func.func private @cast(%input : memref<8xf32>) -> memref<?xf32>


### PR DESCRIPTION
Please review these guidelines to help with the review process:
- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
- [x] Have you organized your commits logically and ensured each can be built by itself?

This PR handles the case where the origin of memrefs are from a mlir::callOp. This PR creates the memory on device and inserts a memcopy to copy the result of the callOp to the allocated buffer.

This PR enables two Jax Test cases 
Janet- jit__get_lgt_birth.7_linalg
Janet - jit__unit_scale_traindata.47_linalg 

The above mentioned test cases are in PR #437 




