### PR TITLE
Some cleanups

### DIFF
--- a/mlir/lib/Dialect/imex_util/Dialect.cpp
+++ b/mlir/lib/Dialect/imex_util/Dialect.cpp
@@ -1740,12 +1740,6 @@ ExtractMemrefMetadataOp::fold(llvm::ArrayRef<mlir::Attribute> /*operands*/) {
   }
 
   if (auto cast = src.getDefiningOp<mlir::memref::CastOp>()) {
-    auto newSrc = cast.getSource();
-    getSourceMutable().assign(newSrc);
-    return getResult();
-  }
-
-  if (auto cast = src.getDefiningOp<mlir::memref::CastOp>()) {
     auto castSrc = cast.getSource();
     auto castSrcType = castSrc.getType().cast<mlir::ShapedType>();
     auto srcType = src.getType().cast<mlir::ShapedType>();

--- a/mlir/lib/Dialect/imex_util/Dialect.cpp
+++ b/mlir/lib/Dialect/imex_util/Dialect.cpp
@@ -1171,6 +1171,61 @@ struct ChangeLayoutSelect
   }
 };
 
+struct ChangeLayoutEnvRegion
+    : public mlir::OpRewritePattern<imex::util::EnvironmentRegionYieldOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(imex::util::EnvironmentRegionYieldOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto args = op.getResults();
+    llvm::SmallVector<mlir::Value> updatedArgs(args.begin(), args.end());
+
+    bool changed = false;
+    for (auto [i, arg] : llvm::enumerate(args)) {
+      auto cl = arg.getDefiningOp<imex::util::ChangeLayoutOp>();
+      if (!cl)
+        continue;
+
+      updatedArgs[i] = cl.getSource();
+      changed = true;
+    }
+
+    if (!changed)
+      return mlir::failure();
+
+    auto region =
+        mlir::cast<imex::util::EnvironmentRegionOp>(op->getParentOp());
+    rewriter.updateRootInPlace(
+        op, [&]() { op.getResultsMutable().assign(updatedArgs); });
+
+    rewriter.updateRootInPlace(region, [&]() {
+      auto loc = region.getLoc();
+      mlir::OpBuilder::InsertionGuard g(rewriter);
+      rewriter.setInsertionPointAfter(region);
+      for (auto [arg, result] : llvm::zip(updatedArgs, region.getResults())) {
+        auto oldType = result.getType();
+        auto newType = arg.getType();
+        if (newType == oldType)
+          continue;
+
+        auto cast =
+            rewriter.create<imex::util::ChangeLayoutOp>(loc, oldType, result);
+        mlir::Value newResult = cast.getResult();
+        for (auto &use : llvm::make_early_inc_range(result.getUses())) {
+          auto owner = use.getOwner();
+          if (owner == cast)
+            continue;
+
+          rewriter.updateRootInPlace(owner, [&]() { use.set(newResult); });
+        }
+        result.setType(newType);
+      }
+    });
+    return mlir::success();
+  }
+};
+
 } // namespace
 
 void ChangeLayoutOp::getCanonicalizationPatterns(
@@ -1181,7 +1236,8 @@ void ChangeLayoutOp::getCanonicalizationPatterns(
       ChangeLayoutFromCast, ChangeLayoutLoad, ChangeLayoutStore,
       ChangeLayoutSubview, ChangeLayoutLinalgGeneric, ChangeLayoutLinalgFill,
       ChangeLayoutIf, ChangeLayout1DReshape, ChangeLayoutSliceGetItem,
-      ChangeLayoutCopy, ChangeLayoutExpandShape, ChangeLayoutSelect>(context);
+      ChangeLayoutCopy, ChangeLayoutExpandShape, ChangeLayoutSelect,
+      ChangeLayoutEnvRegion>(context);
 }
 
 static mlir::Value propagateCasts(mlir::Value val, mlir::Type thisType);

--- a/mlir/test/Transforms/expand-tuple.mlir
+++ b/mlir/test/Transforms/expand-tuple.mlir
@@ -1,8 +1,29 @@
-// RUN: imex-opt --expand-tuple --canonicalize --split-input-file %s | FileCheck %s
+// RUN: imex-opt -allow-unregistered-dialect --expand-tuple --canonicalize --split-input-file %s | FileCheck %s
 
 func.func @test(%arg1: tuple<index, i64>) -> tuple<index, i64> {
   return %arg1 : tuple<index, i64>
 }
 // CHECK-LABEL: func @test
 //  CHECK-SAME:   (%[[ARG1:.*]]: index, %[[ARG2:.*]]: i64)
-//  CHECK-NEXT: return %[[ARG1]], %[[ARG2]] : index, i64
+//  CHECK-NEXT:   return %[[ARG1]], %[[ARG2]] : index, i64
+
+// -----
+
+func.func @test() -> tuple<index, i64> {
+  %0 = imex_util.env_region "test" -> tuple<index, i64> {
+    %1 = "test.test"() : () -> tuple<index, i64>
+    imex_util.env_region_yield %1: tuple<index, i64>
+  }
+  return %0 : tuple<index, i64>
+}
+
+// CHECK-LABEL: func @test
+//       CHECK: %[[C1:.*]] = arith.constant 1 : index
+//       CHECK: %[[C0:.*]] = arith.constant 0 : index
+//       CHECK: %[[RES:.*]]:2 = imex_util.env_region "test" -> index, i64 {
+//       CHECK: %[[TUP:.*]] = "test.test"() : () -> tuple<index, i64>
+//       CHECK: %[[E1:.*]] = imex_util.tuple_extract %[[TUP]] : tuple<index, i64>, %[[C0]] -> index
+//       CHECK: %[[E2:.*]] = imex_util.tuple_extract %[[TUP]] : tuple<index, i64>, %[[C1]] -> i64
+//       CHECK: imex_util.env_region_yield %[[E1]], %[[E2]] : index, i64
+//       CHECK: }
+//       CHECK: return %[[RES]]#0, %[[RES]]#1 : index, i64


### PR DESCRIPTION
* Cleanup `unstrideMemrefPass` patterns
* Fix `ExtractMemrefMetadataOp` folder
* Add env region support to `ChangeLayoutOp` canonicalizations
* Add enc region support to `expand-tuple` pass