### PR TITLE
Broadcast improvement

### DIFF
--- a/mlir/lib/Dialect/imex_util/Dialect.cpp
+++ b/mlir/lib/Dialect/imex_util/Dialect.cpp
@@ -521,6 +521,27 @@ static bool canTransformLayoutCast(mlir::Type src, mlir::Type dst) {
   return true;
 }
 
+static mlir::MemRefType getFullyDynamicType(mlir::Type type) {
+  auto memrefType = type.dyn_cast<mlir::MemRefType>();
+  if (!memrefType)
+    return {};
+
+  auto layout = memrefType.getLayout().dyn_cast<mlir::StridedLayoutAttr>();
+  if (!layout)
+    return {};
+
+  int64_t offset = mlir::ShapedType::kDynamicStrideOrOffset;
+  llvm::SmallVector<int64_t> strides(layout.getStrides().size(), offset);
+  auto dynLayout =
+      mlir::StridedLayoutAttr::get(type.getContext(), offset, strides);
+  if (layout == dynLayout)
+    return {};
+
+  return mlir::MemRefType::get(memrefType.getShape(),
+                               memrefType.getElementType(), dynLayout,
+                               memrefType.getMemorySpace());
+}
+
 struct ChangeLayoutIdentity
     : public mlir::OpRewritePattern<imex::util::ChangeLayoutOp> {
   using OpRewritePattern::OpRewritePattern;
@@ -852,20 +873,31 @@ struct ChangeLayoutIf : public mlir::OpRewritePattern<mlir::scf::YieldOp> {
         auto srcType = src.getType();
 
         auto otherArg = otherYield.getResults()[i];
-        if (canTransformLayoutCast(origType, srcType)) {
+        for (auto dstType : {srcType, getFullyDynamicType(srcType)}) {
+          if (!dstType)
+            continue;
 
-          rewriter.updateRootInPlace(clYield,
-                                     [&]() { clYield.setOperand(i, src); });
+          if (canTransformLayoutCast(origType, dstType)) {
+            if (srcType != dstType) {
+              rewriter.setInsertionPoint(clYield);
+              src = rewriter.create<mlir::memref::CastOp>(clYield.getLoc(),
+                                                          dstType, src);
+            }
 
-          rewriter.setInsertionPoint(otherYield);
-          auto otherRes = rewriter.createOrFold<mlir::memref::CastOp>(
-              otherYield.getLoc(), srcType, otherArg);
+            rewriter.updateRootInPlace(clYield,
+                                       [&]() { clYield.setOperand(i, src); });
 
-          rewriter.updateRootInPlace(
-              otherYield, [&]() { otherYield.setOperand(i, otherRes); });
-          newType = srcType;
-          break;
+            rewriter.setInsertionPoint(otherYield);
+            auto otherRes = rewriter.createOrFold<mlir::memref::CastOp>(
+                otherYield.getLoc(), dstType, otherArg);
+
+            rewriter.updateRootInPlace(
+                otherYield, [&]() { otherYield.setOperand(i, otherRes); });
+            newType = dstType;
+            break;
+          }
         }
+
         if (auto otherCl =
                 otherArg.getDefiningOp<imex::util::ChangeLayoutOp>()) {
           auto otherSrc = otherCl.getSource();

--- a/mlir/lib/Dialect/imex_util/Dialect.cpp
+++ b/mlir/lib/Dialect/imex_util/Dialect.cpp
@@ -873,6 +873,8 @@ struct ChangeLayoutIf : public mlir::OpRewritePattern<mlir::scf::YieldOp> {
         auto srcType = src.getType();
 
         auto otherArg = otherYield.getResults()[i];
+
+        bool outerBreak = false;
         for (auto dstType : {srcType, getFullyDynamicType(srcType)}) {
           if (!dstType)
             continue;
@@ -894,9 +896,13 @@ struct ChangeLayoutIf : public mlir::OpRewritePattern<mlir::scf::YieldOp> {
             rewriter.updateRootInPlace(
                 otherYield, [&]() { otherYield.setOperand(i, otherRes); });
             newType = dstType;
+            outerBreak = true;
             break;
           }
         }
+
+        if (outerBreak)
+          break;
 
         if (auto otherCl =
                 otherArg.getDefiningOp<imex::util::ChangeLayoutOp>()) {

--- a/mlir/lib/Dialect/imex_util/Dialect.cpp
+++ b/mlir/lib/Dialect/imex_util/Dialect.cpp
@@ -875,7 +875,7 @@ struct ChangeLayoutIf : public mlir::OpRewritePattern<mlir::scf::YieldOp> {
         auto otherArg = otherYield.getResults()[i];
 
         if (auto otherCl =
-            otherArg.getDefiningOp<imex::util::ChangeLayoutOp>()) {
+                otherArg.getDefiningOp<imex::util::ChangeLayoutOp>()) {
           auto otherSrc = otherCl.getSource();
           if (otherSrc.getType() == srcType) {
             rewriter.updateRootInPlace(

--- a/mlir/lib/Transforms/ShapeIntegerRangePropagation.cpp
+++ b/mlir/lib/Transforms/ShapeIntegerRangePropagation.cpp
@@ -416,8 +416,7 @@ public:
       auto dstShaped = op->getResult(0).getType().cast<mlir::ShapedType>();
       auto res =
           ShapeValue::intersect(ShapeValue{srcShaped}, ShapeValue{dstShaped});
-      res = ShapeValue::intersect(operands.front()->getValue(),
-                                  ShapeValue{dstShaped});
+      res = ShapeValue::intersect(operands.front()->getValue(), res);
 
       LLVM_DEBUG(llvm::dbgs()
                  << "ShapeValueAnalysis: Shaped cast: " << res << "\n");

--- a/numba_dpcomp/numba_dpcomp/mlir/__init__.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/__init__.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from . import array_type
 from . import dpctl_interop
 from .builtin import funcs
 from .numpy import funcs

--- a/numba_dpcomp/numba_dpcomp/mlir/array_type.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/array_type.py
@@ -4,9 +4,10 @@
 
 import numpy as np
 
-from numba.extending import typeof_impl
-from numba.core.types.npytypes import Array
+from numba.extending import register_model, typeof_impl
 from numba.core import errors
+from numba.core.types.npytypes import Array
+from numba.core.datamodel.models import ArrayModel
 from numba.np import numpy_support
 
 
@@ -46,6 +47,9 @@ class FixedArray(Array):
         return super().key + (self.fixed_dims,)
 
 
+register_model(FixedArray)(ArrayModel)
+
+
 @typeof_impl.register(np.ndarray)
 def _typeof_ndarray(val, c):
     try:
@@ -55,6 +59,4 @@ def _typeof_ndarray(val, c):
     layout = numpy_support.map_layout(val)
     readonly = not val.flags.writeable
     fixed_dims = tuple(d if d == 1 else None for d in val.shape)
-    return FixedArray(
-        dtype, val.ndim, layout, fixed_dims=fixed_dims, readonly=readonly
-    )
+    return FixedArray(dtype, val.ndim, layout, fixed_dims=fixed_dims, readonly=readonly)

--- a/numba_dpcomp/numba_dpcomp/mlir/array_type.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/array_type.py
@@ -10,6 +10,7 @@ from numba.core.types.npytypes import Array
 from numba.core.datamodel.models import ArrayModel
 from numba.np import numpy_support
 from numba.np.arrayobj import intrin_alloc
+from numba.core.imputils import lower_cast
 
 
 class FixedArray(Array):
@@ -49,6 +50,21 @@ class FixedArray(Array):
 
 
 register_model(FixedArray)(ArrayModel)
+
+
+@lower_cast(FixedArray, Array)
+def array_to_array(context, builder, fromty, toty, val):
+    return val
+
+
+@lower_cast(Array, FixedArray)
+def array_to_array(context, builder, fromty, toty, val):
+    return val
+
+
+@lower_cast(FixedArray, FixedArray)
+def array_to_array(context, builder, fromty, toty, val):
+    return val
 
 
 @overload_classmethod(FixedArray, "_allocate")

--- a/numba_dpcomp/numba_dpcomp/mlir/array_type.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/array_type.py
@@ -6,6 +6,8 @@ import numpy as np
 
 from numba.extending import typeof_impl
 from numba.core.types.npytypes import Array
+from numba.core import errors
+from numba.np import numpy_support
 
 
 class FixedArray(Array):
@@ -53,6 +55,6 @@ def _typeof_ndarray(val, c):
     layout = numpy_support.map_layout(val)
     readonly = not val.flags.writeable
     fixed_dims = tuple(d if d == 1 else None for d in val.shape)
-    return types.FixedArray(
+    return FixedArray(
         dtype, val.ndim, layout, fixed_dims=fixed_dims, readonly=readonly
     )

--- a/numba_dpcomp/numba_dpcomp/mlir/array_type.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/array_type.py
@@ -77,6 +77,10 @@ def _ol_array_allocate(cls, allocsize, align):
     return impl
 
 
+def get_fixed_dims(shape):
+    return tuple(d if (d == 0 or d == 1) else None for d in shape)
+
+
 @typeof_impl.register(np.ndarray)
 def _typeof_ndarray(val, c):
     try:
@@ -85,5 +89,5 @@ def _typeof_ndarray(val, c):
         raise errors.NumbaValueError(f"Unsupported array dtype: {val.dtype}")
     layout = numpy_support.map_layout(val)
     readonly = not val.flags.writeable
-    fixed_dims = tuple(d if d == 1 else None for d in val.shape)
+    fixed_dims = get_fixed_dims(val.shape)
     return FixedArray(dtype, val.ndim, layout, fixed_dims=fixed_dims, readonly=readonly)

--- a/numba_dpcomp/numba_dpcomp/mlir/array_type.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/array_type.py
@@ -39,7 +39,7 @@ class FixedArray(Array):
             dtype=dtype,
             ndim=ndim,
             layout=layout,
-            fixed_dims=self.fixed_dims,
+            fixed_dims=(None,) * ndim,
             readonly=readonly,
             aligned=self.aligned,
         )

--- a/numba_dpcomp/numba_dpcomp/mlir/array_type.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/array_type.py
@@ -4,11 +4,12 @@
 
 import numpy as np
 
-from numba.extending import register_model, typeof_impl
+from numba.extending import overload_classmethod, register_model, typeof_impl
 from numba.core import errors
 from numba.core.types.npytypes import Array
 from numba.core.datamodel.models import ArrayModel
 from numba.np import numpy_support
+from numba.np.arrayobj import intrin_alloc
 
 
 class FixedArray(Array):
@@ -48,6 +49,16 @@ class FixedArray(Array):
 
 
 register_model(FixedArray)(ArrayModel)
+
+
+@overload_classmethod(FixedArray, "_allocate")
+def _ol_array_allocate(cls, allocsize, align):
+    """Implements a Numba-only default target (cpu) classmethod on the array type."""
+
+    def impl(cls, allocsize, align):
+        return intrin_alloc(allocsize, align)
+
+    return impl
 
 
 @typeof_impl.register(np.ndarray)

--- a/numba_dpcomp/numba_dpcomp/mlir/dpctl_interop.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/dpctl_interop.py
@@ -151,7 +151,7 @@ if _is_dpctl_available:
             dtype = numpy_support.from_dtype(val.dtype)
         except NotImplementedError:
             raise ValueError("Unsupported array dtype: %s" % (val.dtype,))
-        layout = "C"
+        layout = "A"  # TODO: infer layout
         readonly = False
         filter_string = _get_filter_string(val)
         assert filter_string is not None

--- a/numba_dpcomp/numba_dpcomp/mlir/dpctl_interop.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/dpctl_interop.py
@@ -154,7 +154,7 @@ if _is_dpctl_available:
         readonly = False
         filter_string = _get_filter_string(val)
         assert filter_string is not None
-        fixed_dims = tuple(d if d == 1 else None for d in val.shape)
+        fixed_dims = array_type.get_fixed_dims(val.shape)
         return USMNdArrayType(
             dtype,
             val.ndim,

--- a/numba_dpcomp/numba_dpcomp/mlir/dpctl_interop.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/dpctl_interop.py
@@ -73,6 +73,7 @@ if _is_dpctl_available:
                 dtype=dtype,
                 ndim=ndim,
                 layout=layout,
+                fixed_dims=self.fixed_dims,
                 readonly=readonly,
                 aligned=self.aligned,
             )

--- a/numba_dpcomp/numba_dpcomp/mlir/dpctl_interop.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/dpctl_interop.py
@@ -73,7 +73,7 @@ if _is_dpctl_available:
                 dtype=dtype,
                 ndim=ndim,
                 layout=layout,
-                fixed_dims=self.fixed_dims,
+                fixed_dims=(None,) * ndim,
                 readonly=readonly,
                 aligned=self.aligned,
             )

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/PyLinalgResolver.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/PyLinalgResolver.cpp
@@ -983,6 +983,12 @@ static py::object reshapeImpl(py::capsule context, py::handle src,
       reassoc[std::max(0, currInd)].emplace_back(i);
     }
 
+    shape.resize(static_cast<unsigned>(srcType.getRank()),
+                 mlir::ShapedType::kDynamicSize);
+    auto dynShapeType = srcType.clone(shape);
+    if (dynShapeType != srcType)
+      srcVal = builder.create<mlir::tensor::CastOp>(loc, dynShapeType, srcVal);
+
     auto expandType = resultType.clone(expandShape);
     mlir::Value res = builder.create<mlir::tensor::ExpandShapeOp>(
         loc, expandType, srcVal, reassoc);

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -54,6 +54,7 @@
 #include "imex/Transforms/PromoteBoolMemref.hpp"
 #include "imex/Transforms/PromoteToParallel.hpp"
 #include "imex/Transforms/RewriteWrapper.hpp"
+#include "imex/Transforms/ShapeIntegerRangePropagation.hpp"
 #include "imex/Transforms/TypeConversion.hpp"
 #include "imex/Transforms/UpliftMath.hpp"
 
@@ -1735,6 +1736,64 @@ struct WrapParforRegions
   }
 };
 
+struct MarkInputShapesRanges
+    : public mlir::PassWrapper<MarkInputShapesRanges,
+                               mlir::OperationPass<mlir::ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MarkInputShapesRanges)
+
+  virtual void
+  getDependentDialects(mlir::DialectRegistry &registry) const override {
+    registry.insert<imex::util::ImexUtilDialect>();
+  }
+
+  void runOnOperation() override {
+    auto mod = getOperation();
+
+    auto getRange = [&](int64_t min, int64_t max) {
+      return imex::util::IndexRangeAttr::get(&getContext(), min, max);
+    };
+
+    auto attrName = mlir::StringAttr::get(
+        mod.getContext(), imex::util::attributes::getShapeRangeName());
+    mod.walk([&](mlir::FunctionOpInterface func) {
+      if (func.isExternal())
+        return;
+
+      auto &body = func.getFunctionBody();
+      assert(!body.empty());
+      for (auto [i, arg] : llvm::enumerate(body.front().getArguments())) {
+        auto shaped = arg.getType().dyn_cast<mlir::ShapedType>();
+        if (!shaped)
+          continue;
+
+        auto newRange = [&]() -> llvm::Optional<mlir::ArrayAttr> {
+          auto uses = mlir::SymbolTable::getSymbolUses(func, mod);
+          if (!uses || !uses->empty())
+            return llvm::None;
+
+          auto rank = static_cast<unsigned>(shaped.getRank());
+          llvm::SmallVector<mlir::Attribute> shapeRanges(rank);
+
+          for (auto [i, dim] : llvm::enumerate(shaped.getShape())) {
+            if (mlir::ShapedType::isDynamic(dim)) {
+              shapeRanges[i] = getRange(2, std::numeric_limits<int64_t>::max());
+            } else {
+              shapeRanges[i] = getRange(dim, dim);
+            }
+          }
+
+          return mlir::ArrayAttr::get(&getContext(), shapeRanges);
+        }();
+
+        if (!newRange)
+          continue;
+
+        func.setArgAttr(static_cast<unsigned>(i), attrName, *newRange);
+      }
+    });
+  }
+};
+
 struct ResolveNumpyFuncsPass
     : public mlir::PassWrapper<ResolveNumpyFuncsPass,
                                mlir::OperationPass<void>> {
@@ -2738,6 +2797,8 @@ static void populatePlierToLinalgGenPipeline(mlir::OpPassManager &pm) {
   pm.addNestedPass<mlir::func::FuncOp>(mlir::createCanonicalizerPass());
   pm.addPass(imex::createForceInlinePass());
   pm.addPass(mlir::createSymbolDCEPass());
+  pm.addPass(std::make_unique<MarkInputShapesRanges>());
+  pm.addPass(imex::createShapeIntegerRangePropagationPass());
   pm.addNestedPass<mlir::func::FuncOp>(
       std::make_unique<PostPlierToLinalgPass>());
   pm.addNestedPass<mlir::func::FuncOp>(mlir::createCSEPass());

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -2861,6 +2861,8 @@ static void populatePlierToLinalgOptPipeline(mlir::OpPassManager &pm) {
   pm.addNestedPass<mlir::func::FuncOp>(
       mlir::createLoopInvariantCodeMotionPass());
 
+  pm.addPass(imex::createShapeIntegerRangePropagationPass());
+  pm.addNestedPass<mlir::func::FuncOp>(mlir::createCanonicalizerPass());
   pm.addNestedPass<mlir::func::FuncOp>(mlir::createCSEPass());
   // ToDo: This pass also tries to do some simple fusion, whic should be split
   // in separate pass


### PR DESCRIPTION
* Dispatch to different versions of functions depending if some dimension is equal to 1 or not
* Integrate `hapeIntegerRangePropagationPass` into main pipeline and make all input arrays with non-unit dimensions with `IndexRangeAttr`, as all unit size arrays will be dispatched to separate function
