### PR TITLE
Parallel=True flag wasn't alsways respected when calling functions fro…

### DIFF
--- a/numba_dpcomp/numba_dpcomp/mlir/passes.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/passes.py
@@ -97,6 +97,11 @@ class MlirBackendBase(FunctionPass):
             inline_type = obj.dispatcher.targetoptions.get("inline", None)
             if inline_type is not None:
                 flags.inline._inline = inline_type
+
+            parallel_type = obj.dispatcher.targetoptions.get("parallel", None)
+            if parallel_type is not None:
+                flags.auto_parallel = parallel_type
+
             return (func.__module__ + "." + func.__qualname__, func, flags)
         return (None, None, None)
 

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/Lowering.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/Lowering.cpp
@@ -173,8 +173,8 @@ struct PlierLowerer final {
                       compilationContext["opt_level"]().cast<int64_t>()));
     auto maxConcurrency = compilationContext["max_concurrency"]().cast<int>();
     if (maxConcurrency > 0)
-      mod->setAttr(imex::util::attributes::getMaxConcurrencyName(),
-                   builder.getI64IntegerAttr(maxConcurrency));
+      func->setAttr(imex::util::attributes::getMaxConcurrencyName(),
+                    builder.getI64IntegerAttr(maxConcurrency));
 
     lowerFuncBody(funcIr);
     mod.push_back(func);

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/ParallelToTbb.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/ParallelToTbb.cpp
@@ -65,10 +65,10 @@ struct ParallelToTbb : public mlir::OpRewritePattern<mlir::scf::ParallelOp> {
       return mlir::failure();
 
     int64_t maxConcurrency = 0;
-    auto mod = op->getParentOfType<mlir::ModuleOp>();
-    if (!mod)
+    auto func = op->getParentOfType<mlir::func::FuncOp>();
+    if (!func)
       return mlir::failure();
-    if (auto mc = mod->getAttrOfType<mlir::IntegerAttr>(
+    if (auto mc = func->getAttrOfType<mlir::IntegerAttr>(
             imex::util::attributes::getMaxConcurrencyName()))
       maxConcurrency = mc.getInt();
 
@@ -292,11 +292,11 @@ struct HoistBufferAllocs
     if (!loopInfo)
       return mlir::failure();
 
-    auto mod = op->getParentOfType<mlir::ModuleOp>();
-    if (!mod)
+    auto func = op->getParentOfType<mlir::func::FuncOp>();
+    if (!func)
       return mlir::failure();
 
-    auto mc = mod->getAttrOfType<mlir::IntegerAttr>(
+    auto mc = func->getAttrOfType<mlir::IntegerAttr>(
         imex::util::attributes::getMaxConcurrencyName());
     if (loopInfo->innermostParallel && !mc)
       return mlir::failure();


### PR DESCRIPTION
…m other functions

* Made `max_concurrency` flag per function instead of per module
* Properly propagate parallel flag
