### PR TITLE
fix GPUToSPIRV unit tests

### DIFF
--- a/test/Conversion/GPUToSPIRV/lit.local.cfg
+++ b/test/Conversion/GPUToSPIRV/lit.local.cfg
@@ -1,6 +1,3 @@
 
-local_excludes = [
-                  'scf.mlir',
-                  'loadstore.mlir',
-                 ]
+local_excludes = []
 config.excludes.update(local_excludes)

--- a/test/Conversion/GPUToSPIRV/loadstore.mlir
+++ b/test/Conversion/GPUToSPIRV/loadstore.mlir
@@ -2,90 +2,63 @@
 
 module attributes {
   gpu.container_module,
-  spirv.target_env = #spirv.target_env<
-    #spirv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]>, #spirv.resource_limits<>>
+  spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume]>, #spirv.resource_limits<>>
 } {
-  func.func @load_store(%arg0: memref<12x4xf32, #spirv.storage_class<StorageBuffer>>, %arg1: memref<12x4xf32, #spirv.storage_class<StorageBuffer>>, %arg2: memref<12x4xf32, #spirv.storage_class<StorageBuffer>>) {
-    %c0 = arith.constant 0 : index
-    %c12 = arith.constant 12 : index
-    %0 = arith.subi %c12, %c0 : index
+  func.func @load_store(%arg0: memref<2x5xf32>, %arg1: memref<2x5xf32>, %arg2: memref<2x5xf32>) {
+    %c5 = arith.constant 5 : index
+    %c2 = arith.constant 2 : index
     %c1 = arith.constant 1 : index
-    %c0_0 = arith.constant 0 : index
-    %c4 = arith.constant 4 : index
-    %1 = arith.subi %c4, %c0_0 : index
-    %c1_1 = arith.constant 1 : index
-    %c1_2 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
 
     gpu.launch_func @kernels::@load_store_kernel
-        blocks in (%0, %c1_2, %c1_2) threads in (%1, %c1_2, %c1_2)
-        args(%arg0 : memref<12x4xf32, #spirv.storage_class<StorageBuffer>>, %arg1 : memref<12x4xf32, #spirv.storage_class<StorageBuffer>>, %arg2 : memref<12x4xf32, #spirv.storage_class<StorageBuffer>>,
-             %c0 : index, %c0_0 : index, %c1 : index, %c1_1 : index)
+        blocks in (%c2, %c5, %c1) threads in (%c1, %c1, %c1)
+        args(%arg0: memref<2x5xf32>, %arg1: memref<2x5xf32>, %arg2: memref<2x5xf32>,
+             %c0 : index, %c0 : index, %c1 : index, %c1 : index)
     return
   }
 
-  // CHECK-LABEL: spirv.module @{{.*}} Logical GLSL450
+  // CHECK-LABEL: spirv.module @{{.*}} Physical64 OpenCL
   gpu.module @kernels {
-    // CHECK-DAG: spirv.GlobalVariable @[[NUMWORKGROUPSVAR:.*]] built_in("NumWorkgroups") : !spirv.ptr<vector<3xi32>, Input>
-    // CHECK-DAG: spirv.GlobalVariable @[[$LOCALINVOCATIONIDVAR:.*]] built_in("LocalInvocationId") : !spirv.ptr<vector<3xi32>, Input>
-    // CHECK-DAG: spirv.GlobalVariable @[[$WORKGROUPIDVAR:.*]] built_in("WorkgroupId") : !spirv.ptr<vector<3xi32>, Input>
-    // CHECK-LABEL:    spirv.func @load_store_kernel
-    // CHECK-SAME: %[[ARG0:.*]]: !spirv.ptr<!spirv.struct<(!spirv.array<48 x f32, stride=4> [0])>, StorageBuffer> {spirv.interface_var_abi = #spirv.interface_var_abi<(0, 0)>}
-    // CHECK-SAME: %[[ARG1:.*]]: !spirv.ptr<!spirv.struct<(!spirv.array<48 x f32, stride=4> [0])>, StorageBuffer> {spirv.interface_var_abi = #spirv.interface_var_abi<(0, 1)>}
-    // CHECK-SAME: %[[ARG2:.*]]: !spirv.ptr<!spirv.struct<(!spirv.array<48 x f32, stride=4> [0])>, StorageBuffer> {spirv.interface_var_abi = #spirv.interface_var_abi<(0, 2)>}
-    // CHECK-SAME: %[[ARG3:.*]]: i32 {spirv.interface_var_abi = #spirv.interface_var_abi<(0, 3), StorageBuffer>}
-    // CHECK-SAME: %[[ARG4:.*]]: i32 {spirv.interface_var_abi = #spirv.interface_var_abi<(0, 4), StorageBuffer>}
-    // CHECK-SAME: %[[ARG5:.*]]: i32 {spirv.interface_var_abi = #spirv.interface_var_abi<(0, 5), StorageBuffer>}
-    // CHECK-SAME: %[[ARG6:.*]]: i32 {spirv.interface_var_abi = #spirv.interface_var_abi<(0, 6), StorageBuffer>}
-    // CHECK: spirv.Branch ^bb1
-    // CHECK: ^bb1:  // pred: ^bb0
-    gpu.func @load_store_kernel(%arg0: memref<12x4xf32, #spirv.storage_class<StorageBuffer>>, %arg1: memref<12x4xf32, #spirv.storage_class<StorageBuffer>>, %arg2: memref<12x4xf32, #spirv.storage_class<StorageBuffer>>, %arg3: index, %arg4: index, %arg5: index, %arg6: index) kernel
-      attributes {spirv.entry_point_abi = #spirv.entry_point_abi<local_size = dense<[16, 1, 1]>: vector<3xi32>>} {
+    // CHECK-DAG: spirv.GlobalVariable @[[$LOCALINVOCATIONIDVAR:.*]] built_in("LocalInvocationId") : !spirv.ptr<vector<3xi64>, Input>
+    // CHECK-DAG:spirv.GlobalVariable @[[$WORKGROUPIDVAR:.*]] built_in("WorkgroupId") : !spirv.ptr<vector<3xi64>, Input>
+    // CHECK-LABEL:    spirv.func @load_store_kernel(
+    // CHECK-SAME: %[[ARG0:.*]]: !spirv.ptr<!spirv.array<10 x f32>, CrossWorkgroup>{{.*}}, %[[ARG1:.*]]: !spirv.ptr<!spirv.array<10 x f32>, CrossWorkgroup>{{.*}}, %[[ARG2:.*]]: !spirv.ptr<!spirv.array<10 x f32>, CrossWorkgroup>,
+    // CHECK-SAME: %[[ARG3:.*]]: i64, %[[ARG4:.*]]: i64, %[[ARG5:.*]]: i64, %[[ARG6:.*]]: i64
+    gpu.func @load_store_kernel(%arg0: memref<2x5xf32>, %arg1: memref<2x5xf32>, %arg2: memref<2x5xf32>, %arg3: index, %arg4: index, %arg5: index, %arg6: index) kernel
+      attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
       // CHECK: %[[ADDRESSWORKGROUPID:.*]] = spirv.mlir.addressof @[[$WORKGROUPIDVAR]]
       // CHECK: %[[WORKGROUPID:.*]] = spirv.Load "Input" %[[ADDRESSWORKGROUPID]]
       // CHECK: %[[WORKGROUPIDX:.*]] = spirv.CompositeExtract %[[WORKGROUPID]]{{\[}}0 : i32{{\]}}
       // CHECK: %[[ADDRESSLOCALINVOCATIONID:.*]] = spirv.mlir.addressof @[[$LOCALINVOCATIONIDVAR]]
       // CHECK: %[[LOCALINVOCATIONID:.*]] = spirv.Load "Input" %[[ADDRESSLOCALINVOCATIONID]]
       // CHECK: %[[LOCALINVOCATIONIDX:.*]] = spirv.CompositeExtract %[[LOCALINVOCATIONID]]{{\[}}0 : i32{{\]}}
-      cf.br ^bb1
-    ^bb1:  // pred: ^bb0
       %0 = gpu.block_id x
       %1 = gpu.block_id y
-      %2 = gpu.block_id z
-      %3 = gpu.thread_id x
-      %4 = gpu.thread_id y
-      %5 = gpu.thread_id z
-      %6 = gpu.grid_dim x
-      %7 = gpu.grid_dim y
-      %8 = gpu.grid_dim z
-      %9 = gpu.block_dim x
-      %10 = gpu.block_dim y
-      %11 = gpu.block_dim z
-      // CHECK: %[[INDEX1:.*]] = spirv.IAdd %[[ARG3]], %[[WORKGROUPIDX]]
+      %2 = gpu.thread_id x
+            // CHECK: %[[INDEX1:.*]] = spirv.IAdd %[[ARG3]], %[[WORKGROUPIDX]]
+
       %12 = arith.addi %arg3, %0 : index
       // CHECK: %[[INDEX2:.*]] = spirv.IAdd %[[ARG4]], %[[LOCALINVOCATIONIDX]]
-      %13 = arith.addi %arg4, %3 : index
-      // CHECK: %[[ZERO:.*]] = spirv.Constant 0 : i32
-      // CHECK: %[[OFFSET1_0:.*]] = spirv.Constant 0 : i32
-      // CHECK: %[[STRIDE1_1:.*]] = spirv.Constant 4 : i32
-      // CHECK: %[[UPDATE1_1:.*]] = spirv.IMul %[[STRIDE1_1]], %[[INDEX1]] : i32
-      // CHECK: %[[OFFSET1_1:.*]] = spirv.IAdd %[[OFFSET1_0]], %[[UPDATE1_1]] : i32
-      // CHECK: %[[STRIDE1_2:.*]] = spirv.Constant 1 : i32
-      // CHECK: %[[UPDATE1_2:.*]] = spirv.IMul %[[STRIDE1_2]], %[[INDEX2]] : i32
-      // CHECK: %[[OFFSET1_2:.*]] = spirv.IAdd %[[OFFSET1_1]], %[[UPDATE1_2]] : i32
-      // CHECK: %[[PTR1:.*]] = spirv.AccessChain %[[ARG0]]{{\[}}%[[ZERO]], %[[OFFSET1_2]]{{\]}}
-      // CHECK-NEXT: %[[VAL1:.*]] = spirv.Load "StorageBuffer" %[[PTR1]]
-      %14 = memref.load %arg0[%12, %13] : memref<12x4xf32, #spirv.storage_class<StorageBuffer>>
-      // CHECK: %[[PTR2:.*]] = spirv.AccessChain %[[ARG1]]{{\[}}{{%.*}}, {{%.*}}{{\]}}
-      // CHECK-NEXT: %[[VAL2:.*]] = spirv.Load "StorageBuffer" %[[PTR2]]
-      %15 = memref.load %arg1[%12, %13] : memref<12x4xf32, #spirv.storage_class<StorageBuffer>>
+      %13 = arith.addi %arg4, %2 : index
+      // CHECK: %[[OFFSET1_0:.*]] = spirv.Constant 0 : i64
+      // CHECK: %[[STRIDE1_1:.*]] = spirv.Constant 5 : i64
+      // CHECK: %[[UPDATE1_1:.*]] = spirv.IMul %[[STRIDE1_1]], %[[INDEX1]] : i64
+      // CHECK: %[[OFFSET1_1:.*]] = spirv.IAdd %[[OFFSET1_0]], %[[UPDATE1_1]] : i64
+      // CHECK: %[[STRIDE1_2:.*]] = spirv.Constant 1 : i64
+      // CHECK: %[[UPDATE1_2:.*]] = spirv.IMul %[[STRIDE1_2]], %[[INDEX2]] : i64
+      // CHECK: %[[OFFSET1_2:.*]] = spirv.IAdd %[[OFFSET1_1]], %[[UPDATE1_2]] : i64
+      // CHECK: %[[PTR1:.*]] = spirv.AccessChain %[[ARG0]]{{\[}}
+      // CHECK-NEXT: %[[VAL1:.*]] = spirv.Load "CrossWorkgroup" %[[PTR1]]
+      %14 = memref.load %arg0[%12, %13] : memref<2x5xf32>
+      // CHECK: %[[PTR2:.*]] = spirv.AccessChain %[[ARG1]]{{\[}}
+      // CHECK-NEXT: %[[VAL2:.*]] = spirv.Load "CrossWorkgroup" %[[PTR2]]
+      %15 = memref.load %arg1[%12, %13] : memref<2x5xf32>
       // CHECK: %[[VAL3:.*]] = spirv.FAdd %[[VAL1]], %[[VAL2]]
       %16 = arith.addf %14, %15 : f32
-      // CHECK: %[[PTR3:.*]] = spirv.AccessChain %[[ARG2]]{{\[}}{{%.*}}, {{%.*}}{{\]}}
-      // CHECK-NEXT: spirv.Store "StorageBuffer" %[[PTR3]], %[[VAL3]]
-      memref.store %16, %arg2[%12, %13] : memref<12x4xf32, #spirv.storage_class<StorageBuffer>>
-
-      // CHECK: spirv.GL.InverseSqrt
-      %17 = math.rsqrt %14 : f32
+      // CHECK: %[[PTR3:.*]] = spirv.AccessChain %[[ARG2]]{{\[}}
+      // CHECK-NEXT: spirv.Store "CrossWorkgroup" %[[PTR3]], %[[VAL3]]
+      memref.store %16, %arg2[%12, %13] : memref<2x5xf32>
+  %17 = math.rsqrt %14 : f32
       gpu.return
     }
   }

--- a/test/Conversion/GPUToSPIRV/scf.mlir
+++ b/test/Conversion/GPUToSPIRV/scf.mlir
@@ -2,53 +2,48 @@
 
 module attributes {
     gpu.container_module,
-    spirv.target_env = #spirv.target_env<
-    #spirv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]>, #spirv.resource_limits<>>
+    spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume]>, #spirv.resource_limits<>>
 } {
   gpu.module @kernels {
-    // CHECK:       spirv.module @{{.*}} Logical GLSL450 {
+    // CHECK:       spirv.module @{{.*}} Physical64 OpenCL
     // CHECK-LABEL: spirv.func @loop_kernel
-    // CHECK-SAME: {{%.*}}: !spirv.ptr<!spirv.struct<(!spirv.array<10 x f32, stride=4> [0])>, StorageBuffer> {spirv.interface_var_abi = #spirv.interface_var_abi<(0, 0)>}
-    // CHECK-SAME: {{%.*}}: !spirv.ptr<!spirv.struct<(!spirv.array<10 x f32, stride=4> [0])>, StorageBuffer> {spirv.interface_var_abi = #spirv.interface_var_abi<(0, 1)>}
-    // CHECK-SAME: spirv.entry_point_abi = #spirv.entry_point_abi<local_size = dense<[32, 4, 1]> : vector<3xi32>>
-    gpu.func @loop_kernel(%arg2 : memref<10xf32, #spirv.storage_class<StorageBuffer>>, %arg3 : memref<10xf32, #spirv.storage_class<StorageBuffer>>) kernel
-      attributes {spirv.entry_point_abi = #spirv.entry_point_abi<local_size = dense<[32, 4, 1]>: vector<3xi32>>} {
+    // CHECK-SAME: spirv.entry_point_abi = #spirv.entry_point_abi<>, workgroup_attributions = 0 : i64
+    gpu.func @loop_kernel(%arg2 : memref<10xf32>, %arg3 : memref<10xf32>) kernel
+      attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
       // CHECK: spirv.Branch ^bb1
       // CHECK: ^bb1:  // pred: ^bb0
        cf.br ^bb1
       ^bb1:  // pred: ^bb0
-      // CHECK: %[[LB:.*]] = spirv.Constant 4 : i32
+      // CHECK: %[[LB:.*]] = spirv.Constant 4 : i64
         %lb = arith.constant 4 : index
-        // CHECK: %[[UB:.*]] = spirv.Constant 42 : i32
+        // CHECK: %[[UB:.*]] = spirv.Constant 42 : i64
         %ub = arith.constant 42 : index
-        // CHECK: %[[STEP:.*]] = spirv.Constant 2 : i32
+        // CHECK: %[[STEP:.*]] = spirv.Constant 2 : i64
         %step = arith.constant 2 : index
         // CHECK: spirv.mlir.loop {
-        // CHECK-NEXT: spirv.Branch ^[[HEADER:.*]](%[[LB]] : i32)
-        // CHECK:      ^[[HEADER]](%[[INDVAR:.*]]: i32):
-        // CHECK:        %[[CMP:.*]] = spirv.SLessThan %[[INDVAR]], %[[UB]] : i32
+        // CHECK-NEXT: spirv.Branch ^[[HEADER:.*]](%[[LB]] : i64)
+        // CHECK:      ^[[HEADER]](%[[INDVAR:.*]]: i64):
+        // CHECK:        %[[CMP:.*]] = spirv.SLessThan %[[INDVAR]], %[[UB]] : i64
         // CHECK:        spirv.BranchConditional %[[CMP]], ^[[BODY:.*]], ^[[MERGE:.*]]
         // CHECK:      ^[[BODY]]:
-        // CHECK:        %[[ZERO1:.*]] = spirv.Constant 0 : i32
-        // CHECK:        %[[OFFSET1:.*]] = spirv.Constant 0 : i32
-        // CHECK:        %[[STRIDE1:.*]] = spirv.Constant 1 : i32
-        // CHECK:        %[[UPDATE1:.*]] = spirv.IMul %[[STRIDE1]], %[[INDVAR]] : i32
-        // CHECK:        %[[INDEX1:.*]] = spirv.IAdd %[[OFFSET1]], %[[UPDATE1]] : i32
-        // CHECK:        spirv.AccessChain {{%.*}}{{\[}}%[[ZERO1]], %[[INDEX1]]{{\]}}
-        // CHECK:        %[[ZERO2:.*]] = spirv.Constant 0 : i32
-        // CHECK:        %[[OFFSET2:.*]] = spirv.Constant 0 : i32
-        // CHECK:        %[[STRIDE2:.*]] = spirv.Constant 1 : i32
-        // CHECK:        %[[UPDATE2:.*]] = spirv.IMul %[[STRIDE2]], %[[INDVAR]] : i32
-        // CHECK:        %[[INDEX2:.*]] = spirv.IAdd %[[OFFSET2]], %[[UPDATE2]] : i32
-        // CHECK:        spirv.AccessChain {{%.*}}[%[[ZERO2]], %[[INDEX2]]]
-        // CHECK:        %[[INCREMENT:.*]] = spirv.IAdd %[[INDVAR]], %[[STEP]] : i32
-        // CHECK:        spirv.Branch ^[[HEADER]](%[[INCREMENT]] : i32)
+        // CHECK:        %[[OFFSET1:.*]] = spirv.Constant 0 : i64
+        // CHECK:        %[[STRIDE1:.*]] = spirv.Constant 1 : i64
+        // CHECK:        %[[UPDATE1:.*]] = spirv.IMul %[[STRIDE1]], %[[INDVAR]] : i64
+        // CHECK:        %[[INDEX1:.*]] = spirv.IAdd %[[OFFSET1]], %[[UPDATE1]] : i64
+        // CHECK:        spirv.AccessChain {{%.*}}
+        // CHECK:        %[[OFFSET2:.*]] = spirv.Constant 0 : i64
+        // CHECK:        %[[STRIDE2:.*]] = spirv.Constant 1 : i64
+        // CHECK:        %[[UPDATE2:.*]] = spirv.IMul %[[STRIDE2]], %[[INDVAR]] : i64
+        // CHECK:        %[[INDEX2:.*]] = spirv.IAdd %[[OFFSET2]], %[[UPDATE2]] : i64
+        // CHECK:        spirv.AccessChain {{%.*}}
+        // CHECK:        %[[INCREMENT:.*]] = spirv.IAdd %[[INDVAR]], %[[STEP]] : i64
+        // CHECK:        spirv.Branch ^[[HEADER]](%[[INCREMENT]] : i64)
         // CHECK:      ^[[MERGE]]
         // CHECK:        spirv.mlir.merge
         // CHECK:      }
         scf.for %arg4 = %lb to %ub step %step {
-             %1 = memref.load %arg2[%arg4] : memref<10xf32, #spirv.storage_class<StorageBuffer>>
-            memref.store %1, %arg3[%arg4] : memref<10xf32, #spirv.storage_class<StorageBuffer>>
+             %1 = memref.load %arg2[%arg4] : memref<10xf32>
+            memref.store %1, %arg3[%arg4] : memref<10xf32>
         }
       // CHECK: spirv.Return
       gpu.return
@@ -56,12 +51,12 @@ module attributes {
   }
 
   func.func @main() {
-    %0 = "op"() : () -> (memref<10xf32, #spirv.storage_class<StorageBuffer>>)
-    %1 = "op"() : () -> (memref<10xf32, #spirv.storage_class<StorageBuffer>>)
+    %0 = "op"() : () -> (memref<10xf32>)
+    %1 = "op"() : () -> (memref<10xf32>)
     %cst = arith.constant 1 : index
     gpu.launch_func @kernels::@loop_kernel
         blocks in (%cst, %cst, %cst) threads in (%cst, %cst, %cst)
-        args(%0 : memref<10xf32, #spirv.storage_class<StorageBuffer>>, %1 : memref<10xf32, #spirv.storage_class<StorageBuffer>>)
+        args(%0 : memref<10xf32>, %1 : memref<10xf32>)
     return
   }
 }


### PR DESCRIPTION
GpuToSpirv Pass is using 64bit index now, fixing tests accordingly and enable them back.

Please review these guidelines to help with the review process:
- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [ ] Have you organized your commits logically and ensured each can be built by itself?
