### PR TITLE
Unstride memref pass refactoring

### DIFF
--- a/mlir/lib/Conversion/GpuToGpuRuntime.cpp
+++ b/mlir/lib/Conversion/GpuToGpuRuntime.cpp
@@ -530,6 +530,63 @@ static mlir::Value getFlatIndex(mlir::OpBuilder &builder, mlir::Location loc,
   }
 }
 
+// TODO: copypasted from upstream.
+static std::pair<mlir::OpFoldResult, llvm::SmallVector<mlir::OpFoldResult>>
+getFlatOffsetAndStrides(mlir::OpBuilder &rewriter, mlir::Location loc,
+                        mlir::Value source,
+                        llvm::ArrayRef<mlir::OpFoldResult> subOffsets,
+                        llvm::ArrayRef<mlir::OpFoldResult> subStrides) {
+  auto sourceType = source.getType().cast<mlir::MemRefType>();
+  unsigned sourceRank = sourceType.getRank();
+
+  auto newExtractStridedMetadata =
+      rewriter.create<mlir::memref::ExtractStridedMetadataOp>(loc, source);
+
+  auto [sourceStrides, sourceOffset] = getStridesAndOffset(sourceType);
+
+  // Compute the new strides and offset from the base strides and offset:
+  // newStride#i = baseStride#i * subStride#i
+  // offset = baseOffset + sum(subOffsets#i * newStrides#i)
+  llvm::SmallVector<mlir::OpFoldResult> strides;
+  auto origStrides = newExtractStridedMetadata.getStrides();
+
+  // Hold the affine symbols and values for the computation of the offset.
+  llvm::SmallVector<mlir::OpFoldResult> values(2 * sourceRank + 1);
+  llvm::SmallVector<mlir::AffineExpr> symbols(2 * sourceRank + 1);
+
+  mlir::detail::bindSymbolsList(rewriter.getContext(), symbols);
+  mlir::AffineExpr expr = symbols.front();
+  values[0] = mlir::ShapedType::isDynamic(sourceOffset)
+                  ? getAsOpFoldResult(newExtractStridedMetadata.getOffset())
+                  : rewriter.getIndexAttr(sourceOffset);
+
+  mlir::AffineExpr s0 = rewriter.getAffineSymbolExpr(0);
+  mlir::AffineExpr s1 = rewriter.getAffineSymbolExpr(1);
+  for (unsigned i = 0; i < sourceRank; ++i) {
+    // Compute the stride.
+    mlir::OpFoldResult origStride =
+        mlir::ShapedType::isDynamic(sourceStrides[i])
+            ? origStrides[i]
+            : mlir::OpFoldResult(rewriter.getIndexAttr(sourceStrides[i]));
+    strides.push_back(makeComposedFoldedAffineApply(
+        rewriter, loc, s0 * s1, {subStrides[i], origStride}));
+
+    // Build up the computation of the offset.
+    unsigned baseIdxForDim = 1 + 2 * i;
+    unsigned subOffsetForDim = baseIdxForDim;
+    unsigned origStrideForDim = baseIdxForDim + 1;
+    expr = expr + symbols[subOffsetForDim] * symbols[origStrideForDim];
+    values[subOffsetForDim] = subOffsets[i];
+    values[origStrideForDim] = origStride;
+  }
+
+  // Compute the offset.
+  mlir::OpFoldResult finalOffset =
+      makeComposedFoldedAffineApply(rewriter, loc, expr, values);
+
+  return {finalOffset, strides};
+}
+
 // static mlir::Value getFlatIndex(mlir::OpBuilder &builder, mlir::Location loc,
 //                                 mlir::Value memref,
 //                                 llvm::ArrayRef<mlir::OpFoldResult> indices) {
@@ -604,51 +661,51 @@ struct FlattenStore : public mlir::OpRewritePattern<mlir::memref::StoreOp> {
   }
 };
 
-// TODO: investigate
-// struct FlattenSubview : public
-// mlir::OpRewritePattern<mlir::memref::SubViewOp> {
-//  using OpRewritePattern::OpRewritePattern;
+struct FlattenSubview : public mlir::OpRewritePattern<mlir::memref::SubViewOp> {
+  using OpRewritePattern::OpRewritePattern;
 
-//  mlir::LogicalResult
-//  matchAndRewrite(mlir::memref::SubViewOp op,
-//                  mlir::PatternRewriter &rewriter) const override {
-//    if (!op->getParentOfType<mlir::gpu::LaunchOp>())
-//      return mlir::failure();
+  mlir::LogicalResult
+  matchAndRewrite(mlir::memref::SubViewOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (!op->getParentOfType<mlir::gpu::LaunchOp>())
+      return mlir::failure();
 
-//    auto memref = op.getSource();
-//    if (!needFlatten(memref))
-//      return mlir::failure();
+    auto memref = op.getSource();
+    if (!needFlatten(memref))
+      return mlir::failure();
 
-//    auto srcType = memref.getType().cast<mlir::MemRefType>();
-//    auto resultType = op.getType().cast<mlir::MemRefType>();
-//    auto loc = op.getLoc();
-//    auto flatIndex = getFlatIndex(rewriter, loc, memref,
-//    op.getMixedOffsets());
+    auto loc = op.getLoc();
+    auto subOffsets = op.getMixedOffsets();
+    auto subSizes = op.getMixedSizes();
+    auto subStrides = op.getMixedStrides();
+    auto [finalOffset, strides] =
+        getFlatOffsetAndStrides(rewriter, loc, memref, subOffsets, subStrides);
 
-//    unsigned subRank = static_cast<unsigned>(resultType.getRank());
-//    auto subSizes = op.getMixedSizes();
-//    auto subStrides = op.getMixedStrides();
-//    auto droppedDims = op.getDroppedDims();
+    auto srcType = memref.getType().cast<mlir::MemRefType>();
+    auto resultType = op.getType().cast<mlir::MemRefType>();
+    unsigned subRank = static_cast<unsigned>(resultType.getRank());
 
-//    llvm::SmallVector<mlir::OpFoldResult> finalSizes;
-//    finalSizes.reserve(subRank);
+    auto droppedDims = op.getDroppedDims();
 
-//    llvm::SmallVector<mlir::OpFoldResult> finalStrides;
-//    finalStrides.reserve(subRank);
+    llvm::SmallVector<mlir::OpFoldResult> finalSizes;
+    finalSizes.reserve(subRank);
 
-//    for (auto i : llvm::seq(0u, static_cast<unsigned>(srcType.getRank()))) {
-//      if (droppedDims.test(i))
-//        continue;
+    llvm::SmallVector<mlir::OpFoldResult> finalStrides;
+    finalStrides.reserve(subRank);
 
-//      finalSizes.push_back(subSizes[i]);
-//      finalStrides.push_back(subStrides[i]);
-//    }
+    for (auto i : llvm::seq(0u, static_cast<unsigned>(srcType.getRank()))) {
+      if (droppedDims.test(i))
+        continue;
 
-//    rewriter.replaceOpWithNewOp<mlir::memref::ReinterpretCastOp>(
-//        op, resultType, memref, flatIndex, finalSizes, finalStrides);
-//    return mlir::success();
-//  }
-//};
+      finalSizes.push_back(subSizes[i]);
+      finalStrides.push_back(strides[i]);
+    }
+
+    rewriter.replaceOpWithNewOp<mlir::memref::ReinterpretCastOp>(
+        op, resultType, memref, finalOffset, finalSizes, finalStrides);
+    return mlir::success();
+  }
+};
 
 struct UnstrideMemrefsPass
     : public mlir::PassWrapper<UnstrideMemrefsPass, mlir::OperationPass<void>> {
@@ -665,7 +722,7 @@ struct UnstrideMemrefsPass
     auto *ctx = &getContext();
     mlir::RewritePatternSet patterns(ctx);
 
-    patterns.insert<FlattenLoad, FlattenStore /*, FlattenSubview*/>(ctx);
+    patterns.insert<FlattenLoad, FlattenStore, FlattenSubview>(ctx);
 
     (void)mlir::applyPatternsAndFoldGreedily(getOperation(),
                                              std::move(patterns));


### PR DESCRIPTION
Use code derived from upstream to correctly calculate flat offsets.
