### PR TITLE
FIxes for builder external call API

### DIFF
--- a/mlir/lib/Analysis/MemorySsa.cpp
+++ b/mlir/lib/Analysis/MemorySsa.cpp
@@ -4,6 +4,8 @@
 
 #include "imex/Analysis/MemorySsa.hpp"
 
+#include <mlir/IR/BuiltinTypes.h>
+#include <mlir/Interfaces/CallInterfaces.h>
 #include <mlir/Interfaces/ControlFlowInterfaces.h>
 #include <mlir/Interfaces/LoopLikeInterface.h>
 #include <mlir/Interfaces/SideEffectInterfaces.h>
@@ -404,6 +406,14 @@ auto hasMemEffect(mlir::Operation &op) {
       ret.read = true;
   } else if (op.hasTrait<mlir::OpTrait::HasRecursiveMemoryEffects>()) {
     ret.write = true;
+  } else if (mlir::isa<mlir::CallOpInterface>(op)) {
+    for (auto arg : op.getOperands()) {
+      if (arg.getType().isa<mlir::MemRefType>()) {
+        ret.read = true;
+        ret.write = true;
+        break;
+      }
+    }
   }
   return ret;
 }


### PR DESCRIPTION
* Make MemSSA analysis consider func calls as potential read/write if it takes memref as inputs
* Make `externalCallImpl` use ntensor type for input/output arrays to avoid undesired folding