### PR TITLE
Fixed for GPU deformable workload

### DIFF
--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpu.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/LowerToGpu.cpp
@@ -564,8 +564,7 @@ struct OutlineInitPass
       auto funcName = func.getName();
       initOps.clear();
       deinitOps.clear();
-      for (auto &op : body.front())
-        tryOutlineOp(op);
+      func->walk([&](mlir::Operation *op) { tryOutlineOp(*op); });
 
       if (!initOps.empty()) {
         builder.setInsertionPointToStart(mod.getBody());

--- a/numba_dpcomp/numba_dpcomp/python_runtime/lib/Boxing.cpp
+++ b/numba_dpcomp/numba_dpcomp/python_runtime/lib/Boxing.cpp
@@ -116,7 +116,7 @@ dpcompUnboxSyclInterface(PyObject *obj, arystruct_t *arystruct) {
     npy_intp stride = itemsize;
     for (decltype(ndim) i = 0; i < ndim; i++) {
       strides[ndim - i - 1] = stride;
-      stride *= dims[i];
+      stride *= dims[ndim - i - 1];
     }
   } else {
     for (decltype(ndim) i = 0; i < ndim; i++) {


### PR DESCRIPTION
* Fix incorrect strides calculation in usm arrays unboxing
* Pull `arith` and `math` ops into device region, which is NFC by itself, but allows more aggressive region merging
* Improve `OutlineInitPass` to allow outlining ops inside nested regions.
