### PR TITLE
Deformable conv hotfix

### DIFF
--- a/mlir/include/imex/Dialect/imex_util/ImexUtilOps.td
+++ b/mlir/include/imex/Dialect/imex_util/ImexUtilOps.td
@@ -289,6 +289,26 @@ def EnvironmentRegionYieldOp : ImexUtil_Op<"env_region_yield", [
   let assemblyFormat = "attr-dict ($results^ `:` type($results))?";
 }
 
+def MemrefApplyOffsetOp : ImexUtil_Op<"memref_apply_offset", [
+    Pure, ViewLikeOpInterface
+  ]> {
+
+  let summary = "Applies memref offset to the underlying data pointer";
+  let description = [{
+    "memref_apply_offset" applies memref offset to the underlying data pointer.
+    Returned memref will always have dynamic offset of 0.
+  }];
+
+  let arguments = (ins AnyMemRef:$source);
+  let results = (outs AnyMemRef:$result);
+
+  let extraClassDeclaration = [{
+      ::mlir::Value getViewSource() { return getSource(); }
+  }];
+
+  let assemblyFormat = "$source attr-dict `:` type($source) `to` type($result)";
+}
+
 // TODO: Upstream arith.bitcast doesnt suuport casting between vectors and
 // non-vectors
 def BitcastOp : ImexUtil_Op<"bitcast", [Pure]> {

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -273,7 +273,8 @@ struct ReshapeChangeLayout
       int64_t size = dstType.getShape()[i];
       if (size == 0)
         continue;
-      bool useSizeAsStride = stride == 1;
+
+      bool useSizeAsStride = (stride == 1);
       if (size == mlir::ShapedType::kDynamicSize)
         stride = mlir::ShapedType::kDynamicSize;
       if (stride != mlir::ShapedType::kDynamicSize)
@@ -307,10 +308,10 @@ struct ReshapeChangeLayout
       auto actualStride =
           rewriter.createOrFold<imex::util::ExtractMemrefMetadataOp>(loc, src,
                                                                      i);
-      auto strideVal =
-          rewriter.create<mlir::arith::ConstantIndexOp>(loc, strides[i]);
+
       auto cmpTemp = rewriter.createOrFold<mlir::arith::CmpIOp>(
-          loc, mlir::arith::CmpIPredicate::eq, strideVal, actualStride);
+          loc, mlir::arith::CmpIPredicate::eq, expectedStrides[i],
+          actualStride);
       cmp = rewriter.createOrFold<mlir::arith::AndIOp>(loc, cmp, cmpTemp);
     }
 

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -245,7 +245,10 @@ struct ReshapeChangeLayout
       return mlir::failure();
 
     auto src = cl.getSource();
+    auto srcType = src.getType().cast<mlir::MemRefType>();
     auto dstType = op.getSource().getType().cast<mlir::MemRefType>();
+    if (srcType.getRank() != dstType.getRank())
+      return mlir::failure();
 
     auto rank = static_cast<unsigned>(dstType.getRank());
     if (rank == 0)


### PR DESCRIPTION
* Better handle cases where `numpy.reshape` can be handled as view vs copy