### PR TITLE
Add `ShapeIntegerRangePropagationPass`

### DIFF
--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -71,6 +71,7 @@ set(SOURCES_LIST
     lib/Transforms/PromoteBoolMemref.cpp
     lib/Transforms/PromoteToParallel.cpp
     lib/Transforms/ScalarOpsConversion.cpp
+    lib/Transforms/ShapeIntegerRangePropagation.cpp
     lib/Transforms/TypeConversion.cpp
     lib/Transforms/UpliftMath.cpp
     lib/Utils.cpp
@@ -119,6 +120,7 @@ set(HEADERS_LIST
     include/imex/Transforms/PromoteToParallel.hpp
     include/imex/Transforms/RewriteWrapper.hpp
     include/imex/Transforms/ScalarOpsConversion.hpp
+    include/imex/Transforms/ShapeIntegerRangePropagation.hpp
     include/imex/Transforms/TypeConversion.hpp
     include/imex/Transforms/UpliftMath.hpp
     include/imex/Utils.hpp

--- a/mlir/include/imex/Dialect/imex_util/Dialect.hpp
+++ b/mlir/include/imex/Dialect/imex_util/Dialect.hpp
@@ -35,6 +35,7 @@ llvm::StringRef getParallelName();
 llvm::StringRef getMaxConcurrencyName();
 llvm::StringRef getForceInlineName();
 llvm::StringRef getOptLevelName();
+llvm::StringRef getShapeRangeName();
 } // namespace attributes
 } // namespace util
 } // namespace imex

--- a/mlir/include/imex/Dialect/imex_util/ImexUtilOps.td
+++ b/mlir/include/imex/Dialect/imex_util/ImexUtilOps.td
@@ -21,6 +21,7 @@ def ImexUtil_Dialect : Dialect {
 
   let hasCanonicalizer = 1;
   let hasConstantMaterializer = 1;
+  let useDefaultAttributePrinterParser = 1;
   let useDefaultTypePrinterParser = 1;
 }
 
@@ -30,10 +31,17 @@ class ImexUtil_Type<string name, string typeMnemonic, list<Trait> traits = [],
   let mnemonic = typeMnemonic;
 }
 
+class ImexUtil_Attr<string attrName, string attrMnemonic, list<Trait> traits = []>
+    : AttrDef<ImexUtil_Dialect, attrName, traits> {
+  let mnemonic = attrMnemonic;
+}
+
+class ImexUtil_Op<string mnemonic, list<Trait> traits = []>
+    : Op<ImexUtil_Dialect, mnemonic, traits>;
+
 def ImexUtil_OpaqueType : ImexUtil_Type<"Opaque", "opaque", [], "::mlir::Type">;
 
 def ImexUtil_TypeVar : ImexUtil_Type<"TypeVar", "typevar", [], "::mlir::Type"> {
-
   let parameters = (ins
     "::mlir::Type":$type
   );
@@ -47,8 +55,14 @@ def ImexUtil_TypeVar : ImexUtil_Type<"TypeVar", "typevar", [], "::mlir::Type"> {
   let assemblyFormat = "`<` $type `>`";
 }
 
-class ImexUtil_Op<string mnemonic, list<Trait> traits = []>
-    : Op<ImexUtil_Dialect, mnemonic, traits>;
+def IndexRangeAttr
+    : ImexUtil_Attr<"IndexRange", "index_range"> {
+  let parameters = (ins
+    "int64_t":$min,
+    "int64_t":$max
+    );
+  let assemblyFormat = "`<` `[` $min `,` $max `]` `>`";
+}
 
 def EnforceShapeOp : ImexUtil_Op<"enforce_shape"> {
 

--- a/mlir/include/imex/Transforms/ShapeIntegerRangePropagation.hpp
+++ b/mlir/include/imex/Transforms/ShapeIntegerRangePropagation.hpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2022 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <memory>
+
+namespace mlir {
+class Pass;
+}
+
+namespace imex {
+/// Propagate integer range info through the IR and optimize ops based on this
+/// info.
+std::unique_ptr<mlir::Pass> createShapeIntegerRangePropagationPass();
+} // namespace imex

--- a/mlir/lib/Dialect/imex_util/Dialect.cpp
+++ b/mlir/lib/Dialect/imex_util/Dialect.cpp
@@ -39,27 +39,31 @@ struct ImexUtilInlinerInterface : public mlir::DialectInlinerInterface {
 } // namespace
 
 llvm::StringRef imex::util::attributes::getFastmathName() {
-  return "#plier.fastmath";
+  return "imex.fastmath";
 }
 
 llvm::StringRef imex::util::attributes::getJumpMarkersName() {
-  return "#plier.pipeline_jump_markers";
+  return "imex.pipeline_jump_markers";
 }
 
 llvm::StringRef imex::util::attributes::getParallelName() {
-  return "#plier.parallel";
+  return "imex.parallel";
 }
 
 llvm::StringRef imex::util::attributes::getMaxConcurrencyName() {
-  return "#plier.max_concurrency";
+  return "imex.max_concurrency";
 }
 
 llvm::StringRef imex::util::attributes::getForceInlineName() {
-  return "#plier.force_inline";
+  return "imex.force_inline";
 }
 
 llvm::StringRef imex::util::attributes::getOptLevelName() {
-  return "#plier.opt_level";
+  return "imex.opt_level";
+}
+
+llvm::StringRef imex::util::attributes::getShapeRangeName() {
+  return "imex.shape_range";
 }
 
 namespace imex {

--- a/mlir/lib/Transforms/ShapeIntegerRangePropagation.cpp
+++ b/mlir/lib/Transforms/ShapeIntegerRangePropagation.cpp
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: 2022 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "imex/Transforms/ShapeIntegerRangePropagation.hpp"
+
+#include <mlir/Analysis/DataFlow/DeadCodeAnalysis.h>
+#include <mlir/Analysis/DataFlow/IntegerRangeAnalysis.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/IR/PatternMatch.h>
+#include <mlir/Interfaces/ShapedOpInterfaces.h>
+#include <mlir/Pass/Pass.h>
+#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
+
+namespace {
+static auto getIndexRange(int64_t umin, int64_t umax) {
+  unsigned width = mlir::IndexType::kInternalStorageBitWidth;
+  return mlir::ConstantIntRanges::fromSigned(llvm::APInt(width, umin),
+                                             llvm::APInt(width, umax));
+}
+
+class IntegerRangeAnalysisEx : public mlir::dataflow::IntegerRangeAnalysis {
+public:
+  using IntegerRangeAnalysis::IntegerRangeAnalysis;
+
+  void visitOperation(
+      mlir::Operation *op,
+      llvm::ArrayRef<const mlir::dataflow::IntegerValueRangeLattice *> operands,
+      llvm::ArrayRef<mlir::dataflow::IntegerValueRangeLattice *> results)
+      override {
+    if (auto dim = mlir::dyn_cast<mlir::ShapedDimOpInterface>(op)) {
+      assert(op->getNumResults() == 1);
+      assert(results.size() == 1);
+
+      auto *lattice = results.front();
+      auto oldRange = lattice->getValue();
+      auto newRange = getIndexRange(0, std::numeric_limits<int64_t>::max());
+      auto changed = lattice->join(mlir::dataflow::IntegerValueRange{newRange});
+      propagateIfChanged(lattice, changed);
+      return;
+    }
+
+    mlir::dataflow::IntegerRangeAnalysis::visitOperation(op, operands, results);
+  }
+};
+
+static bool intersects(mlir::ConstantIntRanges lhs,
+                       mlir::ConstantIntRanges rhs) {
+  if ((lhs.smax().sle(rhs.smin()) || lhs.smin().sge(rhs.smax())) &&
+      (lhs.umax().ule(rhs.umin()) || lhs.umin().uge(rhs.umax())))
+    return false;
+
+  return true;
+}
+
+static llvm::Optional<bool> handleEq(mlir::ConstantIntRanges lhs,
+                                     mlir::ConstantIntRanges rhs) {
+  if (!intersects(lhs, rhs))
+    return false;
+
+  return llvm::None;
+}
+
+static llvm::Optional<bool> handleNe(mlir::ConstantIntRanges lhs,
+                                     mlir::ConstantIntRanges rhs) {
+  if (!intersects(lhs, rhs))
+    return true;
+
+  return llvm::None;
+}
+
+static llvm::Optional<bool> handleSlt(mlir::ConstantIntRanges lhs,
+                                      mlir::ConstantIntRanges rhs) {
+  if (lhs.smax().slt(rhs.smin()))
+    return true;
+
+  if (lhs.smin().sge(rhs.smax()))
+    return false;
+
+  return llvm::None;
+}
+
+static llvm::Optional<bool> handleSle(mlir::ConstantIntRanges lhs,
+                                      mlir::ConstantIntRanges rhs) {
+  if (lhs.smax().sle(rhs.smin()))
+    return true;
+
+  if (lhs.smin().sgt(rhs.smax()))
+    return false;
+
+  return llvm::None;
+}
+
+static llvm::Optional<bool> handleSgt(mlir::ConstantIntRanges lhs,
+                                      mlir::ConstantIntRanges rhs) {
+  return handleSlt(rhs, lhs);
+}
+
+static llvm::Optional<bool> handleSge(mlir::ConstantIntRanges lhs,
+                                      mlir::ConstantIntRanges rhs) {
+  return handleSle(rhs, lhs);
+}
+
+static llvm::Optional<bool> handleUlt(mlir::ConstantIntRanges lhs,
+                                      mlir::ConstantIntRanges rhs) {
+  if (lhs.umax().ult(rhs.umin()))
+    return true;
+
+  if (lhs.umin().uge(rhs.umax()))
+    return false;
+
+  return llvm::None;
+}
+
+static llvm::Optional<bool> handleUle(mlir::ConstantIntRanges lhs,
+                                      mlir::ConstantIntRanges rhs) {
+  if (lhs.umax().ule(rhs.umin()))
+    return true;
+
+  if (lhs.umin().ugt(rhs.umax()))
+    return false;
+
+  return llvm::None;
+}
+
+static llvm::Optional<bool> handleUgt(mlir::ConstantIntRanges lhs,
+                                      mlir::ConstantIntRanges rhs) {
+  return handleUlt(rhs, lhs);
+}
+
+static llvm::Optional<bool> handleUge(mlir::ConstantIntRanges lhs,
+                                      mlir::ConstantIntRanges rhs) {
+  return handleUle(rhs, lhs);
+}
+
+struct ConvertCmpOp : public mlir::OpRewritePattern<mlir::arith::CmpIOp> {
+
+  ConvertCmpOp(mlir::MLIRContext *context, mlir::DataFlowSolver &s)
+      : mlir::OpRewritePattern<mlir::arith::CmpIOp>(context), solver(s) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::arith::CmpIOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto *lhsResult =
+        solver.lookupState<mlir::dataflow::IntegerValueRangeLattice>(
+            op.getLhs());
+    if (!lhsResult || lhsResult->getValue().isUninitialized())
+      return mlir::failure();
+
+    auto *rhsResult =
+        solver.lookupState<mlir::dataflow::IntegerValueRangeLattice>(
+            op.getRhs());
+    if (!lhsResult || rhsResult->getValue().isUninitialized())
+      return mlir::failure();
+
+    using HandlerFunc = llvm::Optional<bool> (*)(mlir::ConstantIntRanges,
+                                                 mlir::ConstantIntRanges);
+    std::array<HandlerFunc, mlir::arith::getMaxEnumValForCmpIPredicate() + 1>
+        handlers{};
+    using Pred = mlir::arith::CmpIPredicate;
+    handlers[static_cast<size_t>(Pred::eq)] = &handleEq;
+    handlers[static_cast<size_t>(Pred::ne)] = &handleNe;
+    handlers[static_cast<size_t>(Pred::slt)] = &handleSlt;
+    handlers[static_cast<size_t>(Pred::sle)] = &handleSle;
+    handlers[static_cast<size_t>(Pred::sgt)] = &handleSgt;
+    handlers[static_cast<size_t>(Pred::sge)] = &handleSge;
+    handlers[static_cast<size_t>(Pred::ult)] = &handleUlt;
+    handlers[static_cast<size_t>(Pred::ule)] = &handleUle;
+    handlers[static_cast<size_t>(Pred::ugt)] = &handleUgt;
+    handlers[static_cast<size_t>(Pred::uge)] = &handleUge;
+
+    auto handler = handlers[static_cast<size_t>(op.getPredicate())];
+    if (!handler)
+      return mlir::failure();
+
+    auto result = handler(lhsResult->getValue().getValue(),
+                          rhsResult->getValue().getValue());
+    if (!result)
+      return mlir::failure();
+
+    rewriter.replaceOpWithNewOp<mlir::arith::ConstantIntOp>(
+        op, static_cast<int64_t>(*result), /*width*/ 1);
+    return mlir::success();
+  }
+
+private:
+  mlir::DataFlowSolver &solver;
+};
+
+struct ShapeIntegerRangePropagationPass
+    : public mlir::PassWrapper<ShapeIntegerRangePropagationPass,
+                               mlir::OperationPass<void>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ShapeIntegerRangePropagationPass)
+
+  virtual void
+  getDependentDialects(mlir::DialectRegistry &registry) const override {
+    registry.insert<mlir::arith::ArithDialect>();
+  }
+
+  void runOnOperation() override {
+    auto op = getOperation();
+    mlir::DataFlowSolver solver;
+    solver.load<mlir::dataflow::DeadCodeAnalysis>();
+    solver.load<IntegerRangeAnalysisEx>();
+    if (failed(solver.initializeAndRun(op)))
+      return signalPassFailure();
+
+    auto *ctx = &getContext();
+    mlir::RewritePatternSet patterns(ctx);
+
+    patterns.add<ConvertCmpOp>(ctx, solver);
+
+    (void)mlir::applyPatternsAndFoldGreedily(op, std::move(patterns));
+  }
+};
+} // namespace
+
+std::unique_ptr<mlir::Pass> imex::createShapeIntegerRangePropagationPass() {
+  return std::make_unique<ShapeIntegerRangePropagationPass>();
+}

--- a/mlir/test/Transforms/shape-int-range-opts.mlir
+++ b/mlir/test/Transforms/shape-int-range-opts.mlir
@@ -1,0 +1,77 @@
+// RUN: imex-opt --imex-shape-int-range-opts --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: func @test
+//       CHECK:   %[[C:.*]] = arith.constant false
+//       CHECK:   return %[[C]]
+func.func @test(%arg1: tensor<?xf32>) -> i1 {
+  %cst = arith.constant 0 : index
+  %cst1 = arith.constant -1 : index
+  %0 = tensor.dim %arg1, %cst : tensor<?xf32>
+  %1 = arith.cmpi eq, %0, %cst1 : index
+  return %1: i1
+}
+
+// -----
+
+// CHECK-LABEL: func @test
+//       CHECK:   %[[C:.*]] = arith.constant true
+//       CHECK:   return %[[C]]
+func.func @test(%arg1: tensor<?xf32>) -> i1 {
+  %cst = arith.constant 0 : index
+  %cst1 = arith.constant -1 : index
+  %0 = tensor.dim %arg1, %cst : tensor<?xf32>
+  %1 = arith.cmpi ne, %0, %cst1 : index
+  return %1: i1
+}
+
+// -----
+
+
+// CHECK-LABEL: func @test
+//       CHECK:   %[[C:.*]] = arith.constant true
+//       CHECK:   return %[[C]]
+func.func @test(%arg1: tensor<?xf32>) -> i1 {
+  %cst = arith.constant 0 : index
+  %0 = tensor.dim %arg1, %cst : tensor<?xf32>
+  %1 = arith.cmpi sge, %0, %cst : index
+  return %1: i1
+}
+
+// -----
+
+// CHECK-LABEL: func @test
+//       CHECK:   %[[C:.*]] = arith.constant false
+//       CHECK:   return %[[C]]
+func.func @test(%arg1: tensor<?xf32>) -> i1 {
+  %cst = arith.constant 0 : index
+  %0 = tensor.dim %arg1, %cst : tensor<?xf32>
+  %1 = arith.cmpi slt, %0, %cst : index
+  return %1: i1
+}
+
+// -----
+
+
+// CHECK-LABEL: func @test
+//       CHECK:   %[[C:.*]] = arith.constant true
+//       CHECK:   return %[[C]]
+func.func @test(%arg1: tensor<?xf32>) -> i1 {
+  %cst = arith.constant 0 : index
+  %cst1 = arith.constant -1 : index
+  %0 = tensor.dim %arg1, %cst : tensor<?xf32>
+  %1 = arith.cmpi sgt, %0, %cst1 : index
+  return %1: i1
+}
+
+// -----
+
+// CHECK-LABEL: func @test
+//       CHECK:   %[[C:.*]] = arith.constant false
+//       CHECK:   return %[[C]]
+func.func @test(%arg1: tensor<?xf32>) -> i1 {
+  %cst = arith.constant 0 : index
+  %cst1 = arith.constant -1 : index
+  %0 = tensor.dim %arg1, %cst : tensor<?xf32>
+  %1 = arith.cmpi sle, %0, %cst1 : index
+  return %1: i1
+}

--- a/mlir/test/Transforms/shape-int-range-opts.mlir
+++ b/mlir/test/Transforms/shape-int-range-opts.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: func @test
 //       CHECK:   %[[C:.*]] = arith.constant false
 //       CHECK:   return %[[C]]
-func.func @test(%arg1: tensor<?xf32>) -> i1 {
+func.func @test(%arg1: tensor<?xf32> {imex.shape_range = [#imex_util.index_range<[0,10]>]}) -> i1 {
   %cst = arith.constant 0 : index
   %cst1 = arith.constant -1 : index
   %0 = tensor.dim %arg1, %cst : tensor<?xf32>
@@ -16,7 +16,7 @@ func.func @test(%arg1: tensor<?xf32>) -> i1 {
 // CHECK-LABEL: func @test
 //       CHECK:   %[[C:.*]] = arith.constant true
 //       CHECK:   return %[[C]]
-func.func @test(%arg1: tensor<?xf32>) -> i1 {
+func.func @test(%arg1: tensor<?xf32> {imex.shape_range = [#imex_util.index_range<[0,10]>]}) -> i1 {
   %cst = arith.constant 0 : index
   %cst1 = arith.constant -1 : index
   %0 = tensor.dim %arg1, %cst : tensor<?xf32>
@@ -30,7 +30,7 @@ func.func @test(%arg1: tensor<?xf32>) -> i1 {
 // CHECK-LABEL: func @test
 //       CHECK:   %[[C:.*]] = arith.constant true
 //       CHECK:   return %[[C]]
-func.func @test(%arg1: tensor<?xf32>) -> i1 {
+func.func @test(%arg1: tensor<?xf32> {imex.shape_range = [#imex_util.index_range<[0,10]>]}) -> i1 {
   %cst = arith.constant 0 : index
   %0 = tensor.dim %arg1, %cst : tensor<?xf32>
   %1 = arith.cmpi sge, %0, %cst : index
@@ -42,7 +42,7 @@ func.func @test(%arg1: tensor<?xf32>) -> i1 {
 // CHECK-LABEL: func @test
 //       CHECK:   %[[C:.*]] = arith.constant false
 //       CHECK:   return %[[C]]
-func.func @test(%arg1: tensor<?xf32>) -> i1 {
+func.func @test(%arg1: tensor<?xf32> {imex.shape_range = [#imex_util.index_range<[0,10]>]}) -> i1 {
   %cst = arith.constant 0 : index
   %0 = tensor.dim %arg1, %cst : tensor<?xf32>
   %1 = arith.cmpi slt, %0, %cst : index
@@ -55,7 +55,7 @@ func.func @test(%arg1: tensor<?xf32>) -> i1 {
 // CHECK-LABEL: func @test
 //       CHECK:   %[[C:.*]] = arith.constant true
 //       CHECK:   return %[[C]]
-func.func @test(%arg1: tensor<?xf32>) -> i1 {
+func.func @test(%arg1: tensor<?xf32> {imex.shape_range = [#imex_util.index_range<[0,10]>]}) -> i1 {
   %cst = arith.constant 0 : index
   %cst1 = arith.constant -1 : index
   %0 = tensor.dim %arg1, %cst : tensor<?xf32>
@@ -68,10 +68,37 @@ func.func @test(%arg1: tensor<?xf32>) -> i1 {
 // CHECK-LABEL: func @test
 //       CHECK:   %[[C:.*]] = arith.constant false
 //       CHECK:   return %[[C]]
-func.func @test(%arg1: tensor<?xf32>) -> i1 {
+func.func @test(%arg1: tensor<?xf32> {imex.shape_range = [#imex_util.index_range<[0,10]>]}) -> i1 {
   %cst = arith.constant 0 : index
   %cst1 = arith.constant -1 : index
   %0 = tensor.dim %arg1, %cst : tensor<?xf32>
   %1 = arith.cmpi sle, %0, %cst1 : index
   return %1: i1
+}
+
+// -----
+
+// CHECK-LABEL: func @test
+//       CHECK:   %[[C:.*]] = arith.constant false
+//       CHECK:   return %[[C]]
+func.func @test(%arg1: tensor<?xf32> {imex.shape_range = [#imex_util.index_range<[1,10]>]}) -> i1 {
+  %cst = arith.constant 0 : index
+  %0 = tensor.dim %arg1, %cst : tensor<?xf32>
+  %1 = arith.cmpi eq, %0, %cst : index
+  return %1: i1
+}
+
+// -----
+
+// CHECK-LABEL: func @test
+//       CHECK:   %[[C:.*]] = arith.constant false
+//       CHECK:   return %[[C]]
+func.func @test(%arg1: tensor<?xf32> {imex.shape_range = [#imex_util.index_range<[1,7]>]},
+                %arg2: tensor<?xf32> {imex.shape_range = [#imex_util.index_range<[2,10]>]},
+                %cond: i1) -> i1 {
+  %cst = arith.constant 0 : index
+  %0 = arith.select %cond, %arg1, %arg2 : tensor<?xf32>
+  %1 = tensor.dim %0, %cst : tensor<?xf32>
+  %2 = arith.cmpi eq, %1, %cst : index
+  return %2: i1
 }

--- a/mlir/test/Transforms/shape-int-range-opts.mlir
+++ b/mlir/test/Transforms/shape-int-range-opts.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: func @test
 //       CHECK:   %[[C:.*]] = arith.constant false
 //       CHECK:   return %[[C]]
-func.func @test(%arg1: tensor<?xf32> {imex.shape_range = [#imex_util.index_range<[0,10]>]}) -> i1 {
+func.func @test(%arg1: tensor<?xf32>) -> i1 {
   %cst = arith.constant 0 : index
   %cst1 = arith.constant -1 : index
   %0 = tensor.dim %arg1, %cst : tensor<?xf32>
@@ -16,7 +16,7 @@ func.func @test(%arg1: tensor<?xf32> {imex.shape_range = [#imex_util.index_range
 // CHECK-LABEL: func @test
 //       CHECK:   %[[C:.*]] = arith.constant true
 //       CHECK:   return %[[C]]
-func.func @test(%arg1: tensor<?xf32> {imex.shape_range = [#imex_util.index_range<[0,10]>]}) -> i1 {
+func.func @test(%arg1: tensor<?xf32>) -> i1 {
   %cst = arith.constant 0 : index
   %cst1 = arith.constant -1 : index
   %0 = tensor.dim %arg1, %cst : tensor<?xf32>
@@ -30,7 +30,7 @@ func.func @test(%arg1: tensor<?xf32> {imex.shape_range = [#imex_util.index_range
 // CHECK-LABEL: func @test
 //       CHECK:   %[[C:.*]] = arith.constant true
 //       CHECK:   return %[[C]]
-func.func @test(%arg1: tensor<?xf32> {imex.shape_range = [#imex_util.index_range<[0,10]>]}) -> i1 {
+func.func @test(%arg1: tensor<?xf32>) -> i1 {
   %cst = arith.constant 0 : index
   %0 = tensor.dim %arg1, %cst : tensor<?xf32>
   %1 = arith.cmpi sge, %0, %cst : index
@@ -42,7 +42,7 @@ func.func @test(%arg1: tensor<?xf32> {imex.shape_range = [#imex_util.index_range
 // CHECK-LABEL: func @test
 //       CHECK:   %[[C:.*]] = arith.constant false
 //       CHECK:   return %[[C]]
-func.func @test(%arg1: tensor<?xf32> {imex.shape_range = [#imex_util.index_range<[0,10]>]}) -> i1 {
+func.func @test(%arg1: tensor<?xf32>) -> i1 {
   %cst = arith.constant 0 : index
   %0 = tensor.dim %arg1, %cst : tensor<?xf32>
   %1 = arith.cmpi slt, %0, %cst : index
@@ -55,7 +55,7 @@ func.func @test(%arg1: tensor<?xf32> {imex.shape_range = [#imex_util.index_range
 // CHECK-LABEL: func @test
 //       CHECK:   %[[C:.*]] = arith.constant true
 //       CHECK:   return %[[C]]
-func.func @test(%arg1: tensor<?xf32> {imex.shape_range = [#imex_util.index_range<[0,10]>]}) -> i1 {
+func.func @test(%arg1: tensor<?xf32>) -> i1 {
   %cst = arith.constant 0 : index
   %cst1 = arith.constant -1 : index
   %0 = tensor.dim %arg1, %cst : tensor<?xf32>
@@ -68,7 +68,7 @@ func.func @test(%arg1: tensor<?xf32> {imex.shape_range = [#imex_util.index_range
 // CHECK-LABEL: func @test
 //       CHECK:   %[[C:.*]] = arith.constant false
 //       CHECK:   return %[[C]]
-func.func @test(%arg1: tensor<?xf32> {imex.shape_range = [#imex_util.index_range<[0,10]>]}) -> i1 {
+func.func @test(%arg1: tensor<?xf32>) -> i1 {
   %cst = arith.constant 0 : index
   %cst1 = arith.constant -1 : index
   %0 = tensor.dim %arg1, %cst : tensor<?xf32>

--- a/mlir/tools/imex-opt/Passes.cpp
+++ b/mlir/tools/imex-opt/Passes.cpp
@@ -24,6 +24,7 @@
 #include "imex/Transforms/ExpandTuple.hpp"
 #include "imex/Transforms/MakeSignless.hpp"
 #include "imex/Transforms/MemoryRewrites.hpp"
+#include "imex/Transforms/ShapeIntegerRangePropagation.hpp"
 
 // Passes registration.
 
@@ -168,4 +169,10 @@ static mlir::PassPipelineRegistration<> insertGPUGlobalReduce(
     "gpu_runtime.global_reduce",
     [](mlir::OpPassManager &pm) {
       pm.addPass(gpu_runtime::createInsertGPUGlobalReducePass());
+    });
+
+static mlir::PassPipelineRegistration<> shapeIntegerRangePropagation(
+    "imex-shape-int-range-opts", "Shape integer range optimizations",
+    [](mlir::OpPassManager &pm) {
+      pm.addPass(imex::createShapeIntegerRangePropagationPass());
     });


### PR DESCRIPTION
* Upstream already has `IntegerRangeAnalysis` analysis and related passes to propagate and optimize IR based on integer ranges
* Add analysis which extends it for the shape values
* Add an optimization for `arith.cmpi` based on this integer ranges analysis (TODO: upstream)
* Default range for dynamic shape dimensions is assumed to be `[0, INT64_MAX]` unless you specified it explicitly via `imex.shape_range` attribute
* This is needed for better broadcast optimizations during ntensor->linalg conversion
* Integration with actual compiler pipeline will be done in separate PR