### PR TITLE
[Transforms] lower memref.copy

### DIFF
--- a/include/imex/Transforms/Passes.h
+++ b/include/imex/Transforms/Passes.h
@@ -25,6 +25,7 @@ std::unique_ptr<mlir::Pass> createInsertGPUAllocsPass();
 std::unique_ptr<mlir::Pass> createSetSPIRVCapabilitiesPass();
 std::unique_ptr<mlir::Pass> createSetSPIRVAbiAttributePass();
 std::unique_ptr<mlir::Pass> createAddOuterParallelLoopPass();
+std::unique_ptr<mlir::Pass> createLowerMemRefCopyPass();
 
 #define GEN_PASS_DECL
 #include "imex/Transforms/Passes.h.inc"

--- a/include/imex/Transforms/Passes.td
+++ b/include/imex/Transforms/Passes.td
@@ -75,4 +75,19 @@ def AddOuterParallelLoop : Pass<"imex-add-outer-parallel-loop", "::mlir::func::F
     ];
 }
 
+def LowerMemRefCopy : Pass<"imex-lower-memref-copy", "::mlir::func::FuncOp"> {
+  let summary = "lower memref.copy to linalg.generic";
+  let description = [{
+    This Pass transforms memref.copy to linalg.generic with identity index map and
+    parallel iterator. If satisfied, this pass also does memref.copy canonicalization.
+
+    This pass is supposed to work after bufferization and before linalg-lowering.
+  }];
+  let constructor = "imex::createLowerMemRefCopyPass()";
+  let dependentDialects = [
+    "::mlir::linalg::LinalgDialect",
+    "::mlir::memref::MemRefDialect"
+    ];
+}
+
 #endif // _IMEX_TRANSFORMS_PASSES_TD_INCLUDED_

--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_mlir_library(IMEXTransforms
   SetSPIRVCapabilities.cpp
   SetSPIRVAbiAttribute.cpp
   AddOuterParallelLoop.cpp
+  LowerMemRefCopy.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/imex/Transforms

--- a/lib/Transforms/PassDetail.h
+++ b/lib/Transforms/PassDetail.h
@@ -30,6 +30,10 @@ class SPIRVDialect;
 namespace scf {
 class SCFDialect;
 }
+
+namespace linalg {
+class LinalgDialect;
+}
 } // end namespace mlir
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"

--- a/test/Transforms/lower-memref-copy.mlir
+++ b/test/Transforms/lower-memref-copy.mlir
@@ -1,0 +1,39 @@
+// RUN: imex-opt -imex-lower-memref-copy -allow-unregistered-dialect %s | FileCheck %s
+#map = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  func.func @copy_with_later_use(%arg0: memref<10x20xf32>) -> memref<10x20xf32> {
+    %cst = arith.constant 0.000000e+00 : f32
+    %alloc = memref.alloc() {alignment = 128 : i64} : memref<10x20xf32>
+    %alloc_0 = memref.alloc() {alignment = 128 : i64} : memref<10x20xf32>
+    linalg.fill ins(%cst : f32) outs(%alloc_0 : memref<10x20xf32>)
+    %alloc_1 = memref.alloc() {alignment = 128 : i64} : memref<10x20xf32>
+    memref.copy %alloc_0, %alloc_1 : memref<10x20xf32> to memref<10x20xf32>
+    "some_use" (%alloc_0) {} : (memref<10x20xf32>) -> ()
+    // CHECK-LABEL: func @copy_with_later_use
+    // CHECK:       linalg.generic
+    // CHECK:       linalg.generic
+    linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0 : memref<10x20xf32>) outs(%alloc_1 : memref<10x20xf32>) attrs =  {iterator_ranges = [10, 20]} {
+    ^bb0(%in: f32, %out: f32):
+      %0 = arith.addf %out, %in : f32
+      linalg.yield %0 : f32
+    }
+    return %alloc_1 : memref<10x20xf32>
+  }
+  func.func @copy_without_later_use(%arg0: memref<10x20xf32>) -> memref<10x20xf32> {
+    %cst = arith.constant 0.000000e+00 : f32
+    %alloc = memref.alloc() {alignment = 128 : i64} : memref<10x20xf32>
+    %alloc_0 = memref.alloc() {alignment = 128 : i64} : memref<10x20xf32>
+    linalg.fill ins(%cst : f32) outs(%alloc_0 : memref<10x20xf32>)
+    %alloc_1 = memref.alloc() {alignment = 128 : i64} : memref<10x20xf32>
+    memref.copy %alloc_0, %alloc_1 : memref<10x20xf32> to memref<10x20xf32>
+    // CHECK-LABEL: func @copy_without_later_use
+    // CHECK:       linalg.generic
+    // CHECK-NOT:   linalg.generic
+    linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0 : memref<10x20xf32>) outs(%alloc_1 : memref<10x20xf32>) attrs =  {iterator_ranges = [10, 20]} {
+    ^bb0(%in: f32, %out: f32):
+      %0 = arith.addf %out, %in : f32
+      linalg.yield %0 : f32
+    }
+    return %alloc_1 : memref<10x20xf32>
+  }
+}


### PR DESCRIPTION
add an optional pass to lower memref.copy  after bufferization and before linalg-lowering.
with this, we can open more chance to later optimization like loop-fusion/store-load-forwarding.
also it make sense to process load/store in a memref.copy  in the same way with load/store in a linalg.generic op.

Please review these guidelines to help with the review process:
- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
- [x] Have you organized your commits logically and ensured each can be built by itself?
