### PR TITLE
Disable some unsafe optimizations

### DIFF
--- a/mlir/include/imex/Dialect/imex_util/ImexUtilOps.td
+++ b/mlir/include/imex/Dialect/imex_util/ImexUtilOps.td
@@ -102,6 +102,19 @@ def ParallelOp : ImexUtil_Op<"parallel", [
 
     let extraClassDeclaration = [{
         unsigned getNumLoops() { return getSteps().size(); }
+
+        ::mlir::Block *getBodyBlock() { return &getLoopBody().front(); }
+
+        ::mlir::ValueRange getBodyLowerBounds() {
+          return getBodyBlock()->getArguments().take_front(getNumLoops());
+        }
+
+        ::mlir::ValueRange getBodyUpperBounds() {
+          auto count = getNumLoops();
+          return getBodyBlock()->getArguments().drop_front(count).take_front(count);
+        }
+
+        ::mlir::Value getBodyThreadIndex() { return getBodyBlock()->getArguments().back(); }
     }];
 }
 

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/ParallelToTbb.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/ParallelToTbb.cpp
@@ -311,6 +311,8 @@ struct HoistBufferAllocs
         newShape.emplace_back(mc.getValue().getSExtValue());
         auto oldShape = oldType.getShape();
         newShape.append(oldShape.begin(), oldShape.end());
+        return mlir::MemRefType::get(newShape, oldType.getElementType(),
+                                     oldType.getMemorySpace());
       }
       return oldType;
     }();
@@ -373,7 +375,7 @@ struct ParallelToTbbPass
 
 struct HoistBufferAllocsPass
     : public imex::RewriteWrapperPass<
-          ParallelToTbbPass, mlir::func::FuncOp,
+          HoistBufferAllocsPass, mlir::func::FuncOp,
           imex::DependentDialectsList<imex::util::ImexUtilDialect,
                                       mlir::scf::SCFDialect,
                                       mlir::memref::MemRefDialect>,

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/ParallelToTbb.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/ParallelToTbb.cpp
@@ -348,8 +348,11 @@ struct HoistBufferAllocs
               .cast<mlir::MemRefType>();
       view = rewriter.create<mlir::memref::SubViewOp>(loc, newType, newMemref,
                                                       offsets, sizes, strides);
-      if (view.getType() != oldType)
-        view = rewriter.create<imex::util::ChangeLayoutOp>(loc, oldType, view);
+      if (view.getType() != oldType) {
+        view = rewriter.create<imex::util::MemrefApplyOffsetOp>(loc, oldType,
+                                                                view);
+        view = rewriter.create<mlir::memref::CastOp>(loc, oldType, view);
+      }
     }
 
     rewriter.replaceOp(op, view);

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -2767,8 +2767,8 @@ static void populatePlierToLinalgOptPipeline(mlir::OpPassManager &pm) {
   pm.addPass(mlir::createCanonicalizerPass());
 
   pm.addNestedPass<mlir::func::FuncOp>(std::make_unique<LowerCloneOpsPass>());
-  pm.addNestedPass<mlir::func::FuncOp>(
-      mlir::bufferization::createPromoteBuffersToStackPass());
+  //  pm.addNestedPass<mlir::func::FuncOp>(
+  //      mlir::bufferization::createPromoteBuffersToStackPass());
 
   pm.addNestedPass<mlir::func::FuncOp>(
       mlir::createConvertLinalgToParallelLoopsPass());

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -2752,10 +2752,10 @@ static void populatePlierToLinalgOptPipeline(mlir::OpPassManager &pm) {
 
   pm.addPass(mlir::createCanonicalizerPass());
 
-  pm.addNestedPass<mlir::func::FuncOp>(
-      mlir::bufferization::createBufferHoistingPass());
-  pm.addNestedPass<mlir::func::FuncOp>(
-      mlir::bufferization::createBufferLoopHoistingPass());
+  //  pm.addNestedPass<mlir::func::FuncOp>(
+  //      mlir::bufferization::createBufferHoistingPass());
+  //  pm.addNestedPass<mlir::func::FuncOp>(
+  //      mlir::bufferization::createBufferLoopHoistingPass());
 
   pm.addNestedPass<mlir::func::FuncOp>(std::make_unique<CloneArgsPass>());
   pm.addPass(std::make_unique<MakeStridedLayoutPass>());


### PR DESCRIPTION
* Disable buffer hoisting and alloca promotion optimizations, as they are not safe wrt `scf.for` to `scf.parallel` promotion na dgpu pipeline
* Introduce out own buffer hoisting pass after parallel-to-tbb
* This fixed `covariance` and `correlation` npbench workloads