### PR TITLE
[Profiling] add profiling code to get kernel submit/execute time

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,8 @@ Add '-v' to the above command-line to get verbose output.
 ## License
 This code is made available under the Apache License 2.0 with LLVM Exceptions.
 See the `LICENSE.txt` file for more details.
+
+## Profiling kernel execute time
+```sh
+export IMEX_ENABLE_PROFILING=ON
+```

--- a/README.md
+++ b/README.md
@@ -152,6 +152,16 @@ This code is made available under the Apache License 2.0 with LLVM Exceptions.
 See the `LICENSE.txt` file for more details.
 
 ## Profiling kernel execute time
+### sycl event
 ```sh
 export IMEX_ENABLE_PROFILING=ON
+run the test
+```
+### trace tools
+```sh
+python {your_path}/imex_runner.py xxx -o test.mlir
+mlir-translate test.mlir -mlir-to-llvmir -o test.ll
+llc test.ll -filetype=obj -o test.o
+clang++ test.o {path}/libmlir_runner_utils.so {path}/libmlir_c_runner_utils.so {path}/libsycl-runtime.so -no-pie -o test
+ze_tracer ./test
 ```

--- a/include/imex/Transforms/Passes.td
+++ b/include/imex/Transforms/Passes.td
@@ -46,6 +46,7 @@ def InsertGPUAllocs : Pass<"insert-gpu-allocs", "::mlir::func::FuncOp"> {
 def SetSPIRVCapabilities : Pass<"set-spirv-capabilities"> {
   let summary = "Sets Spirv capabilities";
   let constructor = "imex::createSetSPIRVCapabilitiesPass()";
+  let dependentDialects = ["::mlir::spirv::SPIRVDialect"];
   let options = [
     Option<"clientAPI", "client-api", "std::string", /*default=*/"\"vulkan\"",
            "The client API to use for setting Spirv capabilities">

--- a/tools/imex-runner/imex-runner.py.in
+++ b/tools/imex-runner/imex-runner.py.in
@@ -73,6 +73,7 @@ parser = argparse.ArgumentParser(
     description="Run imex-opt, optionally pipe result into selected mlir runner (default: mlir-cpu-runner) and then optionally pipe output into FileCheck"
 )
 parser.add_argument("--input-file", "-i", default=None, help="input MLIR file")
+parser.add_argument("--output-file", "-o", default=None, help="output MLIR file")
 parser.add_argument("--pass-pipeline-file", "-f", default=None, help="file defining pass pipeline")
 parser.add_argument("--pass-pipeline", "-p", default=None, help="pass pipeline (string)")
 parser.add_argument("--imex-print-before-all", "-b", action='store_true', dest='before', help="print ir before all passes")
@@ -163,6 +164,12 @@ if args.before:
     cmd.append(f'--mlir-print-ir-before-all')
 if args.after:
     cmd.append(f'--mlir-print-ir-after-all')
+cmds.append(cmd)
+
+# output to a file
+if args.output_file:
+    cmd=['tee']
+    cmd.append(args.output_file)
 cmds.append(cmd)
 
 # build runner command


### PR DESCRIPTION
take test/PlaidML/OpTest.EltwiseAdd.mlir for example, we can get the following result.
the kernel execution time is 0.082560 ms
the kernel submission time is 97647.601562 ms  
( this duration is obviously wrong cause the test is done within 3 seconds, still trying to find the reason)


Please review these guidelines to help with the review process:
- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
- [x] Have you organized your commits logically and ensured each can be built by itself?
