### PR TITLE
More GPU reductions fixes and tests

### DIFF
--- a/mlir/lib/Conversion/GpuToGpuRuntime.cpp
+++ b/mlir/lib/Conversion/GpuToGpuRuntime.cpp
@@ -200,8 +200,8 @@ struct InsertGPUAllocs
                   if (op) {
                     if (mlir::isa<mlir::scf::SCFDialect>(op->getDialect()) ||
                         mlir::isa<mlir::ViewLikeOpInterface,
-                                  mlir::arith::SelectOp, mlir::func::CallOp>(
-                            op))
+                                  mlir::arith::SelectOp, mlir::func::CallOp,
+                                  imex::util::EnvironmentRegionOp>(op))
                       // Ignore
                       continue;
                     if (mlir::isa<mlir::memref::AllocOp,

--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_gpu.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_gpu.py
@@ -1127,12 +1127,14 @@ _shapes = (1, 7, 16, 25, 64, 65)
     "py_func",
     [
         "lambda a: a.sum()",
+        "lambda a: a.sum(axis=0)",
+        "lambda a: a.sum(axis=1)",
     ],
 )
 @pytest.mark.parametrize("shape", itertools.product(_shapes, _shapes))
 @pytest.mark.parametrize("dtype", [np.int32, np.int64, np.float32])
 def test_cfd_reduce2(py_func, shape, dtype):
-    if shape == (1, 1):
+    if shape[0] == 1 or shape[1] == 1:
         # TODO: Handle gpu array access outside the loops
         pytest.xfail()
 

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -2988,7 +2988,7 @@ struct FixDeallocPlacementPass
                                       mlir::func::FuncOp, void,
                                       FixDeallocPlacement> {};
 
-/// Move reduction iterators to the left to help later reduction simplification
+/// Move reduction iterators to the right to help later reduction simplification
 /// passes.
 struct MakeGenericReduceInnermost
     : public mlir::OpRewritePattern<mlir::linalg::GenericOp> {


### PR DESCRIPTION
* Add pass to move `linalg.generic` reduction iterators right to help later reduction uplifting passes
* Add `EnvironmentRegionOp` support to `InsertGPUAllocs`
* More tests
