### PR TITLE
Some code cleanup

### DIFF
--- a/mlir/lib/Conversion/GpuToGpuRuntime.cpp
+++ b/mlir/lib/Conversion/GpuToGpuRuntime.cpp
@@ -2124,18 +2124,6 @@ struct TruncateF64ForGPUPass
     imex::populateTupleTypeConversionRewritesAndTarget(converter, patterns,
                                                        target);
 
-    // TODO: remove
-    mlir::populateFunctionOpInterfaceTypeConversionPattern<
-        mlir::gpu::GPUFuncOp>(patterns, converter);
-    target.addDynamicallyLegalOp<mlir::gpu::GPUFuncOp>(
-        [&](mlir::gpu::GPUFuncOp op) -> llvm::Optional<bool> {
-          if (converter.isSignatureLegal(op.getFunctionType()) &&
-              converter.isLegal(&op.getBody()))
-            return true;
-
-          return llvm::None;
-        });
-
     patterns.insert<ConvertF64LoadOp, ConvertF64StoreOp>(converter, ctx);
     target.addDynamicallyLegalOp<mlir::memref::LoadOp, mlir::memref::StoreOp>(
         [&converter](mlir::Operation *op) -> llvm::Optional<bool> {

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -296,10 +296,6 @@ struct ReshapeChangeLayout
     mlir::OpFoldResult offsetVal = rewriter.getIndexAttr(offset);
 
     llvm::SmallVector<mlir::OpFoldResult> stridesVals(rank);
-    auto offsetConst =
-        rewriter.create<mlir::arith::ConstantIndexOp>(loc, offset);
-    auto actualOffset =
-        rewriter.createOrFold<imex::util::ExtractMemrefMetadataOp>(loc, src);
 
     mlir::Value cmp;
     for (auto i : llvm::seq(0u, rank)) {


### PR DESCRIPTION
* Remove unused vars
* Rework `populateControlFlowTypeConversionRewritesAndTarget` to work on any `FunctionOpInterface` and not only `func.func`, cleanup related code in gpu passes