### PR TITLE
Add LLVM_INCLUDE_DIRS if building IMEX with external LLVM build tree.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,8 +77,15 @@ else()
     set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
     set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
 
-    # LLVM_INCLUDE_DIRS is the same as MLIR_INCLUDE_DIRS in an MLIR install tree
     include_directories(${MLIR_INCLUDE_DIRS})
+    if(DEFINED LLVM_BUILD_BINARY_DIR)
+        message(STATUS "Building IMEX with external MLIR build tree")
+        # LLVM_INCLUDE_DIRS needs to added if MLIR build tree is used.
+        include_directories(${LLVM_INCLUDE_DIRS})
+    else()
+        message(STATUS "Building IMEX with external MLIR install tree")
+        # LLVM_INCLUDE_DIRS is the same as MLIR_INCLUDE_DIRS in an MLIR install tree
+    endif()
 
     list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
     list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")


### PR DESCRIPTION
Should fix compilation error like
fatal error: llvm/ADT/None.h: No such file or directory   23 | #include "llvm/ADT/None.h"      |          ^~~~~~~~~~~~~~~~~ compilation terminated.
when building IMEX with an external mlir build tree (not an install tree)

Please review these guidelines to help with the review process:
- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [ ] Have you organized your commits logically and ensured each can be built by itself?
