### PR TITLE
More optimizations for defoemable workload

### DIFF
--- a/mlir/lib/Transforms/ShapeIntegerRangePropagation.cpp
+++ b/mlir/lib/Transforms/ShapeIntegerRangePropagation.cpp
@@ -5,6 +5,7 @@
 #include "imex/Transforms/ShapeIntegerRangePropagation.hpp"
 
 #include "imex/Dialect/imex_util/Dialect.hpp"
+#include "imex/Dialect/ntensor/IR/NTensorOps.hpp"
 
 #include <llvm/Support/Debug.h>
 #include <mlir/Analysis/DataFlow/DeadCodeAnalysis.h>
@@ -184,6 +185,10 @@ struct ShapeValueLattice : public mlir::dataflow::Lattice<ShapeValue> {
 };
 
 static bool isShapedCast(mlir::Operation *op) {
+  if (mlir::isa<imex::ntensor::FromTensorOp, imex::ntensor::ToTensorOp,
+                imex::ntensor::FromMemrefOp, imex::ntensor::ToMemrefOp>(op))
+    return true;
+
   return mlir::isa<mlir::CastOpInterface>(op) && op->getNumOperands() == 1 &&
          op->getNumResults() == 1 &&
          mlir::isa<mlir::ShapedType>(op->getOperand(0).getType()) &&
@@ -714,6 +719,7 @@ struct ShapeIntegerRangePropagationPass
   virtual void
   getDependentDialects(mlir::DialectRegistry &registry) const override {
     registry.insert<imex::util::ImexUtilDialect>();
+    registry.insert<imex::ntensor::NTensorDialect>();
     registry.insert<mlir::arith::ArithDialect>();
     registry.insert<mlir::tensor::TensorDialect>();
     registry.insert<mlir::linalg::LinalgDialect>();

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -2359,8 +2359,8 @@ struct CompositePass
         return signalPassFailure();
 
       if (currentIter++ >= maxIters) {
-        op->emitWarning("Composite pass didn't converge in " +
-                        llvm::Twine(maxIters) + " iterations");
+        //        op->emitWarning("Composite pass didn't converge in " +
+        //                        llvm::Twine(maxIters) + " iterations");
         break;
       }
 

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -78,6 +78,54 @@ static int64_t getOptLevel(mlir::Operation *op) {
   return std::max(static_cast<int64_t>(0), attr.getInt());
 }
 
+static bool optimizeSimpleLoads(mlir::Operation *op) {
+  bool changed = false;
+
+  mlir::DominanceInfo dom;
+  op->walk([&](mlir::memref::LoadOp load) {
+    auto memref = load.getMemRef();
+    auto src = memref.getDefiningOp();
+    if (!mlir::isa_and_nonnull<mlir::memref::AllocOp, mlir::memref::AllocaOp>(
+            src))
+      return;
+
+    mlir::memref::StoreOp store;
+    for (auto user : src->getUsers()) {
+      if (mlir::isa<mlir::memref::DeallocOp, mlir::memref::LoadOp>(user))
+        continue;
+
+      auto reshape = mlir::dyn_cast<mlir::memref::ReshapeOp>(user);
+      if (reshape && reshape.getShape() == memref)
+        continue;
+
+      if (mlir::isa<mlir::memref::DeallocOp, mlir::memref::LoadOp>(user))
+        continue;
+
+      auto newStore = mlir::dyn_cast<mlir::memref::StoreOp>(user);
+      if (!newStore || !dom.properlyDominates(newStore, load))
+        return;
+
+      if (load.getType() != newStore.getValueToStore().getType() ||
+          load.getIndices() != newStore.getIndices())
+        continue;
+
+      if (store && dom.properlyDominates(store, newStore))
+        continue;
+
+      store = newStore;
+    }
+
+    if (!store)
+      return;
+
+    load.getResult().replaceAllUsesWith(store.getValueToStore());
+    load->erase();
+    changed = true;
+  });
+
+  return changed;
+}
+
 static mlir::LogicalResult applyOptimizations(
     mlir::func::FuncOp op, const mlir::FrozenRewritePatternSet &patterns,
     mlir::AnalysisManager am,
@@ -91,20 +139,21 @@ static mlir::LogicalResult applyOptimizations(
       repeat = true;
 
     auto memOptRes = imex::optimizeMemoryOps(am);
-    if (!memOptRes) {
-      op.emitError() << "Failed to build memssa analysis";
-      return mlir::failure();
-    }
-    if (mlir::succeeded(*memOptRes)) {
-      repeat = true;
-    }
+    if (!memOptRes)
+      return op.emitError() << "Failed to build memssa analysis";
 
-    if (additionalOpts && mlir::succeeded(additionalOpts(op))) {
+    if (mlir::succeeded(*memOptRes))
       repeat = true;
-    }
-    if (repeat) {
+
+    if (optimizeSimpleLoads(op))
+      repeat = true;
+
+    if (additionalOpts && mlir::succeeded(additionalOpts(op)))
+      repeat = true;
+
+    if (repeat)
       am.invalidate({});
-    }
+
   } while (repeat);
   return mlir::success();
 }


### PR DESCRIPTION
* Add support ntensor cast ops to `ShapeIntegerRangePropagation.cpp`, (TODO: wee need separate interface for this, instead of adding ops into the pass)
* Add simple (and conservative) optimization for the case when some memref alloc has one store and load and no aliases
* Make `LinalgOptPass` composite (Run it wit CSE and shape range passes until fixed point)