### PR TITLE
ShapeIntegerRangePropagationPass: propagate shape range through `tens…

### DIFF
--- a/mlir/test/Transforms/shape-int-range-opts.mlir
+++ b/mlir/test/Transforms/shape-int-range-opts.mlir
@@ -102,3 +102,33 @@ func.func @test(%arg1: tensor<?xf32> {imex.shape_range = [#imex_util.index_range
   %2 = arith.cmpi eq, %1, %cst : index
   return %2: i1
 }
+
+// -----
+
+// CHECK-LABEL: func @test
+//       CHECK:   %[[C:.*]] = arith.constant false
+//       CHECK:   return %[[C]]
+func.func @test(%arg1: tensor<?xf32>) -> i1 {
+  %cst0 = arith.constant 0 : index
+  %cst1 = arith.constant 1 : index
+  %0 = tensor.from_elements %cst0, %cst1 : tensor<2xindex>
+  %1 = tensor.reshape %arg1(%0) : (tensor<?xf32>, tensor<2xindex>) -> tensor<?x?xf32>
+  %2 = tensor.dim %1, %cst0 : tensor<?x?xf32>
+  %3 = arith.cmpi eq, %2, %cst1 : index
+  return %3: i1
+}
+
+// -----
+
+// CHECK-LABEL: func @test
+//       CHECK:   %[[C:.*]] = arith.constant false
+//       CHECK:   return %[[C]]
+func.func @test(%arg1: tensor<?xf32>) -> i1 {
+  %cst0 = arith.constant 0 : index
+  %cst1 = arith.constant 1 : index
+  %0 = tensor.from_elements %cst0, %cst1 : tensor<2xindex>
+  %1 = tensor.reshape %arg1(%0) : (tensor<?xf32>, tensor<2xindex>) -> tensor<?x?xf32>
+  %2 = tensor.dim %1, %cst1 : tensor<?x?xf32>
+  %3 = arith.cmpi eq, %2, %cst0 : index
+  return %3: i1
+}


### PR DESCRIPTION
…or.reshape`

