### PR TITLE
Add `numba.prange` offloading

### DIFF
--- a/mlir/lib/Dialect/ntensor/Transforms/PropagateEnvironment.cpp
+++ b/mlir/lib/Dialect/ntensor/Transforms/PropagateEnvironment.cpp
@@ -206,6 +206,9 @@ struct PropagateEnvironmentPass
           if (!state)
             continue;
 
+          if (auto srcEnv = getTensorEnv(arg))
+            env = *srcEnv;
+
           auto &val = state->getValue();
           if (val.isUninitialized())
             continue;

--- a/mlir/test/Dialect/ntensor/propagate-env.mlir
+++ b/mlir/test/Dialect/ntensor/propagate-env.mlir
@@ -61,8 +61,8 @@ func.func @test(%arg1: !ntensor.ntensor<?xf32, "test1">, %arg2: !ntensor.ntensor
 // -----
 
 // CHECK-LABEL: func @test
-//  CHECK-SAME: (%[[ARG:.*]]: !ntensor.ntensor<?xf32>)
-//       CHECK: %[[RES:.*]] = ntensor.primitive "foo" (%[[ARG]]) : !ntensor.ntensor<?xf32> -> !ntensor.ntensor<?xf32>
+//  CHECK-SAME: (%[[ARG:.*]]: !ntensor.ntensor<?xf32, "test">)
+//       CHECK: %[[RES:.*]] = ntensor.load %[[ARG]][%{{.*}}] : !ntensor.ntensor<?xf32, "test">
 //       CHECK: return %[[RES]]
 func.func @test(%arg1: !ntensor.ntensor<?xf32, "test">) -> f32 {
   %0 = arith.constant 0 : index

--- a/mlir/test/Dialect/ntensor/propagate-env.mlir
+++ b/mlir/test/Dialect/ntensor/propagate-env.mlir
@@ -57,3 +57,15 @@ func.func @test(%arg1: !ntensor.ntensor<?xf32, "test1">, %arg2: !ntensor.ntensor
   %4 = ntensor.primitive "foo" (%3) : !ntensor.ntensor<?xf32> -> !ntensor.ntensor<?xf32>
   return %4 : !ntensor.ntensor<?xf32>
 }
+
+// -----
+
+// CHECK-LABEL: func @test
+//  CHECK-SAME: (%[[ARG:.*]]: !ntensor.ntensor<?xf32>)
+//       CHECK: %[[RES:.*]] = ntensor.primitive "foo" (%[[ARG]]) : !ntensor.ntensor<?xf32> -> !ntensor.ntensor<?xf32>
+//       CHECK: return %[[RES]]
+func.func @test(%arg1: !ntensor.ntensor<?xf32, "test">) -> f32 {
+  %0 = arith.constant 0 : index
+  %1 = ntensor.load %arg1[%0] : !ntensor.ntensor<?xf32, "test">
+  return %1 : f32
+}


### PR DESCRIPTION
Add `WrapParforRegions` pass to pipeline:
* Scan function body for `scf.for` loops marked with `getParallelName()` attribute (i.e. generated from `prange`)
* Scan for ntensor load and stores inside loop and check theirs env attributes, if all attributes are `null` - usual numpy arrays - do nothing
* If multiple different envs - conflicting arrays - compilation error
* Wrap loop into env region with this env
* Rest of the pipeline will handle env region and translate it to `gpu.launch`
