### PR TITLE
Add more ntensor canonicalizers

### DIFF
--- a/mlir/include/imex/Dialect/ntensor/IR/NTensorOps.td
+++ b/mlir/include/imex/Dialect/ntensor/IR/NTensorOps.td
@@ -374,6 +374,8 @@ def SubviewOp : NTensor_OpWithOffsetSizesAndStrides<"subview", [
 
     ::mlir::Value getViewSource() { return getSource(); }
   }];
+
+  let hasFolder = 1;
 }
 
 def LoadOp : NTensor_OpBase<"load",

--- a/mlir/test/Dialect/ntensor/canonicalize.mlir
+++ b/mlir/test/Dialect/ntensor/canonicalize.mlir
@@ -293,3 +293,35 @@ func.func @test(%arg1: f32, %arg2: f32, %arg3: f32) -> f32 {
 // CHECK-LABEL: func @test
 //  CHECK-SAME:   (%[[ARG1:.*]]: f32, %[[ARG2:.*]]: f32, %[[ARG3:.*]]: f32)
 //  CHECK-NEXT:   return %[[ARG2]] : f32
+
+// -----
+
+func.func @test(%t: !ntensor.ntensor<?x?xf32>) -> !ntensor.ntensor<?x?xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+
+  %1 = ntensor.dim %t, %c0 : !ntensor.ntensor<?x?xf32>
+  %2 = ntensor.dim %t, %c1 : !ntensor.ntensor<?x?xf32>
+
+  %3 = ntensor.subview %t[%c0, %c0][%1, %2][%c1, %c1] : !ntensor.ntensor<?x?xf32> to !ntensor.ntensor<?x?xf32>
+  return %3 : !ntensor.ntensor<?x?xf32>
+}
+// CHECK-LABEL: func @test
+//  CHECK-SAME:   (%[[ARG:.*]]: !ntensor.ntensor<?x?xf32>)
+//       CHECK:   return %[[ARG]] : !ntensor.ntensor<?x?xf32>
+
+// -----
+
+func.func @test(%t: !ntensor.ntensor<?x2xf32>) -> !ntensor.ntensor<?x2xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+
+  %1 = ntensor.dim %t, %c0 : !ntensor.ntensor<?x2xf32>
+
+  %3 = ntensor.subview %t[%c0, %c0][%1, 2][%c1, %c1] : !ntensor.ntensor<?x2xf32>  to !ntensor.ntensor<?x2xf32>
+  return %3 : !ntensor.ntensor<?x2xf32>
+}
+// CHECK-LABEL: func @test
+//  CHECK-SAME:   (%[[ARG:.*]]: !ntensor.ntensor<?x2xf32>)
+//       CHECK:   return %[[ARG]] : !ntensor.ntensor<?x2xf32>

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -3137,6 +3137,7 @@ static void populateCommonOptPass(mlir::OpPassManager &pm) {
 static void populatePlierToLinalgGenPipeline(mlir::OpPassManager &pm) {
   pm.addNestedPass<mlir::func::FuncOp>(
       std::make_unique<MarkContigiousArraysPass>());
+  pm.addPass(std::make_unique<MarkArgsRestrictPass>());
   pm.addPass(std::make_unique<PlierToNtensorPass>());
   pm.addNestedPass<mlir::func::FuncOp>(mlir::createCanonicalizerPass());
   pm.addPass(std::make_unique<ResolveNumpyFuncsPass>());


### PR DESCRIPTION
* Add canonicalizer for identity subview (i.e. when offsets are 0s, strides are 1s and sizes equal to original array)
* Add `MarkArgsRestrictPass` earlier to help copy removal pass
