### PR TITLE
Move BufferDeallocationPass after linalg lowering, othwewise it can g…

### DIFF
--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -3009,18 +3009,22 @@ static void populatePlierToLinalgOptPipeline(mlir::OpPassManager &pm) {
   pm.addPass(std::make_unique<OptimizeStridedLayoutPass>());
   pm.addNestedPass<mlir::func::FuncOp>(
       std::make_unique<FinalizeStridedLayoutPass>());
-  pm.addNestedPass<mlir::func::FuncOp>(
-      mlir::bufferization::createBufferDeallocationPass());
-  pm.addPass(mlir::createCanonicalizerPass());
 
-  pm.addNestedPass<mlir::func::FuncOp>(std::make_unique<LowerCloneOpsPass>());
-  pm.addNestedPass<mlir::func::FuncOp>(std::make_unique<LowerCopyOpsPass>());
-  pm.addPass(mlir::createCanonicalizerPass());
+  pm.addNestedPass<mlir::func::FuncOp>(mlir::createCanonicalizerPass());
+
   //  pm.addNestedPass<mlir::func::FuncOp>(
   //      mlir::bufferization::createPromoteBuffersToStackPass());
 
   pm.addNestedPass<mlir::func::FuncOp>(
       mlir::createConvertLinalgToParallelLoopsPass());
+  pm.addNestedPass<mlir::func::FuncOp>(mlir::createCanonicalizerPass());
+  pm.addNestedPass<mlir::func::FuncOp>(
+      mlir::bufferization::createBufferDeallocationPass());
+  pm.addNestedPass<mlir::func::FuncOp>(std::make_unique<LowerCloneOpsPass>());
+  pm.addNestedPass<mlir::func::FuncOp>(std::make_unique<LowerCopyOpsPass>());
+  pm.addNestedPass<mlir::func::FuncOp>(
+      mlir::createConvertLinalgToParallelLoopsPass());
+  pm.addNestedPass<mlir::func::FuncOp>(mlir::createCanonicalizerPass());
   pm.addPass(imex::createForceInlinePass());
   pm.addPass(mlir::createSymbolDCEPass());
 


### PR DESCRIPTION
…enerate invalid IR.

Another round of linalg lowering is needed after `LowerCopyOpsPass` because we are lowering memref copy to linalg.generic.

