### PR TITLE
Remove `ForceCopyOp` and related refactoring

### DIFF
--- a/mlir/include/imex/Dialect/imex_util/ImexUtilOps.td
+++ b/mlir/include/imex/Dialect/imex_util/ImexUtilOps.td
@@ -184,18 +184,6 @@ def ExtractMemrefMetadataOp
   ];
 }
 
-def ForceCopyOp : ImexUtil_Op<"force_copy", [ViewLikeOpInterface]> {
-  let arguments = (ins AnyRankedTensor : $source);
-
-  let results = (outs AnyRankedTensor);
-
-  let builders = [OpBuilder<(ins "::mlir::Value" : $value)>];
-
-  let extraClassDeclaration = [{
-      ::mlir::Value getViewSource() { return getSource(); }
-  }];
-}
-
 def TakeContextOp : ImexUtil_Op<"take_context"> {
   let arguments = (ins OptionalAttr<SymbolRefAttr>:$initFunc,
                        OptionalAttr<SymbolRefAttr>:$releaseFunc);

--- a/mlir/lib/Conversion/NtensorToLinalg.cpp
+++ b/mlir/lib/Conversion/NtensorToLinalg.cpp
@@ -11,6 +11,7 @@
 #include <mlir/Analysis/AliasAnalysis.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Linalg/IR/Linalg.h>
+#include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/Dialect/Tensor/IR/Tensor.h>
 #include <mlir/IR/FunctionInterfaces.h>
@@ -666,10 +667,6 @@ struct NtensorAliasAnalysisPass
     auto &context = getContext();
     auto func = getOperation();
 
-    auto *ntensorDialect =
-        context.getOrLoadDialect<imex::ntensor::NTensorDialect>();
-    assert(ntensorDialect);
-
     llvm::SmallVector<mlir::Operation *, 0> writers;
     func->walk([&](mlir::Operation *op) {
       if (mlir::isa<mlir::CallOpInterface>(op)) {
@@ -677,7 +674,8 @@ struct NtensorAliasAnalysisPass
         return;
       }
 
-      if (op->getDialect() != ntensorDialect)
+      if (!mlir::isa<mlir::memref::MemRefDialect, mlir::linalg::LinalgDialect,
+                     imex::ntensor::NTensorDialect>(op->getDialect()))
         return;
 
       auto memInterface = mlir::dyn_cast<mlir::MemoryEffectOpInterface>(op);

--- a/mlir/lib/Conversion/NtensorToLinalg.cpp
+++ b/mlir/lib/Conversion/NtensorToLinalg.cpp
@@ -32,6 +32,9 @@ struct ConvertCreateOp
   mlir::LogicalResult
   matchAndRewrite(imex::ntensor::CreateArrayOp op,
                   mlir::PatternRewriter &rewriter) const override {
+    if (!op->hasAttr(kReadonly))
+      return mlir::failure();
+
     auto dstType = op.getType().dyn_cast<imex::ntensor::NTensorType>();
     if (!dstType)
       return mlir::failure();
@@ -694,6 +697,9 @@ struct NtensorAliasAnalysisPass
       assert(op);
       if (auto subview = mlir::dyn_cast<imex::ntensor::SubviewOp>(op))
         return subview.getResult();
+
+      if (auto create = mlir::dyn_cast<imex::ntensor::CreateArrayOp>(op))
+        return create.getResult();
 
       return {};
     };

--- a/mlir/lib/Dialect/imex_util/Dialect.cpp
+++ b/mlir/lib/Dialect/imex_util/Dialect.cpp
@@ -1818,11 +1818,6 @@ ExtractMemrefMetadataOp::fold(llvm::ArrayRef<mlir::Attribute> /*operands*/) {
   return nullptr;
 }
 
-void ForceCopyOp::build(mlir::OpBuilder &b, mlir::OperationState &result,
-                        mlir::Value source) {
-  build(b, result, source.getType(), source);
-}
-
 void TakeContextOp::build(mlir::OpBuilder &b, mlir::OperationState &result,
                           mlir::SymbolRefAttr initFunc,
                           mlir::SymbolRefAttr releaseFunc,

--- a/mlir/lib/Transforms/MakeSignless.cpp
+++ b/mlir/lib/Transforms/MakeSignless.cpp
@@ -7,6 +7,7 @@
 #include "imex/Dialect/imex_util/Dialect.hpp"
 #include "imex/Transforms/TypeConversion.hpp"
 
+#include <mlir/Dialect/Bufferization/IR/Bufferization.h>
 #include <mlir/Dialect/Linalg/IR/Linalg.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/Tensor/IR/Tensor.h>
@@ -14,6 +15,75 @@
 #include <mlir/Transforms/DialectConversion.h>
 
 namespace {
+struct ConvertChangeLayout
+    : public mlir::OpConversionPattern<imex::util::ChangeLayoutOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(imex::util::ChangeLayoutOp op,
+                  imex::util::ChangeLayoutOp::Adaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto converter = getTypeConverter();
+    assert(converter);
+
+    auto oldResType = op.getType();
+    auto newResType =
+        converter->convertType(oldResType).dyn_cast_or_null<mlir::MemRefType>();
+    if (!newResType)
+      return mlir::failure();
+
+    rewriter.replaceOpWithNewOp<imex::util::ChangeLayoutOp>(
+        op, newResType, adaptor.getSource());
+    return mlir::success();
+  }
+};
+
+struct ConvertToMemref
+    : public mlir::OpConversionPattern<mlir::bufferization::ToMemrefOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::bufferization::ToMemrefOp op,
+                  mlir::bufferization::ToMemrefOp::Adaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto converter = getTypeConverter();
+    assert(converter);
+
+    auto oldResType = op.getType();
+    auto newResType =
+        converter->convertType(oldResType).dyn_cast_or_null<mlir::MemRefType>();
+    if (!newResType)
+      return mlir::failure();
+
+    rewriter.replaceOpWithNewOp<mlir::bufferization::ToMemrefOp>(
+        op, newResType, adaptor.getTensor());
+    return mlir::success();
+  }
+};
+
+struct ConvertToTensor
+    : public mlir::OpConversionPattern<mlir::bufferization::ToTensorOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::bufferization::ToTensorOp op,
+                  mlir::bufferization::ToTensorOp::Adaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto converter = getTypeConverter();
+    assert(converter);
+
+    auto oldResType = op.getType();
+    auto newResType = converter->convertType(oldResType)
+                          .dyn_cast_or_null<mlir::RankedTensorType>();
+    if (!newResType)
+      return mlir::failure();
+
+    rewriter.replaceOpWithNewOp<mlir::bufferization::ToTensorOp>(
+        op, newResType, adaptor.getMemref());
+    return mlir::success();
+  }
+};
+
 template <typename Op>
 struct ConvertAlloc : public mlir::OpConversionPattern<Op> {
   using mlir::OpConversionPattern<Op>::OpConversionPattern;
@@ -317,15 +387,17 @@ void imex::populateMakeSignlessRewritesAndTarget(
   converter.addTargetMaterialization(materializeSignCast);
 
   target.addDynamicallyLegalOp<
-      mlir::memref::AllocOp, mlir::memref::AllocaOp, mlir::memref::DeallocOp,
-      mlir::memref::SubViewOp, mlir::tensor::EmptyOp,
-      mlir::tensor::FromElementsOp, mlir::tensor::ExpandShapeOp,
-      mlir::tensor::ReshapeOp, mlir::tensor::ExtractSliceOp,
-      mlir::tensor::InsertSliceOp, mlir::linalg::FillOp,
-      mlir::linalg::GenericOp, mlir::linalg::YieldOp>(
+      imex::util::ChangeLayoutOp, mlir::bufferization::ToMemrefOp,
+      mlir::bufferization::ToTensorOp, mlir::memref::AllocOp,
+      mlir::memref::AllocaOp, mlir::memref::DeallocOp, mlir::memref::SubViewOp,
+      mlir::tensor::EmptyOp, mlir::tensor::FromElementsOp,
+      mlir::tensor::ExpandShapeOp, mlir::tensor::ReshapeOp,
+      mlir::tensor::ExtractSliceOp, mlir::tensor::InsertSliceOp,
+      mlir::linalg::FillOp, mlir::linalg::GenericOp, mlir::linalg::YieldOp>(
       [&converter](mlir::Operation *op) { return converter.isLegal(op); });
 
-  patterns.insert<ConvertAlloc<mlir::memref::AllocOp>,
+  patterns.insert<ConvertChangeLayout, ConvertToMemref, ConvertToTensor,
+                  ConvertAlloc<mlir::memref::AllocOp>,
                   ConvertAlloc<mlir::memref::AllocaOp>, ConvertDealloc,
                   ConvertSubview, ConvertTensorEmpty, ConvertTensorFromElements,
                   ConvertTensorExpandShape, ConvertTensorReshape,
@@ -342,6 +414,7 @@ struct MakeSignlessPass
   virtual void
   getDependentDialects(mlir::DialectRegistry &registry) const override {
     registry.insert<imex::util::ImexUtilDialect>();
+    registry.insert<mlir::bufferization::BufferizationDialect>();
     registry.insert<mlir::linalg::LinalgDialect>();
     registry.insert<mlir::memref::MemRefDialect>();
     registry.insert<mlir::tensor::TensorDialect>();

--- a/mlir/lib/Transforms/MakeSignless.cpp
+++ b/mlir/lib/Transforms/MakeSignless.cpp
@@ -235,28 +235,6 @@ struct ConvertLinalgYield
     return mlir::success();
   }
 };
-
-struct ConvertForceCopy
-    : public mlir::OpConversionPattern<imex::util::ForceCopyOp> {
-  using OpConversionPattern::OpConversionPattern;
-
-  mlir::LogicalResult
-  matchAndRewrite(imex::util::ForceCopyOp op,
-                  imex::util::ForceCopyOp::Adaptor adaptor,
-                  mlir::ConversionPatternRewriter &rewriter) const override {
-    auto converter = this->getTypeConverter();
-    assert(converter);
-
-    auto oldResType = op.getType();
-    auto newResType = converter->convertType(oldResType);
-    if (!newResType)
-      return mlir::failure();
-
-    rewriter.replaceOpWithNewOp<imex::util::ForceCopyOp>(op, newResType,
-                                                         adaptor.getSource());
-    return mlir::success();
-  }
-};
 } // namespace
 
 static llvm::Optional<mlir::Type> makeSignlessType(mlir::Type type) {
@@ -291,15 +269,14 @@ void imex::populateMakeSignlessRewritesAndTarget(
       mlir::tensor::EmptyOp, mlir::tensor::FromElementsOp,
       mlir::tensor::ExpandShapeOp, mlir::tensor::ReshapeOp,
       mlir::tensor::InsertSliceOp, mlir::linalg::FillOp,
-      mlir::linalg::GenericOp, mlir::linalg::YieldOp, imex::util::ForceCopyOp>(
+      mlir::linalg::GenericOp, mlir::linalg::YieldOp>(
       [&converter](mlir::Operation *op) { return converter.isLegal(op); });
 
-  patterns.insert<ConvertAlloc<mlir::memref::AllocOp>,
-                  ConvertAlloc<mlir::memref::AllocaOp>, ConvertDealloc,
-                  ConvertTensorEmpty, ConvertTensorFromElements,
-                  ConvertTensorExpandShape, ConvertTensorReshape,
-                  ConvertTensorInserSlice, ConvertLinalgFill,
-                  ConvertLinalgGeneric, ConvertLinalgYield, ConvertForceCopy>(
+  patterns.insert<
+      ConvertAlloc<mlir::memref::AllocOp>, ConvertAlloc<mlir::memref::AllocaOp>,
+      ConvertDealloc, ConvertTensorEmpty, ConvertTensorFromElements,
+      ConvertTensorExpandShape, ConvertTensorReshape, ConvertTensorInserSlice,
+      ConvertLinalgFill, ConvertLinalgGeneric, ConvertLinalgYield>(
       converter, patterns.getContext());
 }
 

--- a/numba_dpcomp/numba_dpcomp/mlir/numpy/funcs.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/numpy/funcs.py
@@ -739,7 +739,7 @@ def getitem_impl(builder, arr, index):
 
 
 @register_func("array.__setitem__")
-def getitem_impl(builder, arr, index, val):
+def setitem_impl(builder, arr, index, val):
     if index.dtype != builder.bool:
         return
 
@@ -748,7 +748,6 @@ def getitem_impl(builder, arr, index, val):
     val = flatten_impl(builder, val)
 
     def func(a, ind, val):
-        a = a.copy()  # TODO: investigate
         s = a.size
         res = numpy.empty((s,), a.dtype)
         curr = 0

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/PyLinalgResolver.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/PyLinalgResolver.cpp
@@ -695,42 +695,30 @@ static py::object initTensorImpl(py::capsule context, py::iterable shape,
   auto loc = ctx.loc;
   auto &builder = ctx.builder;
   auto elemType = unwrapType(dtype);
-  mlir::Value init;
+
   auto indexType = builder.getIndexType();
   auto count = py::len(shape);
-  llvm::SmallVector<mlir::Value> shapeVal(count);
+  llvm::SmallVector<mlir::Value> dynamicShape;
   llvm::SmallVector<int64_t> staticShape(count, mlir::ShapedType::kDynamic);
-  for (auto it : llvm::enumerate(shape)) {
-    auto i = it.index();
-    auto elem = it.value();
+  for (auto [i, elem] : llvm::enumerate(shape)) {
     auto elemVal = ctx.context.unwrapVal(loc, builder, elem, indexType);
-    if (auto constVal = mlir::getConstantIntValue(elemVal))
+    if (auto constVal = mlir::getConstantIntValue(elemVal)) {
       staticShape[i] = *constVal;
-
-    shapeVal[i] = elemVal;
+    } else {
+      dynamicShape.emplace_back(elemVal);
+    }
   }
 
-  if (initVal.is_none()) {
-    init = builder.create<mlir::tensor::EmptyOp>(loc, getTempShape(shapeVal),
-                                                 elemType);
-  } else {
-    auto val = doCast(builder, loc,
-                      ctx.context.unwrapVal(loc, builder, initVal), elemType);
-    llvm::SmallVector<int64_t> shape(count, mlir::ShapedType::kDynamic);
-    auto type = mlir::RankedTensorType::get(shape, elemType);
-    auto body = [&](mlir::OpBuilder &builder, mlir::Location loc,
-                    mlir::ValueRange /*indices*/) {
-      builder.create<mlir::tensor::YieldOp>(loc, val);
-    };
-    init = builder.create<mlir::tensor::GenerateOp>(loc, type, shapeVal, body);
+  mlir::Value init;
+  if (!initVal.is_none()) {
+    init = doCast(builder, loc, ctx.context.unwrapVal(loc, builder, initVal),
+                  elemType);
   }
 
-  if (llvm::any_of(staticShape, [](auto val) { return val >= 0; })) {
-    auto newType = mlir::RankedTensorType::get(staticShape, elemType);
-    init = builder.create<mlir::tensor::CastOp>(loc, newType, init);
-  }
-
-  return ctx.context.createVar(context, init);
+  auto resType = imex::ntensor::NTensorType::get(staticShape, elemType);
+  mlir::Value res = builder.create<imex::ntensor::CreateArrayOp>(
+      loc, resType, dynamicShape, init);
+  return ctx.context.createVar(context, res);
 }
 
 static py::object fillTensorImpl(py::capsule context, py::handle tensor,


### PR DESCRIPTION
* Replace `ForceCopyOp` with `ntensor.create` + `ntesnor.copy`
* Do not convert `ntensor.create` to `tensor.empty` if it can be potentially written to
* Add more patterns to `ntensor-to-memref` and `make-signless` passes
