### PR TITLE
Work on parallel reduction for gpu

### DIFF
--- a/mlir/include/imex/Conversion/GpuToGpuRuntime.hpp
+++ b/mlir/include/imex/Conversion/GpuToGpuRuntime.hpp
@@ -38,4 +38,8 @@ std::unique_ptr<mlir::Pass> createTileParallelLoopsForGPUPass();
 /// For devices without f64 support, truncate all operations to f32.
 std::unique_ptr<mlir::Pass> createTruncateF64ForGPUPass();
 
+/// Update scf.parallel loops with reductions to use gpu_runtime.global_reduce.
+/// This pass is intended to be run right before scf-to-gpu.
+std::unique_ptr<mlir::Pass> createInsertGPUGlobalReducePass();
+
 } // namespace gpu_runtime

--- a/mlir/include/imex/Dialect/gpu_runtime/IR/GpuRuntimeOps.td
+++ b/mlir/include/imex/Dialect/gpu_runtime/IR/GpuRuntimeOps.td
@@ -223,4 +223,42 @@ def GPUMemFenceOp : GpuRuntime_Op<"mem_fence"> {
   let assemblyFormat = "$flags attr-dict";
 }
 
+def GPUGlobalReduceOp : GpuRuntime_Op<"global_reduce", [
+    SameOperandsAndResultType,
+    IsolatedFromAbove,
+    SingleBlockImplicitTerminator<"::gpu_runtime::GPUGlobalReduceYieldOp">,
+    RecursiveMemoryEffects
+  ]> {
+  let summary = "Reduce values among global exectuion space.";
+  let description = [{
+    The `global_reduce` op reduces the value of every work item. The result is
+    equal for all work items.
+  }];
+
+  let arguments = (ins AnyType:$value);
+  let results = (outs AnyType:$result);
+
+  let regions = (region AnyRegion:$region);
+  let assemblyFormat = "attr-dict $value `:` type($value) $region";
+}
+
+def GPUGlobalReduceYieldOp : GpuRuntime_Op<"global_reduce_yield", [
+    Pure,
+    ReturnLike,
+    Terminator,
+    HasParent<"::gpu_runtime::GPUGlobalReduceOp">
+  ]> {
+
+  let summary = "Global reduce yield and termination operation";
+  let description = [{
+    "global_reduce_yield" yields an SSA value from the "global_reduce" op region
+    and terminates it.
+  }];
+
+  let arguments = (ins AnyType:$result);
+  let builders = [OpBuilder<(ins), [{ /* nothing to do */ }]>];
+
+  let assemblyFormat = "attr-dict $result `:` type($result)";
+}
+
 #endif // GPURUNTIME_OPS

--- a/mlir/lib/Conversion/GpuToGpuRuntime.cpp
+++ b/mlir/lib/Conversion/GpuToGpuRuntime.cpp
@@ -2304,7 +2304,6 @@ struct InsertGPUGlobalReduce
                                              newReduce.getResult(), array);
 
       auto &newRegion = newReduce.getRegion();
-      //      rewriter.eraseBlock(&newRegion.front());
       rewriter.inlineRegionBefore(reduceRegion, newRegion, newRegion.end());
 
       rewriter.setInsertionPoint(term);

--- a/mlir/test/Transforms/insert-global-reduce.mlir
+++ b/mlir/test/Transforms/insert-global-reduce.mlir
@@ -1,0 +1,47 @@
+// RUN: imex-opt -allow-unregistered-dialect --gpux-insert-global-reduce --split-input-file %s | FileCheck %s
+
+
+func.func @test(%lb: index, %ub: index, %s: index) {
+  %init = "test.init"() : () -> f32
+  %0 = scf.parallel (%i, %j, %k) = (%lb, %lb, %lb) to (%ub, %ub, %ub) step (%s, %s, %s) init(%init) -> f32 {
+    %1 = "test.produce"() : () -> f32
+    scf.reduce(%1) : f32 {
+    ^bb0(%lhs: f32, %rhs: f32):
+      %2 = "test.transform"(%lhs, %rhs) : (f32, f32) -> f32
+      scf.reduce.return %2 : f32
+    }
+    scf.yield
+  } {mapping = [#gpu.loop_dim_map<processor = block_x, map = (d0) -> (d0), bound = (d0) -> (d0)>,
+                #gpu.loop_dim_map<processor = block_y, map = (d0) -> (d0), bound = (d0) -> (d0)>,
+                #gpu.loop_dim_map<processor = block_z, map = (d0) -> (d0), bound = (d0) -> (d0)>]}
+  "test.consume"(%0) : (f32) -> ()
+  return
+}
+
+
+// CHECK-LABEL: @test
+//  CHECK-SAME: (%[[LB:.*]]: index, %[[UB:.*]]: index, %[[S:.*]]: index)
+//       CHECK: %[[INIT:.*]] = "test.init"() : () -> f32
+//       CHECK: %[[ARRAY:.*]] = memref.alloc() : memref<f32>
+//       CHECK: scf.parallel (%[[ARG1:.*]], %[[ARG2:.*]], %[[ARG3:.*]]) = (%[[LB]], %[[LB]], %[[LB]]) to (%[[UB]], %[[UB]], %[[UB]]) step (%[[S]], %[[S]], %[[S]]) {
+//       CHECK: %[[COND1:.*]] = arith.cmpi eq, %[[ARG1]], %[[LB]] : index
+//       CHECK: %[[COND2:.*]] = arith.cmpi eq, %[[ARG2]], %[[LB]] : index
+//       CHECK: %[[COND3:.*]] = arith.andi %[[COND1]], %[[COND2]] : i1
+//       CHECK: %[[COND4:.*]] = arith.cmpi eq, %[[ARG3]], %[[LB]] : index
+//       CHECK: %[[COND5:.*]] = arith.andi %[[COND3]], %[[COND4]] : i1
+//       CHECK: %[[PROD:.*]] = "test.produce"() : () -> f32
+//       CHECK: %[[RED:.*]] = gpu_runtime.global_reduce %[[PROD]] : f32 {
+//       CHECK: ^bb0(%[[ARG4:.*]]: f32, %[[ARG5:.*]]: f32):
+//       CHECK: %[[VAL:.*]] = "test.transform"(%[[ARG4]], %[[ARG5]]) : (f32, f32) -> f32
+//       CHECK: gpu_runtime.global_reduce_yield %[[VAL]] : f32
+//       CHECK: }
+//       CHECK: scf.if %[[COND5]] {
+//       CHECK: memref.store %[[RED]], %[[ARRAY]][] : memref<f32>
+//       CHECK: }
+//       CHECK: scf.yield
+//       CHECK: }
+//       CHECK: %[[RES1:.*]] = memref.load %[[ARRAY]][] : memref<f32>
+//       CHECK: memref.dealloc %[[ARRAY]] : memref<f32>
+//       CHECK: %[[RES2:.*]] = "test.transform"(%[[RES1]], %[[INIT]]) : (f32, f32) -> f32
+//       CHECK: "test.consume"(%[[RES2]]) : (f32) -> ()
+//       CHECK: return

--- a/mlir/tools/imex-opt/Passes.cpp
+++ b/mlir/tools/imex-opt/Passes.cpp
@@ -161,3 +161,11 @@ static mlir::PassPipelineRegistration<> tileParallelLoopsGPU(
 static mlir::PassPipelineRegistration<> memoryOpts(
     "imex-memory-opts", "Apply memory optimizations",
     [](mlir::OpPassManager &pm) { pm.addPass(imex::createMemoryOptPass()); });
+
+static mlir::PassPipelineRegistration<> insertGPUGlobalReduce(
+    "gpux-insert-global-reduce",
+    "Update scf.parallel loops with reductions to use "
+    "gpu_runtime.global_reduce",
+    [](mlir::OpPassManager &pm) {
+      pm.addPass(gpu_runtime::createInsertGPUGlobalReducePass());
+    });


### PR DESCRIPTION
* `scf-to-gpu` pass only accepts loops without reductions
* Introduce `GPUGlobalReduceOp` which reduces values from all work items in kernel
* Add a pass which translates `scf.parallel` reductions to `GPUGlobalReduceOp`
* `GPUGlobalReduceOp` is expected to be lowered into series of group reductions, barriers and global mem accesses (will be done in follow up PRs)