### PR TITLE
Fix a build error when IMEX_ENABLE_IGPU_DIALECT is OFF

### DIFF
--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/Lowering.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/Lowering.cpp
@@ -708,7 +708,7 @@ static void createPipeline(imex::PipelineRegistry &registry,
     registerLowerToGPUPipeline(registry);
     // TODO(nbpatel): Add Gpu->GpuRuntime & GpuRuntimetoLlvm Transformation
 #else
-    plier::reportError("DPCOMP was compiled without GPU support");
+    imex::reportError("DPCOMP was compiled without GPU support");
 #endif
   }
 }


### PR DESCRIPTION
Fix a build error when IMEX_ENABLE_IGPU_DIALECT is OFF. `reportError` does not belong to namespace `plier`.

Please review these guidelines to help with the review process:
- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
- [x] Have you organized your commits logically and ensured each can be built by itself?
