### PR TITLE
Refactor reshape handling

### DIFF
--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -368,7 +368,6 @@ struct ReshapeChangeLayout
       return mlir::failure();
 
     auto loc = cl.getLoc();
-
     auto sizesVals = getSizes(rewriter, loc, src);
     auto expectedStrides =
         computeIdentityStrides(rewriter, loc, srcType.getShape(), sizesVals);

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -367,7 +367,7 @@ struct ReshapeChangeLayout
     if (mlir::failed(mlir::getStridesAndOffset(dstType, strides, offset)))
       return mlir::failure();
 
-    auto loc = cl.getLoc();
+    auto loc = op.getLoc();
     auto sizesVals = getSizes(rewriter, loc, src);
     auto expectedStrides =
         computeIdentityStrides(rewriter, loc, srcType.getShape(), sizesVals);


### PR DESCRIPTION
Lower trivial `memref.reshape` to `memref.reinterpret_cast` early