### PR TITLE
Linalg matmul converter 2

### DIFF
--- a/include/imex/Conversion/Passes.td
+++ b/include/imex/Conversion/Passes.td
@@ -333,7 +333,7 @@ def ConvertGPUXToLLVM : Pass<"convert-gpux-to-llvm", "::mlir::ModuleOp"> {
 // LinalgToSPIRV
 //===----------------------------------------------------------------------===//
 
-def ConvertLinalgToSPIRV: Pass<"convert-linalg-to-spirv", "::mlir::ModuleOp"> {
+def ConvertLinalgToSPIRV: Pass<"imex-convert-linalg-to-spirv", "::mlir::ModuleOp"> {
   let summary = "Convert from the Linalg dialect to the SPIRV dialect.";
   let description = [{
     Convert Linalg dialect operations into the SPIRV dialect operations.

--- a/test/Conversion/LinalgToSPIRV/LinalgToSPIRV.mlir
+++ b/test/Conversion/LinalgToSPIRV/LinalgToSPIRV.mlir
@@ -1,1 +1,10 @@
-// RUN: imex-opt --split-input-file --convert-linalg-to-spirv %s -verify-diagnostics -o -| FileCheck %s
+// RUN: imex-opt -allow-unregistered-dialect -imex-convert-linalg-to-spirv %s -verify-diagnostics -o -| FileCheck %s
+
+// CHECK-LABEL: func.func @simple_constant
+func.func @simple_constant() -> (i32) {
+  // CHECK-NEXT: %[[RESULT:.*]] = arith.constant 1
+  // CHECK-NEXT: return %[[RESULT]]
+
+  %0 = arith.constant 1 : i32
+  return %0 : i32
+}


### PR DESCRIPTION
This PR is a small fix for #563 because name of the pass interfere with "upstream" LLVM/MLIR
- added prefix "imex" for pass name
- added "empty" test to sutisfy test system at this moment