### PR TITLE
Cleanup gpu testing logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,17 @@ if(POLICY CMP0116)
     cmake_policy(SET CMP0116 OLD)
 endif()
 
+if(${CMAKE_VERSION} VERSION_LESS 3.25)
+	# CMake starting with version 3.25 sets var LINUX to true if target system is linux
+    if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+	    set(LINUX TRUE)
+    endif()
+endif()
+message(STATUS "CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
+if(LINUX)
+	message(STATUS "Building for target: LINUX")
+endif()
+
 set(IMEX_EXTERNAL_PROJECT_BUILD OFF)
 
 if(NOT (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR) AND NOT DEFINED MLIR_BINARY_DIR)
@@ -158,15 +169,20 @@ endmacro()
 
 include(HandleLLVMOptions)
 
-set(IMEX_ENABLE_SYCL_RUNTIME 0 CACHE BOOL "Enable the Sycl Runtime")
+# Sycl runtime only supports linux for now
+if(LINUX)
+    set(IMEX_ENABLE_SYCL_RUNTIME 0 CACHE BOOL "Enable the Sycl Runtime")
+endif()
 set(IMEX_ENABLE_L0_RUNTIME 0 CACHE BOOL "Enable the Level Zero Runtime")
 
 # Normalize IMEX_ENABLE_SYCL_RUNTIME and IMEX_ENABLE_L0_RUNTIME
 # These values are expected to be passed as 0 or 1 to imex-runner.py
-if (IMEX_ENABLE_SYCL_RUNTIME)
-    set(IMEX_ENABLE_SYCL_RUNTIME 1)
-else ()
-    set(IMEX_ENABLE_SYCL_RUNTIME 0)
+if(LINUX)
+    if (IMEX_ENABLE_SYCL_RUNTIME)
+        set(IMEX_ENABLE_SYCL_RUNTIME 1)
+    else ()
+        set(IMEX_ENABLE_SYCL_RUNTIME 0)
+    endif()
 endif()
 
 if (IMEX_ENABLE_L0_RUNTIME)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,20 +170,15 @@ endmacro()
 
 include(HandleLLVMOptions)
 
-# Sycl runtime only supports linux for now
-if(LINUX)
-    set(IMEX_ENABLE_SYCL_RUNTIME 0 CACHE BOOL "Enable the Sycl Runtime")
-endif()
+set(IMEX_ENABLE_SYCL_RUNTIME 0 CACHE BOOL "Enable the Sycl Runtime")
 set(IMEX_ENABLE_L0_RUNTIME 0 CACHE BOOL "Enable the Level Zero Runtime")
 
 # Normalize IMEX_ENABLE_SYCL_RUNTIME and IMEX_ENABLE_L0_RUNTIME
 # These values are expected to be passed as 0 or 1 to imex-runner.py
-if(LINUX)
-    if (IMEX_ENABLE_SYCL_RUNTIME)
-        set(IMEX_ENABLE_SYCL_RUNTIME 1)
-    else ()
-        set(IMEX_ENABLE_SYCL_RUNTIME 0)
-    endif()
+if (IMEX_ENABLE_SYCL_RUNTIME)
+    set(IMEX_ENABLE_SYCL_RUNTIME 1)
+else ()
+    set(IMEX_ENABLE_SYCL_RUNTIME 0)
 endif()
 
 if (IMEX_ENABLE_L0_RUNTIME)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,17 +6,6 @@ if(POLICY CMP0116)
     cmake_policy(SET CMP0116 OLD)
 endif()
 
-if(${CMAKE_VERSION} VERSION_LESS 3.25)
-	# CMake starting with version 3.25 sets var LINUX to true if target system is linux
-    if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-	    set(LINUX TRUE)
-    endif()
-endif()
-message(STATUS "CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
-if(LINUX)
-	message(STATUS "Building for target: LINUX")
-endif()
-
 set(IMEX_EXTERNAL_PROJECT_BUILD OFF)
 
 if(NOT (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR) AND NOT DEFINED MLIR_BINARY_DIR)
@@ -32,6 +21,18 @@ else()
 
     set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to conform to")
     list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/modules")
+endif()
+
+# CMAKE_SYSTEM_NAME needs to be checked after "project"
+if(${CMAKE_VERSION} VERSION_LESS 3.25)
+    # CMake starting with version 3.25 sets var LINUX to true if target system is linux
+    if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+        set(LINUX TRUE)
+    endif()
+endif()
+message(STATUS "CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
+if(LINUX)
+    message(STATUS "Building for target: LINUX")
 endif()
 
 # Expected LLVM SHA

--- a/lib/ExecutionEngine/SYCLRUNTIME/CMakeLists.txt
+++ b/lib/ExecutionEngine/SYCLRUNTIME/CMakeLists.txt
@@ -27,7 +27,11 @@ add_mlir_library(sycl-runtime
     EXCLUDE_FROM_LIBMLIR
   )
 
-target_compile_options (sycl-runtime PUBLIC -fexceptions)
+check_cxx_compiler_flag("-frtti" CXX_HAS_FRTTI_FLAG)
+if(NOT CXX_HAS_FRTTI_FLAG)
+    message(FATAL_ERROR "CXX compiler does not accept flag -frtti")
+endif()
+target_compile_options (sycl-runtime PUBLIC -fexceptions -frtti)
 
 target_include_directories(sycl-runtime PRIVATE
     ${MLIR_INCLUDE_DIRS}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,12 @@ if(IMEX_ENABLE_L0_RUNTIME)
         )
 endif()
 
+if(IMEX_ENABLE_L0_RUNTIME OR IMEX_ENABLE_SYCL_RUNTIME)
+    list(APPEND IMEX_TEST_DEPENDS
+        l0-fp64-checker
+        )
+endif()
+
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,10 +50,20 @@ configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
   )
 
-add_lit_testsuite(check-imex "Running the IMEX regression tests"
+# limit number of workers for lit test when gpu test is enabled
+if(IMEX_ENABLE_L0_RUNTIME OR IMEX_ENABLE_SYCL_RUNTIME OR IMEX_ENABLE_VULKAN_RUNNER)
+    add_lit_testsuite(check-imex "Running the IMEX regression tests"
+        ${CMAKE_CURRENT_BINARY_DIR}
+        DEPENDS ${IMEX_TEST_DEPENDS}
+        ARGS "--workers=1"
+        )
+else()
+    add_lit_testsuite(check-imex "Running the IMEX regression tests"
         ${CMAKE_CURRENT_BINARY_DIR}
         DEPENDS ${IMEX_TEST_DEPENDS}
         )
+endif()
+
 set_target_properties(check-imex PROPERTIES FOLDER "Tests")
 
 add_lit_testsuite(check-ptensor "Running the IMEX/ptensor regression tests"

--- a/test/Integration/Dialect/Linalg/Vulkan/linalg-to-gpu-vulkan.pp
+++ b/test/Integration/Dialect/Linalg/Vulkan/linalg-to-gpu-vulkan.pp
@@ -19,7 +19,7 @@ builtin.module(
         convert-parallel-loops-to-gpu
         )
 // insert-gpu-allocs pass can have client-api = opencl or vulkan args
-    func.func(insert-gpu-allocs)
+    func.func(insert-gpu-allocs{client-api=vulkan})
     canonicalize
     normalize-memrefs
 // Unstride memrefs does not seem to be needed.
@@ -30,8 +30,8 @@ builtin.module(
     cse
 
 // The following set-spirv-* passes can have client-api = opencl or vulkan args
-    set-spirv-capabilities
-    gpu.module(set-spirv-abi-attrs)
+    set-spirv-capabilities{client-api=vulkan}
+    gpu.module(set-spirv-abi-attrs{client-api=vulkan})
     canonicalize
     )
 // End

--- a/test/Jax/gordon/jit__logsm_from_logmhalo_jax_kern_0_before_linalg.mlir
+++ b/test/Jax/gordon/jit__logsm_from_logmhalo_jax_kern_0_before_linalg.mlir
@@ -2,7 +2,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<() -> ()>
 #map1 = affine_map<(d0) -> ()>

--- a/test/Jax/gordon/jit__logsm_from_logmhalo_jax_kern_0_before_linalg.mlir
+++ b/test/Jax/gordon/jit__logsm_from_logmhalo_jax_kern_0_before_linalg.mlir
@@ -1,5 +1,5 @@
 // RUN: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-cpu.pp --runner mlir-cpu-runner -e main --shared-libs=%mlir_runner_utils --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/Jax/gordon/lit.local.cfg
+++ b/test/Jax/gordon/lit.local.cfg
@@ -1,4 +1,2 @@
-if config.gpu_skip == 'true':
-    config.substitutions.append(('%gpu_skip', 'true'))
-else:
-    config.substitutions.append(('%gpu_skip', 'false'))
+local_excludes = []
+config.excludes.update(local_excludes)

--- a/test/Jax/janet/jit__get_age_weights_from_tables.8_linalg.mlir
+++ b/test/Jax/janet/jit__get_age_weights_from_tables.8_linalg.mlir
@@ -2,7 +2,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0) -> (d0)>
 #map1 = affine_map<(d0) -> ()>

--- a/test/Jax/janet/jit__get_age_weights_from_tables.8_linalg.mlir
+++ b/test/Jax/janet/jit__get_age_weights_from_tables.8_linalg.mlir
@@ -1,5 +1,5 @@
 // RUN: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-cpu.pp --runner mlir-cpu-runner -e main --shared-libs=%mlir_runner_utils --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/Jax/janet/jit__get_lgt_birth.7_linalg.mlir
+++ b/test/Jax/janet/jit__get_lgt_birth.7_linalg.mlir
@@ -2,7 +2,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0) -> ()>
 #map1 = affine_map<(d0) -> (d0)>

--- a/test/Jax/janet/jit__get_lgt_birth.7_linalg.mlir
+++ b/test/Jax/janet/jit__get_lgt_birth.7_linalg.mlir
@@ -1,5 +1,5 @@
 // RUN: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-cpu.pp --runner mlir-cpu-runner -e main --shared-libs=%mlir_runner_utils --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/Jax/janet/jit__get_met_weights_singlegal.43_linalg.mlir
+++ b/test/Jax/janet/jit__get_met_weights_singlegal.43_linalg.mlir
@@ -2,7 +2,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0) -> (d0)>
 #map1 = affine_map<(d0) -> ()>

--- a/test/Jax/janet/jit__get_met_weights_singlegal.43_linalg.mlir
+++ b/test/Jax/janet/jit__get_met_weights_singlegal.43_linalg.mlir
@@ -1,5 +1,5 @@
 // RUN: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-cpu.pp --runner mlir-cpu-runner -e main --shared-libs=%mlir_runner_utils --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/Jax/janet/jit__net_loss.91_linalg.mlir
+++ b/test/Jax/janet/jit__net_loss.91_linalg.mlir
@@ -2,7 +2,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0, d1) -> (d1)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>

--- a/test/Jax/janet/jit__net_loss.91_linalg.mlir
+++ b/test/Jax/janet/jit__net_loss.91_linalg.mlir
@@ -1,5 +1,5 @@
 // RUN: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-cpu.pp --runner mlir-cpu-runner -e main --shared-libs=%mlir_runner_utils --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/Jax/janet/jit__unit_scale_traindata.47_linalg.mlir
+++ b/test/Jax/janet/jit__unit_scale_traindata.47_linalg.mlir
@@ -1,5 +1,5 @@
 // RUN: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-cpu.pp --runner mlir-cpu-runner -e main --shared-libs=%mlir_runner_utils --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/Jax/janet/jit__unit_scale_traindata.47_linalg.mlir
+++ b/test/Jax/janet/jit__unit_scale_traindata.47_linalg.mlir
@@ -2,7 +2,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0) -> (d0)>
 #map1 = affine_map<(d0, d1) -> (d0)>

--- a/test/Jax/janet/jit_prim_fun.50_linalg.mlir
+++ b/test/Jax/janet/jit_prim_fun.50_linalg.mlir
@@ -2,7 +2,7 @@
 // RUN-GPU: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN-GPU:                                        --runner mlir-cpu-runner -e main \
 // RUN-GPU:                                        --entry-point-result=void \
-// RUN-GPU:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN-GPU:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @jit_prim_fun.50 {

--- a/test/Jax/janet/lit.local.cfg
+++ b/test/Jax/janet/lit.local.cfg
@@ -1,7 +1,2 @@
 local_excludes = ['jit__get_age_weights_from_tables.8_linalg.mlir']
 config.excludes.update(local_excludes)
-
-if config.gpu_skip == 'true':
-    config.substitutions.append(('%gpu_skip', 'true'))
-else:
-    config.substitutions.append(('%gpu_skip', 'false'))

--- a/test/Jax/jax_qmc/jit__linspace.39_linalg.mlir
+++ b/test/Jax/jax_qmc/jit__linspace.39_linalg.mlir
@@ -2,7 +2,7 @@
 // RUN-GPU: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN-GPU:                                        --runner mlir-cpu-runner -e main \
 // RUN-GPU:                                        --entry-point-result=void \
-// RUN-GPU:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN-GPU:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<() -> ()>
 #map1 = affine_map<(d0) -> ()>

--- a/test/Jax/jax_qmc/jit__linspace.39_linalg.mlir
+++ b/test/Jax/jax_qmc/jit__linspace.39_linalg.mlir
@@ -1,5 +1,5 @@
 // RUN: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-cpu.pp --runner mlir-cpu-runner -e main --shared-libs=%mlir_runner_utils --entry-point-result=void | FileCheck %s
-// RUN-GPU: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN-GPU: %python_executable %imex_runner --requires=l0-runtime,igpu-fp64 %igpu_fp64 -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN-GPU:                                        --runner mlir-cpu-runner -e main \
 // RUN-GPU:                                        --entry-point-result=void \
 // RUN-GPU:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck

--- a/test/Jax/jax_qmc/jit__mean.46_linalg.mlir
+++ b/test/Jax/jax_qmc/jit__mean.46_linalg.mlir
@@ -2,7 +2,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0, d1, d2) -> (d0, d2, d1)>
 #map1 = affine_map<(d0, d1, d2) -> (d0, d1)>

--- a/test/Jax/jax_qmc/jit__mean.46_linalg.mlir
+++ b/test/Jax/jax_qmc/jit__mean.46_linalg.mlir
@@ -1,5 +1,5 @@
 // RUN: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-cpu.pp --runner mlir-cpu-runner -e main --shared-libs=%mlir_runner_utils --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/Jax/jax_qmc/jit__mean.46_linalg.mlir
+++ b/test/Jax/jax_qmc/jit__mean.46_linalg.mlir
@@ -1,5 +1,5 @@
 // RUN: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-cpu.pp --runner mlir-cpu-runner -e main --shared-libs=%mlir_runner_utils --entry-point-result=void | FileCheck %s
-// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime,igpu-fp64 %igpu_fp64 -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck

--- a/test/Jax/jax_qmc/jit__mean.51_linalg.mlir
+++ b/test/Jax/jax_qmc/jit__mean.51_linalg.mlir
@@ -1,5 +1,5 @@
 // RUN: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-cpu.pp --runner mlir-cpu-runner -e main --shared-libs=%mlir_runner_utils --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/Jax/jax_qmc/jit__mean.51_linalg.mlir
+++ b/test/Jax/jax_qmc/jit__mean.51_linalg.mlir
@@ -1,5 +1,5 @@
 // RUN: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-cpu.pp --runner mlir-cpu-runner -e main --shared-libs=%mlir_runner_utils --entry-point-result=void | FileCheck %s
-// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime,igpu-fp64 %igpu_fp64 -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck

--- a/test/Jax/jax_qmc/jit__mean.51_linalg.mlir
+++ b/test/Jax/jax_qmc/jit__mean.51_linalg.mlir
@@ -2,7 +2,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> ()>

--- a/test/Jax/jax_qmc/jit_pionless_2b_lo.41_linalg.mlir
+++ b/test/Jax/jax_qmc/jit_pionless_2b_lo.41_linalg.mlir
@@ -2,7 +2,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<() -> ()>
 #map1 = affine_map<(d0) -> (d0)>

--- a/test/Jax/jax_qmc/jit_pionless_2b_lo.41_linalg.mlir
+++ b/test/Jax/jax_qmc/jit_pionless_2b_lo.41_linalg.mlir
@@ -1,5 +1,5 @@
 // RUN: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-cpu.pp --runner mlir-cpu-runner -e main --shared-libs=%mlir_runner_utils --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/Jax/jax_qmc/jit_pionless_2b_lo.41_linalg.mlir
+++ b/test/Jax/jax_qmc/jit_pionless_2b_lo.41_linalg.mlir
@@ -1,5 +1,5 @@
 // RUN: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-cpu.pp --runner mlir-cpu-runner -e main --shared-libs=%mlir_runner_utils --entry-point-result=void | FileCheck %s
-// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime,igpu-fp64 %igpu_fp64 -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck

--- a/test/Jax/jax_qmc/jit_prim_fun.13_linalg.mlir
+++ b/test/Jax/jax_qmc/jit_prim_fun.13_linalg.mlir
@@ -2,7 +2,7 @@
 // RUN-GPU: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN-GPU:                                        --runner mlir-cpu-runner -e main \
 // RUN-GPU:                                        --entry-point-result=void \
-// RUN-GPU:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN-GPU:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map = affine_map<(d0) -> (d0)>
 module @jit_prim_fun.13 {

--- a/test/Jax/jax_qmc/jit_v_em.42_linalg.mlir
+++ b/test/Jax/jax_qmc/jit_v_em.42_linalg.mlir
@@ -2,7 +2,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map = affine_map<() -> ()>
 module @jit_v_em.42 {

--- a/test/Jax/jax_qmc/jit_v_em.42_linalg.mlir
+++ b/test/Jax/jax_qmc/jit_v_em.42_linalg.mlir
@@ -1,5 +1,5 @@
 // RUN: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-cpu.pp --runner mlir-cpu-runner -e main --shared-libs=%mlir_runner_utils --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/Jax/jax_qmc/jit_v_em.42_linalg.mlir
+++ b/test/Jax/jax_qmc/jit_v_em.42_linalg.mlir
@@ -1,5 +1,5 @@
 // RUN: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-cpu.pp --runner mlir-cpu-runner -e main --shared-libs=%mlir_runner_utils --entry-point-result=void | FileCheck %s
-// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime,igpu-fp64 %igpu_fp64 -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck

--- a/test/Jax/jax_qmc/lit.local.cfg
+++ b/test/Jax/jax_qmc/lit.local.cfg
@@ -1,7 +1,2 @@
 local_excludes = []
 config.excludes.update(local_excludes)
-
-if config.gpu_skip == 'true':
-    config.substitutions.append(('%gpu_skip', 'true'))
-else:
-    config.substitutions.append(('%gpu_skip', 'false'))

--- a/test/Jax/qoc/jit__diag.11_linalg.mlir
+++ b/test/Jax/qoc/jit__diag.11_linalg.mlir
@@ -1,5 +1,5 @@
 // RUN: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-cpu.pp --runner mlir-cpu-runner -e main --shared-libs=%mlir_runner_utils --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/Jax/qoc/jit__diag.11_linalg.mlir
+++ b/test/Jax/qoc/jit__diag.11_linalg.mlir
@@ -2,7 +2,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0) -> (d0)>
 #map1 = affine_map<(d0, d1) -> (d0)>

--- a/test/Jax/qoc/jit__reduce_sum.357_linalg.mlir
+++ b/test/Jax/qoc/jit__reduce_sum.357_linalg.mlir
@@ -2,7 +2,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0) -> (d0)>
 #map1 = affine_map<(d0) -> ()>

--- a/test/Jax/qoc/jit__reduce_sum.357_linalg.mlir
+++ b/test/Jax/qoc/jit__reduce_sum.357_linalg.mlir
@@ -1,5 +1,5 @@
 // RUN: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-cpu.pp --runner mlir-cpu-runner -e main --shared-libs=%mlir_runner_utils --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/Jax/qoc/jit_absolute.341_linalg.mlir
+++ b/test/Jax/qoc/jit_absolute.341_linalg.mlir
@@ -2,7 +2,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map = affine_map<() -> ()>
 module @jit_absolute.341 {

--- a/test/Jax/qoc/jit_absolute.341_linalg.mlir
+++ b/test/Jax/qoc/jit_absolute.341_linalg.mlir
@@ -1,5 +1,5 @@
 // RUN: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-cpu.pp --runner mlir-cpu-runner -e main --shared-libs=%mlir_runner_utils --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/Jax/qoc/jit_conjugate.307_linalg.mlir
+++ b/test/Jax/qoc/jit_conjugate.307_linalg.mlir
@@ -2,7 +2,7 @@
 // RUN-GPU: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN-GPU:                                        --runner mlir-cpu-runner -e main \
 // RUN-GPU:                                        --entry-point-result=void \
-// RUN-GPU:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN-GPU:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @jit_conjugate.307 {

--- a/test/Jax/qoc/jit_matmul.338_linalg.mlir
+++ b/test/Jax/qoc/jit_matmul.338_linalg.mlir
@@ -1,5 +1,5 @@
 // RUN: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-cpu.pp --runner mlir-cpu-runner -e main --shared-libs=%mlir_runner_utils --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/Jax/qoc/jit_matmul.338_linalg.mlir
+++ b/test/Jax/qoc/jit_matmul.338_linalg.mlir
@@ -2,7 +2,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0, d1, d2, d3) -> (d0, d3)>
 #map1 = affine_map<(d0, d1, d2, d3) -> (d1, d3, d3)>

--- a/test/Jax/qoc/jit_prim_fun.335_linalg.mlir
+++ b/test/Jax/qoc/jit_prim_fun.335_linalg.mlir
@@ -2,7 +2,7 @@
 // RUN-GPU: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN-GPU:                                        --runner mlir-cpu-runner -e main \
 // RUN-GPU:                                        --entry-point-result=void \
-// RUN-GPU:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN-GPU:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map = affine_map<(d0) -> (d0)>
 module @jit_prim_fun.335 {

--- a/test/Jax/qoc/jit_real.364_linalg.mlir
+++ b/test/Jax/qoc/jit_real.364_linalg.mlir
@@ -2,7 +2,7 @@
 // RUN-GPU: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN-GPU:                                        --runner mlir-cpu-runner -e main \
 // RUN-GPU:                                        --entry-point-result=void \
-// RUN-GPU:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN-GPU:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map = affine_map<(d0) -> (d0)>
 module @jit_real.364 {

--- a/test/Jax/qoc/jit_swapaxes.304_linalg.mlir
+++ b/test/Jax/qoc/jit_swapaxes.304_linalg.mlir
@@ -1,5 +1,5 @@
 // RUN: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-cpu.pp --runner mlir-cpu-runner -e main --shared-libs=%mlir_runner_utils --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/Jax/qoc/jit_swapaxes.304_linalg.mlir
+++ b/test/Jax/qoc/jit_swapaxes.304_linalg.mlir
@@ -2,7 +2,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0, d1) -> (d1, d0)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>

--- a/test/Jax/qoc/jit_trace.340_linalg.mlir
+++ b/test/Jax/qoc/jit_trace.340_linalg.mlir
@@ -1,5 +1,5 @@
 // RUN: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-cpu.pp --runner mlir-cpu-runner -e main --shared-libs=%mlir_runner_utils --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/Jax/qoc/jit_trace.340_linalg.mlir
+++ b/test/Jax/qoc/jit_trace.340_linalg.mlir
@@ -2,7 +2,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0) -> (d0)>
 #map1 = affine_map<(d0, d1) -> (d0)>

--- a/test/Jax/qoc/jit_true_divide.316_linalg.mlir
+++ b/test/Jax/qoc/jit_true_divide.316_linalg.mlir
@@ -2,7 +2,7 @@
 // RUN-GPU: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN-GPU:                                        --runner mlir-cpu-runner -e main \
 // RUN-GPU:                                        --entry-point-result=void \
-// RUN-GPU:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN-GPU:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map = affine_map<() -> ()>
 module @jit_true_divide.316 {

--- a/test/Jax/qoc/lit.local.cfg
+++ b/test/Jax/qoc/lit.local.cfg
@@ -1,7 +1,2 @@
 local_excludes = []
 config.excludes.update(local_excludes)
-
-if config.gpu_skip == 'true':
-    config.substitutions.append(('%gpu_skip', 'true'))
-else:
-    config.substitutions.append(('%gpu_skip', 'false'))

--- a/test/Models/Mobilenet-v3/mobilenetv3-linalg-without-tensor-pad.mlir
+++ b/test/Models/Mobilenet-v3/mobilenetv3-linalg-without-tensor-pad.mlir
@@ -1,5 +1,5 @@
 // RUN: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-cpu.pp --runner mlir-cpu-runner -e main --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/Models/Mobilenet-v3/mobilenetv3-linalg-without-tensor-pad.mlir
+++ b/test/Models/Mobilenet-v3/mobilenetv3-linalg-without-tensor-pad.mlir
@@ -2,7 +2,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map1 = affine_map<(d0, d1, d2, d3) -> ()>

--- a/test/Models/Mobilenet-v3/mobilenetv3-linalg.mlir
+++ b/test/Models/Mobilenet-v3/mobilenetv3-linalg.mlir
@@ -1,5 +1,5 @@
 // RUN: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-cpu.pp --runner mlir-cpu-runner -e main --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/Models/Mobilenet-v3/mobilenetv3-linalg.mlir
+++ b/test/Models/Mobilenet-v3/mobilenetv3-linalg.mlir
@@ -2,7 +2,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map1 = affine_map<(d0, d1, d2, d3) -> ()>

--- a/test/Models/Resnet-50/resnet-50-linalg-without-tensor-pad.mlir
+++ b/test/Models/Resnet-50/resnet-50-linalg-without-tensor-pad.mlir
@@ -1,5 +1,5 @@
 // RUN: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-cpu.pp --runner mlir-cpu-runner -e main --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/Models/Resnet-50/resnet-50-linalg-without-tensor-pad.mlir
+++ b/test/Models/Resnet-50/resnet-50-linalg-without-tensor-pad.mlir
@@ -2,7 +2,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3, d1)>

--- a/test/Models/Resnet-50/resnet-50-linalg.mlir
+++ b/test/Models/Resnet-50/resnet-50-linalg.mlir
@@ -1,5 +1,5 @@
 // RUN: %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-cpu.pp --runner mlir-cpu-runner -e main --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/Models/Resnet-50/resnet-50-linalg.mlir
+++ b/test/Models/Resnet-50/resnet-50-linalg.mlir
@@ -2,7 +2,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3, d1)>

--- a/test/Models/lit.local.cfg
+++ b/test/Models/lit.local.cfg
@@ -1,8 +1,3 @@
 local_excludes = ['resnet-50-linalg.mlir',
                   'resnet-50-linalg-without-tensor-pad.mlir',]
 config.excludes.update(local_excludes)
-
-if config.gpu_skip == 'true':
-    config.substitutions.append(('%gpu_skip', 'true'))
-else:
-    config.substitutions.append(('%gpu_skip', 'false'))

--- a/test/PlaidML/CppEdsl.Add.mlir
+++ b/test/PlaidML/CppEdsl.Add.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @add {
 func.func @main() {

--- a/test/PlaidML/CppEdsl.Add.mlir
+++ b/test/PlaidML/CppEdsl.Add.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/CppEdsl.Atan.mlir
+++ b/test/PlaidML/CppEdsl.Atan.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @atan {
   func.func @test(%arg0: tensor<3x3xf32>) -> tensor<3x3xf32> {

--- a/test/PlaidML/CppEdsl.Atan.mlir
+++ b/test/PlaidML/CppEdsl.Atan.mlir
@@ -2,7 +2,7 @@
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --shared-libs=%mlir_runner_utils \
 // RUN:                                        --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/CppEdsl.BigDot.mlir
+++ b/test/PlaidML/CppEdsl.BigDot.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/CppEdsl.BigDot.mlir
+++ b/test/PlaidML/CppEdsl.BigDot.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>

--- a/test/PlaidML/CppEdsl.BitAnd.mlir
+++ b/test/PlaidML/CppEdsl.BitAnd.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/CppEdsl.BitAnd.mlir
+++ b/test/PlaidML/CppEdsl.BitAnd.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @bit_and {
 func.func @main() {

--- a/test/PlaidML/CppEdsl.BitAndScalar.mlir
+++ b/test/PlaidML/CppEdsl.BitAndScalar.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> ()>
 module @bit_and {

--- a/test/PlaidML/CppEdsl.BitAndScalar.mlir
+++ b/test/PlaidML/CppEdsl.BitAndScalar.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/CppEdsl.BitLeft.mlir
+++ b/test/PlaidML/CppEdsl.BitLeft.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/CppEdsl.BitLeft.mlir
+++ b/test/PlaidML/CppEdsl.BitLeft.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @bit_left {
 func.func @main() {

--- a/test/PlaidML/CppEdsl.BitNot.mlir
+++ b/test/PlaidML/CppEdsl.BitNot.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/CppEdsl.BitNot.mlir
+++ b/test/PlaidML/CppEdsl.BitNot.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @bit_not {
 func.func @main() {

--- a/test/PlaidML/CppEdsl.BitOr.mlir
+++ b/test/PlaidML/CppEdsl.BitOr.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/CppEdsl.BitOr.mlir
+++ b/test/PlaidML/CppEdsl.BitOr.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @bit_or {
 func.func @main() {

--- a/test/PlaidML/CppEdsl.BitRightScalar.mlir
+++ b/test/PlaidML/CppEdsl.BitRightScalar.mlir
@@ -3,7 +3,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/CppEdsl.BitRightScalar.mlir
+++ b/test/PlaidML/CppEdsl.BitRightScalar.mlir
@@ -6,7 +6,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> ()>
 module @bit_right_scalar {

--- a/test/PlaidML/CppEdsl.BitRightTensor.mlir
+++ b/test/PlaidML/CppEdsl.BitRightTensor.mlir
@@ -6,7 +6,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @bit_right_tensor {
 func.func @main() {

--- a/test/PlaidML/CppEdsl.BitRightTensor.mlir
+++ b/test/PlaidML/CppEdsl.BitRightTensor.mlir
@@ -3,7 +3,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/CppEdsl.BitXor.mlir
+++ b/test/PlaidML/CppEdsl.BitXor.mlir
@@ -3,7 +3,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/CppEdsl.BitXor.mlir
+++ b/test/PlaidML/CppEdsl.BitXor.mlir
@@ -6,7 +6,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @bit_xor {
 func.func @main() {

--- a/test/PlaidML/CppEdsl.BroadcastCmp.mlir
+++ b/test/PlaidML/CppEdsl.BroadcastCmp.mlir
@@ -6,7 +6,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d0, 0)>
 module @broadcast_cmp {

--- a/test/PlaidML/CppEdsl.BroadcastCmp.mlir
+++ b/test/PlaidML/CppEdsl.BroadcastCmp.mlir
@@ -3,7 +3,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/CppEdsl.Cast.mlir
+++ b/test/PlaidML/CppEdsl.Cast.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/CppEdsl.Cast.mlir
+++ b/test/PlaidML/CppEdsl.Cast.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @cast {

--- a/test/PlaidML/CppEdsl.ConstAdd.mlir
+++ b/test/PlaidML/CppEdsl.ConstAdd.mlir
@@ -3,7 +3,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/CppEdsl.ConstAdd.mlir
+++ b/test/PlaidML/CppEdsl.ConstAdd.mlir
@@ -6,7 +6,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0) -> (d0)>
 module @const_add {
 func.func @test(%arg0: tensor<4xi32> {stdx.const}, %arg1: tensor<4xi32> {stdx.const}) -> tensor<4xi32> {

--- a/test/PlaidML/CppEdsl.ConvI8.mlir
+++ b/test/PlaidML/CppEdsl.ConvI8.mlir
@@ -2,10 +2,11 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
-// RUN:                                        --runner mlir-cpu-runner -e main \
-// RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN: %python_executable %imex_runner -i %s --requires=l0-runtime \
+// RUN:                                       --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN:                                       --runner mlir-cpu-runner -e main \
+// RUN:                                       --entry-point-result=void \
+// RUN:                                       --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime | FileCheck %s
 #map0 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d3)>

--- a/test/PlaidML/CppEdsl.ConvI8.mlir
+++ b/test/PlaidML/CppEdsl.ConvI8.mlir
@@ -6,7 +6,7 @@
 // RUN:                                       --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d3)>

--- a/test/PlaidML/CppEdsl.Convolution.mlir
+++ b/test/PlaidML/CppEdsl.Convolution.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d3)>

--- a/test/PlaidML/CppEdsl.Convolution.mlir
+++ b/test/PlaidML/CppEdsl.Convolution.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/CppEdsl.Cos.mlir
+++ b/test/PlaidML/CppEdsl.Cos.mlir
@@ -6,7 +6,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @cos {
 func.func @test(%arg0: tensor<3x3xf32>) -> tensor<3x3xf32> {

--- a/test/PlaidML/CppEdsl.Cos.mlir
+++ b/test/PlaidML/CppEdsl.Cos.mlir
@@ -3,7 +3,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/CppEdsl.CumSum.mlir
+++ b/test/PlaidML/CppEdsl.CumSum.mlir
@@ -3,7 +3,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/CppEdsl.CumSum.mlir
+++ b/test/PlaidML/CppEdsl.CumSum.mlir
@@ -6,7 +6,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1) -> (d1)>
 #map1 = affine_map<(d0, d1) -> (d0)>
 #set = affine_set<(d0, d1) : (d0 - d1 >= 0)>

--- a/test/PlaidML/CppEdsl.DefractLong.mlir
+++ b/test/PlaidML/CppEdsl.DefractLong.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/CppEdsl.DefractLong.mlir
+++ b/test/PlaidML/CppEdsl.DefractLong.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10) -> (d1, -d0 + d3 + d8 + 1, -d0 + d4 + d5 + d9, d10)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10) -> (d0 * 4 + d2 * 2 + d7 - d8 * 2, d0 * 4 + d2 - d4 + d7 - d9 * 2 + 3, d6, d10)>

--- a/test/PlaidML/CppEdsl.Dot.mlir
+++ b/test/PlaidML/CppEdsl.Dot.mlir
@@ -3,7 +3,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/CppEdsl.Dot.mlir
+++ b/test/PlaidML/CppEdsl.Dot.mlir
@@ -6,7 +6,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>

--- a/test/PlaidML/CppEdsl.DotF16.mlir
+++ b/test/PlaidML/CppEdsl.DotF16.mlir
@@ -3,7 +3,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/CppEdsl.DotF16.mlir
+++ b/test/PlaidML/CppEdsl.DotF16.mlir
@@ -6,7 +6,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>

--- a/test/PlaidML/CppEdsl.DotF16_AccF32.mlir
+++ b/test/PlaidML/CppEdsl.DotF16_AccF32.mlir
@@ -3,7 +3,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/CppEdsl.DotF16_AccF32.mlir
+++ b/test/PlaidML/CppEdsl.DotF16_AccF32.mlir
@@ -6,7 +6,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map2 = affine_map<(d0, d1, d2) -> (d2, d1)>

--- a/test/PlaidML/CppEdsl.DoubleDot.mlir
+++ b/test/PlaidML/CppEdsl.DoubleDot.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>

--- a/test/PlaidML/CppEdsl.DoubleDot.mlir
+++ b/test/PlaidML/CppEdsl.DoubleDot.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/CppEdsl.DupOut.mlir
+++ b/test/PlaidML/CppEdsl.DupOut.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>

--- a/test/PlaidML/CppEdsl.DupOut.mlir
+++ b/test/PlaidML/CppEdsl.DupOut.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/CppEdsl.EltwiseMod.mlir
+++ b/test/PlaidML/CppEdsl.EltwiseMod.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/CppEdsl.EltwiseMod.mlir
+++ b/test/PlaidML/CppEdsl.EltwiseMod.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @mod {

--- a/test/PlaidML/CppEdsl.Erf.mlir
+++ b/test/PlaidML/CppEdsl.Erf.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/CppEdsl.Erf.mlir
+++ b/test/PlaidML/CppEdsl.Erf.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @erf {
 func.func @main() {

--- a/test/PlaidML/OpTest.Abs.mlir
+++ b/test/PlaidML/OpTest.Abs.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.Abs.mlir
+++ b/test/PlaidML/OpTest.Abs.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map1 = affine_map<(d0, d1, d2, d3) -> ()>

--- a/test/PlaidML/OpTest.Argmax.mlir
+++ b/test/PlaidML/OpTest.Argmax.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.Argmax.mlir
+++ b/test/PlaidML/OpTest.Argmax.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map1 = affine_map<(d0, d1, d2, d3) -> ()>

--- a/test/PlaidML/OpTest.BinaryCrossentropy.mlir
+++ b/test/PlaidML/OpTest.BinaryCrossentropy.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.BinaryCrossentropy.mlir
+++ b/test/PlaidML/OpTest.BinaryCrossentropy.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map1 = affine_map<(d0, d1, d2, d3) -> ()>

--- a/test/PlaidML/OpTest.BroadcastNonNumpy.mlir
+++ b/test/PlaidML/OpTest.BroadcastNonNumpy.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.BroadcastNonNumpy.mlir
+++ b/test/PlaidML/OpTest.BroadcastNonNumpy.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1) -> (d0)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>
 module @broadcast_non_numpy {

--- a/test/PlaidML/OpTest.ComplexConv2D.mlir
+++ b/test/PlaidML/OpTest.ComplexConv2D.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1 * 2 + d5 * 3, d2 * 2 + d6 * 3, d3, d7)>

--- a/test/PlaidML/OpTest.ComplexConv2D.mlir
+++ b/test/PlaidML/OpTest.ComplexConv2D.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.Conv1D.mlir
+++ b/test/PlaidML/OpTest.Conv1D.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.Conv1D.mlir
+++ b/test/PlaidML/OpTest.Conv1D.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1 + d3, d4)>
 #map1 = affine_map<(d0, d1, d2, d3, d4) -> (d3, d4, d2)>
 #map2 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>

--- a/test/PlaidML/OpTest.Conv2DDilated.mlir
+++ b/test/PlaidML/OpTest.Conv2DDilated.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.Conv2DDilated.mlir
+++ b/test/PlaidML/OpTest.Conv2DDilated.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4 * 2, d2 + d5 * 3, d6)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d3)>

--- a/test/PlaidML/OpTest.Dot.mlir
+++ b/test/PlaidML/OpTest.Dot.mlir
@@ -2,7 +2,7 @@
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --shared-libs=%mlir_runner_utils \
 // RUN:                                        --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.Dot.mlir
+++ b/test/PlaidML/OpTest.Dot.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>

--- a/test/PlaidML/OpTest.DotF16.mlir
+++ b/test/PlaidML/OpTest.DotF16.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.DotF16.mlir
+++ b/test/PlaidML/OpTest.DotF16.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>

--- a/test/PlaidML/OpTest.EltwiseAdd.mlir
+++ b/test/PlaidML/OpTest.EltwiseAdd.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @eltwise_add {
   func.func @test(%arg0: tensor<10x20xf32>, %arg1: tensor<10x20xf32>) -> tensor<10x20xf32> {

--- a/test/PlaidML/OpTest.EltwiseAdd.mlir
+++ b/test/PlaidML/OpTest.EltwiseAdd.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.ExplicitPadding.mlir
+++ b/test/PlaidML/OpTest.ExplicitPadding.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.ExplicitPadding.mlir
+++ b/test/PlaidML/OpTest.ExplicitPadding.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d0 + 2, d1 + 1)>
 module @explicit_padding {

--- a/test/PlaidML/OpTest.ExplicitPaddingInf.mlir
+++ b/test/PlaidML/OpTest.ExplicitPaddingInf.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.ExplicitPaddingInf.mlir
+++ b/test/PlaidML/OpTest.ExplicitPaddingInf.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d0 + 2, d1 + 1)>
 module @explicit_padding {

--- a/test/PlaidML/OpTest.ExplicitPaddingNegInf.mlir
+++ b/test/PlaidML/OpTest.ExplicitPaddingNegInf.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.ExplicitPaddingNegInf.mlir
+++ b/test/PlaidML/OpTest.ExplicitPaddingNegInf.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d0 + 2, d1 + 1)>
 module @explicit_padding {

--- a/test/PlaidML/OpTest.Floor.mlir
+++ b/test/PlaidML/OpTest.Floor.mlir
@@ -2,7 +2,7 @@
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --shared-libs=%mlir_runner_utils \
 // RUN:                                        --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.Floor.mlir
+++ b/test/PlaidML/OpTest.Floor.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @floor {
 func.func @main() {

--- a/test/PlaidML/OpTest.GEMM_FLOAT32.mlir
+++ b/test/PlaidML/OpTest.GEMM_FLOAT32.mlir
@@ -2,7 +2,7 @@
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --shared-libs=%mlir_runner_utils \
 // RUN:                                        --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.GEMM_FLOAT32.mlir
+++ b/test/PlaidML/OpTest.GEMM_FLOAT32.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>

--- a/test/PlaidML/OpTest.GEMM_INT32.mlir
+++ b/test/PlaidML/OpTest.GEMM_INT32.mlir
@@ -2,7 +2,7 @@
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --shared-libs=%mlir_runner_utils \
 // RUN:                                        --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.GEMM_INT32.mlir
+++ b/test/PlaidML/OpTest.GEMM_INT32.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>

--- a/test/PlaidML/OpTest.GEMM_INT64.mlir
+++ b/test/PlaidML/OpTest.GEMM_INT64.mlir
@@ -2,7 +2,7 @@
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --shared-libs=%mlir_runner_utils \
 // RUN:                                        --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.GEMM_INT64.mlir
+++ b/test/PlaidML/OpTest.GEMM_INT64.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>

--- a/test/PlaidML/OpTest.GEMM_INT8.mlir
+++ b/test/PlaidML/OpTest.GEMM_INT8.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --entry-point-result=void \
-// RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>

--- a/test/PlaidML/OpTest.GEMM_INT8.mlir
+++ b/test/PlaidML/OpTest.GEMM_INT8.mlir
@@ -2,7 +2,7 @@
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --shared-libs=%mlir_runner_utils \
 // RUN:                                            --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --entry-point-result=void \
 // RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.GEMM_UINT64.mlir
+++ b/test/PlaidML/OpTest.GEMM_UINT64.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --entry-point-result=void \
-// RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>

--- a/test/PlaidML/OpTest.GEMM_UINT64.mlir
+++ b/test/PlaidML/OpTest.GEMM_UINT64.mlir
@@ -2,7 +2,7 @@
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --shared-libs=%mlir_runner_utils \
 // RUN:                                            --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --entry-point-result=void \
 // RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.GEMVC_INT64.mlir
+++ b/test/PlaidML/OpTest.GEMVC_INT64.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --entry-point-result=void \
-// RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> ()>

--- a/test/PlaidML/OpTest.GEMVC_INT64.mlir
+++ b/test/PlaidML/OpTest.GEMVC_INT64.mlir
@@ -2,7 +2,7 @@
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --shared-libs=%mlir_runner_utils \
 // RUN:                                            --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --entry-point-result=void \
 // RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.GEMV_FLOAT32.mlir
+++ b/test/PlaidML/OpTest.GEMV_FLOAT32.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --entry-point-result=void \
-// RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d1)>
 #map2 = affine_map<(d0, d1) -> (d0)>

--- a/test/PlaidML/OpTest.GEMV_FLOAT32.mlir
+++ b/test/PlaidML/OpTest.GEMV_FLOAT32.mlir
@@ -2,7 +2,7 @@
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --shared-libs=%mlir_runner_utils \
 // RUN:                                            --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --entry-point-result=void \
 // RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.GEMV_INT32.mlir
+++ b/test/PlaidML/OpTest.GEMV_INT32.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --entry-point-result=void \
-// RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d1)>

--- a/test/PlaidML/OpTest.GEMV_INT32.mlir
+++ b/test/PlaidML/OpTest.GEMV_INT32.mlir
@@ -2,7 +2,7 @@
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --shared-libs=%mlir_runner_utils \
 // RUN:                                            --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --entry-point-result=void \
 // RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.GEMV_INT64.mlir
+++ b/test/PlaidML/OpTest.GEMV_INT64.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --entry-point-result=void \
-// RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d1)>

--- a/test/PlaidML/OpTest.GEMV_INT64.mlir
+++ b/test/PlaidML/OpTest.GEMV_INT64.mlir
@@ -2,7 +2,7 @@
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --shared-libs=%mlir_runner_utils \
 // RUN:                                            --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --entry-point-result=void \
 // RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.GEMV_INT8.mlir
+++ b/test/PlaidML/OpTest.GEMV_INT8.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --entry-point-result=void \
-// RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d1)>

--- a/test/PlaidML/OpTest.GEMV_INT8.mlir
+++ b/test/PlaidML/OpTest.GEMV_INT8.mlir
@@ -2,7 +2,7 @@
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --shared-libs=%mlir_runner_utils \
 // RUN:                                            --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --entry-point-result=void \
 // RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.GEMV_UINT64.mlir
+++ b/test/PlaidML/OpTest.GEMV_UINT64.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --entry-point-result=void \
-// RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d1)>

--- a/test/PlaidML/OpTest.GEMV_UINT64.mlir
+++ b/test/PlaidML/OpTest.GEMV_UINT64.mlir
@@ -2,7 +2,7 @@
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --shared-libs=%mlir_runner_utils \
 // RUN:                                            --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --entry-point-result=void \
 // RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.GlobalMin.mlir
+++ b/test/PlaidML/OpTest.GlobalMin.mlir
@@ -2,7 +2,7 @@
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --shared-libs=%mlir_runner_utils \
 // RUN:                                        --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.GlobalMin.mlir
+++ b/test/PlaidML/OpTest.GlobalMin.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 #map1 = affine_map<(d0, d1, d2) -> ()>

--- a/test/PlaidML/OpTest.HigherPrecisioConstants.mlir
+++ b/test/PlaidML/OpTest.HigherPrecisioConstants.mlir
@@ -2,7 +2,7 @@
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --shared-libs=%mlir_runner_utils \
 // RUN:                                        --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.HigherPrecisioConstants.mlir
+++ b/test/PlaidML/OpTest.HigherPrecisioConstants.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> ()>

--- a/test/PlaidML/OpTest.HigherPrecisioConstants.mlir
+++ b/test/PlaidML/OpTest.HigherPrecisioConstants.mlir
@@ -2,7 +2,7 @@
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --shared-libs=%mlir_runner_utils \
 // RUN:                                        --entry-point-result=void | FileCheck %s
-// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime,igpu-fp64 %igpu_fp64 -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck

--- a/test/PlaidML/OpTest.LarsMomentum4d.mlir
+++ b/test/PlaidML/OpTest.LarsMomentum4d.mlir
@@ -2,7 +2,7 @@
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --shared-libs=%mlir_runner_utils \
 // RUN:                                        --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.LarsMomentum4d.mlir
+++ b/test/PlaidML/OpTest.LarsMomentum4d.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map1 = affine_map<(d0, d1, d2, d3) -> ()>

--- a/test/PlaidML/OpTest.Layer.mlir
+++ b/test/PlaidML/OpTest.Layer.mlir
@@ -2,7 +2,7 @@
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --shared-libs=%mlir_runner_utils \
 // RUN:                                        --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.Layer.mlir
+++ b/test/PlaidML/OpTest.Layer.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> ()>

--- a/test/PlaidML/OpTest.LayerEmbeddedConst.mlir
+++ b/test/PlaidML/OpTest.LayerEmbeddedConst.mlir
@@ -2,7 +2,7 @@
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --shared-libs=%mlir_runner_utils \
 // RUN:                                        --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.LayerEmbeddedConst.mlir
+++ b/test/PlaidML/OpTest.LayerEmbeddedConst.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @LayerEmbeddedConst {

--- a/test/PlaidML/OpTest.LayerException.mlir
+++ b/test/PlaidML/OpTest.LayerException.mlir
@@ -2,7 +2,7 @@
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --shared-libs=%mlir_runner_utils \
 // RUN:                                        --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.LayerException.mlir
+++ b/test/PlaidML/OpTest.LayerException.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @LayerException {

--- a/test/PlaidML/OpTest.LayerMulti.mlir
+++ b/test/PlaidML/OpTest.LayerMulti.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @LayerMulti {

--- a/test/PlaidML/OpTest.LayerMulti.mlir
+++ b/test/PlaidML/OpTest.LayerMulti.mlir
@@ -2,7 +2,7 @@
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --shared-libs=%mlir_runner_utils \
 // RUN:                                        --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.LayerOperandOrder.mlir
+++ b/test/PlaidML/OpTest.LayerOperandOrder.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @LayerOperandOrder {

--- a/test/PlaidML/OpTest.LayerOperandOrder.mlir
+++ b/test/PlaidML/OpTest.LayerOperandOrder.mlir
@@ -2,7 +2,7 @@
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --shared-libs=%mlir_runner_utils \
 // RUN:                                        --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.LayerUnusedOperand.mlir
+++ b/test/PlaidML/OpTest.LayerUnusedOperand.mlir
@@ -2,7 +2,7 @@
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --shared-libs=%mlir_runner_utils \
 // RUN:                                        --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.LayerUnusedOperand.mlir
+++ b/test/PlaidML/OpTest.LayerUnusedOperand.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @LayerUnusedOperand {

--- a/test/PlaidML/OpTest.Lens.mlir
+++ b/test/PlaidML/OpTest.Lens.mlir
@@ -2,7 +2,7 @@
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --shared-libs=%mlir_runner_utils \
 // RUN:                                        --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.Lens.mlir
+++ b/test/PlaidML/OpTest.Lens.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                        --runner mlir-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
-// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                        --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 #map0 = affine_map<(d0, d1) -> (d1, d0)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>

--- a/test/PlaidML/OpTest.LogicalAnd_mixed.mlir
+++ b/test/PlaidML/OpTest.LogicalAnd_mixed.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.LogicalAnd_mixed.mlir
+++ b/test/PlaidML/OpTest.LogicalAnd_mixed.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @logical_and {
 func.func @main() {

--- a/test/PlaidML/OpTest.LogicalAnd_uint64.mlir
+++ b/test/PlaidML/OpTest.LogicalAnd_uint64.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.LogicalAnd_uint64.mlir
+++ b/test/PlaidML/OpTest.LogicalAnd_uint64.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @logical_and {
 func.func @main() {

--- a/test/PlaidML/OpTest.LogicalNot_float.mlir
+++ b/test/PlaidML/OpTest.LogicalNot_float.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.LogicalNot_float.mlir
+++ b/test/PlaidML/OpTest.LogicalNot_float.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @logical_not {
 func.func @main() {

--- a/test/PlaidML/OpTest.LogicalNot_int32.mlir
+++ b/test/PlaidML/OpTest.LogicalNot_int32.mlir
@@ -6,7 +6,7 @@
 // RUN:                                       --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @logical_not {
 func.func @main() {

--- a/test/PlaidML/OpTest.LogicalNot_int32.mlir
+++ b/test/PlaidML/OpTest.LogicalNot_int32.mlir
@@ -2,7 +2,8 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner -i %s --requires=l0-runtime \
+// RUN:                                       --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.LogicalOr_float.mlir
+++ b/test/PlaidML/OpTest.LogicalOr_float.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.LogicalOr_float.mlir
+++ b/test/PlaidML/OpTest.LogicalOr_float.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @logical_or {
 func.func @main() {

--- a/test/PlaidML/OpTest.LogicalOr_int32.mlir
+++ b/test/PlaidML/OpTest.LogicalOr_int32.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.LogicalOr_int32.mlir
+++ b/test/PlaidML/OpTest.LogicalOr_int32.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @logical_or {
 func.func @main() {

--- a/test/PlaidML/OpTest.LogicalOr_uint64.mlir
+++ b/test/PlaidML/OpTest.LogicalOr_uint64.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.LogicalOr_uint64.mlir
+++ b/test/PlaidML/OpTest.LogicalOr_uint64.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @logical_or {
 func.func @main() {

--- a/test/PlaidML/OpTest.Matmul.mlir
+++ b/test/PlaidML/OpTest.Matmul.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.Matmul.mlir
+++ b/test/PlaidML/OpTest.Matmul.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 
 module @linalg_matmul{
 func.func @matmul(%arg0: tensor<5x3xf32>, %arg1: tensor<3x2xf32>) -> (tensor<5x2xf32>) {

--- a/test/PlaidML/OpTest.Max.mlir
+++ b/test/PlaidML/OpTest.Max.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.Max.mlir
+++ b/test/PlaidML/OpTest.Max.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d0)>
 module @max {

--- a/test/PlaidML/OpTest.MaxPool1D.mlir
+++ b/test/PlaidML/OpTest.MaxPool1D.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.MaxPool1D.mlir
+++ b/test/PlaidML/OpTest.MaxPool1D.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1) -> (d1)>
 #map1 = affine_map<(d0, d1) -> (d0)>
 module @max_pool_1d {

--- a/test/PlaidML/OpTest.MnistCnn.mlir
+++ b/test/PlaidML/OpTest.MnistCnn.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.MnistCnn.mlir
+++ b/test/PlaidML/OpTest.MnistCnn.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map1 = affine_map<(d0, d1, d2, d3) -> (d3)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>

--- a/test/PlaidML/OpTest.MnistMlp.mlir
+++ b/test/PlaidML/OpTest.MnistMlp.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.MnistMlp.mlir
+++ b/test/PlaidML/OpTest.MnistMlp.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1) -> (d1)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d2)>

--- a/test/PlaidML/OpTest.Pow.mlir
+++ b/test/PlaidML/OpTest.Pow.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.Pow.mlir
+++ b/test/PlaidML/OpTest.Pow.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @pow {
 func.func @main() {

--- a/test/PlaidML/OpTest.Quantize.mlir
+++ b/test/PlaidML/OpTest.Quantize.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --entry-point-result=void \
-// RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0) -> (d0)>
 #map1 = affine_map<(d0) -> ()>
 module @quantize {

--- a/test/PlaidML/OpTest.Quantize.mlir
+++ b/test/PlaidML/OpTest.Quantize.mlir
@@ -2,7 +2,7 @@
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --shared-libs=%mlir_runner_utils \
 // RUN:                                            --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                            --runner mlir-cpu-runner -e main \
 // RUN:                                            --entry-point-result=void \
 // RUN:                                            --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.Reciprocal.mlir
+++ b/test/PlaidML/OpTest.Reciprocal.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.Reciprocal.mlir
+++ b/test/PlaidML/OpTest.Reciprocal.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0) -> ()>
 #map1 = affine_map<(d0) -> (d0)>
 module @reciprocal {

--- a/test/PlaidML/OpTest.Relu.mlir
+++ b/test/PlaidML/OpTest.Relu.mlir
@@ -2,7 +2,8 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner -i %s --requires=l0-runtime \
+// RUN:                                       --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.Relu.mlir
+++ b/test/PlaidML/OpTest.Relu.mlir
@@ -6,7 +6,7 @@
 // RUN:                                       --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> ()>
 module @relu {

--- a/test/PlaidML/OpTest.RepeatElements.mlir
+++ b/test/PlaidML/OpTest.RepeatElements.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1, d2) -> (d0, d1 floordiv 3, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 module @repeat_elts {

--- a/test/PlaidML/OpTest.RepeatElements.mlir
+++ b/test/PlaidML/OpTest.RepeatElements.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.ReshapeFold.mlir
+++ b/test/PlaidML/OpTest.ReshapeFold.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.ReshapeFold.mlir
+++ b/test/PlaidML/OpTest.ReshapeFold.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @reshape_fold {
 func.func @main() {

--- a/test/PlaidML/OpTest.ReshapeIntoScalar.mlir
+++ b/test/PlaidML/OpTest.ReshapeIntoScalar.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.ReshapeIntoScalar.mlir
+++ b/test/PlaidML/OpTest.ReshapeIntoScalar.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<() -> ()>
 module @reshape_into_scalar {
 func.func @main() {

--- a/test/PlaidML/OpTest.Select.mlir
+++ b/test/PlaidML/OpTest.Select.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.Select.mlir
+++ b/test/PlaidML/OpTest.Select.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> ()>
 module @select {

--- a/test/PlaidML/OpTest.Shape.mlir
+++ b/test/PlaidML/OpTest.Shape.mlir
@@ -2,7 +2,8 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner -i %s --requires=l0-runtime \
+// RUN:                                       --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.Shape.mlir
+++ b/test/PlaidML/OpTest.Shape.mlir
@@ -6,7 +6,7 @@
 // RUN:                                       --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 module @shape {
 func.func @main() {
     %0= arith.constant dense<[[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]>:tensor<2x3xf32>

--- a/test/PlaidML/OpTest.SimpleAdd.mlir
+++ b/test/PlaidML/OpTest.SimpleAdd.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.SimpleAdd.mlir
+++ b/test/PlaidML/OpTest.SimpleAdd.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @simple_add {
 func.func @main() {

--- a/test/PlaidML/OpTest.Sin.mlir
+++ b/test/PlaidML/OpTest.Sin.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.Sin.mlir
+++ b/test/PlaidML/OpTest.Sin.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @sin {
 func.func @main() {

--- a/test/PlaidML/OpTest.SinH.mlir
+++ b/test/PlaidML/OpTest.SinH.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.SinH.mlir
+++ b/test/PlaidML/OpTest.SinH.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @sinh {
 func.func @main() {

--- a/test/PlaidML/OpTest.Softmax.mlir
+++ b/test/PlaidML/OpTest.Softmax.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.Softmax.mlir
+++ b/test/PlaidML/OpTest.Softmax.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d0, 0)>
 module @softmax {

--- a/test/PlaidML/OpTest.Sum.mlir
+++ b/test/PlaidML/OpTest.Sum.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.Sum.mlir
+++ b/test/PlaidML/OpTest.Sum.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> ()>
 module @sum {

--- a/test/PlaidML/OpTest.Tan.mlir
+++ b/test/PlaidML/OpTest.Tan.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.Tan.mlir
+++ b/test/PlaidML/OpTest.Tan.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @tan {
 func.func @main() {

--- a/test/PlaidML/OpTest.Transpose.mlir
+++ b/test/PlaidML/OpTest.Transpose.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.Transpose.mlir
+++ b/test/PlaidML/OpTest.Transpose.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map0 = affine_map<(d0, d1) -> (d1, d0)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>
 module @transpose {

--- a/test/PlaidML/OpTest.UniqueNames.mlir
+++ b/test/PlaidML/OpTest.UniqueNames.mlir
@@ -2,7 +2,7 @@
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --shared-libs=%mlir_runner_utils \
 // RUN:                                       --entry-point-result=void | FileCheck %s
-// RUN: %gpu_skip || %python_executable %imex_runner -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s

--- a/test/PlaidML/OpTest.UniqueNames.mlir
+++ b/test/PlaidML/OpTest.UniqueNames.mlir
@@ -5,7 +5,7 @@
 // RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/linalg-to-llvm.pp \
 // RUN:                                       --runner mlir-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime | FileCheck %s
+// RUN:                                       --shared-libs=%mlir_runner_utils,%levelzero_runtime --filecheck
 #map = affine_map<(d0) -> (d0)>
 module @unique_names {
 func.func @main() {

--- a/test/PlaidML/lit.local.cfg
+++ b/test/PlaidML/lit.local.cfg
@@ -1,4 +1,3 @@
-
 local_excludes = [
                   'CppEdsl.Atan.mlir',
                   'CppEdsl.Erf.mlir',
@@ -11,8 +10,3 @@ local_excludes = [
                   'CppEdsl.DefractLong.mlir'
                  ]
 config.excludes.update(local_excludes)
-
-if config.gpu_skip == 'true':
-    config.substitutions.append(('%gpu_skip', 'true'))
-else:
-    config.substitutions.append(('%gpu_skip', 'false'))

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -44,6 +44,8 @@ if config.imex_enable_sycl_runtime:
     config.substitutions.append(('%sycl_runtime', config.sycl_runtime))
 if config.imex_enable_l0_runtime:
     config.substitutions.append(('%levelzero_runtime', config.levelzero_runtime))
+if config.imex_enable_igpu:
+    config.substitutions.append(('%igpu_fp64', config.igpu_fp64))
 
 llvm_config.with_system_environment(
     ['HOME', 'INCLUDE', 'LIB', 'TMP', 'TEMP'])

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -36,11 +36,14 @@ config.substitutions.append(('%mlir_lib_dir', config.mlir_runner_utils_dir))
 config.substitutions.append(('%imex_tools_dir', config.imex_tools_dir))
 config.substitutions.append(('%mlir_runner_utils', config.mlir_runner_utils))
 config.substitutions.append(('%mlir_c_runner_utils', config.mlir_c_runner_utils))
-config.substitutions.append(('%vulkan_runtime_wrappers', config.vulkan_runtime_wrappers))
+if config.enable_vulkan_runner:
+    config.substitutions.append(('%vulkan_runtime_wrappers', config.vulkan_runtime_wrappers))
 config.substitutions.append(('%imex_runner', config.imex_runner))
 config.substitutions.append(('%python_executable', config.python_executable))
-config.substitutions.append(('%sycl_runtime', config.sycl_runtime))
-config.substitutions.append(('%levelzero_runtime', config.levelzero_runtime))
+if config.imex_enable_sycl_runtime:
+    config.substitutions.append(('%sycl_runtime', config.sycl_runtime))
+if config.imex_enable_l0_runtime:
+    config.substitutions.append(('%levelzero_runtime', config.levelzero_runtime))
 
 llvm_config.with_system_environment(
     ['HOME', 'INCLUDE', 'LIB', 'TMP', 'TEMP'])

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -53,7 +53,7 @@ if config.imex_enable_l0_runtime:
     config.levelzero_runtime = os.path.normpath(os.path.join(config.imex_lib_dir, config.shlib_prefix + "level-zero-runtime" + config.llvm_shlib_ext))
 config.imex_enable_igpu = config.imex_enable_l0_runtime or config.imex_enable_sycl_runtime
 if config.imex_enable_igpu:
-    config.l0_fp64_checker = os.path.normpath(os.path.join(config.imex_tools_dir, "l0_fp64_checker"))
+    config.l0_fp64_checker = os.path.normpath(os.path.join(config.imex_tools_dir, "l0-fp64-checker"))
     p = subprocess.run( [ config.l0_fp64_checker ] )
     if p.returncode == 0:
         config.igpu_fp64 = "--igpu-fp64"

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -1,6 +1,7 @@
 @LIT_SITE_CFG_IN_HEADER@
 
 import sys
+import subprocess
 
 config.host_triple = "@LLVM_HOST_TRIPLE@"
 config.target_triple = "@TARGET_TRIPLE@"
@@ -50,6 +51,14 @@ if config.imex_enable_sycl_runtime:
     config.sycl_runtime = os.path.normpath(os.path.join(config.imex_lib_dir, config.shlib_prefix + "sycl-runtime" + config.llvm_shlib_ext))
 if config.imex_enable_l0_runtime:
     config.levelzero_runtime = os.path.normpath(os.path.join(config.imex_lib_dir, config.shlib_prefix + "level-zero-runtime" + config.llvm_shlib_ext))
+config.imex_enable_igpu = config.imex_enable_l0_runtime or config.imex_enable_sycl_runtime
+if config.imex_enable_igpu:
+    config.l0_fp64_checker = os.path.normpath(os.path.join(config.imex_tools_dir, "l0_fp64_checker"))
+    p = subprocess.run( [ config.l0_fp64_checker ] )
+    if p.returncode == 0:
+        config.igpu_fp64 = "--igpu-fp64"
+    else:
+        config.igpu_fp64 = "--no-igpu-fp64"
 
 # Support substitution of the tools_dir with user parameters. This is
 # used when we can't determine the tool dir at configuration time.

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -37,11 +37,6 @@ config.imex_lib_dir = "@IMEX_LIB_DIR@"
 config.imex_enable_l0_runtime = @IMEX_ENABLE_L0_RUNTIME@
 config.imex_enable_sycl_runtime = @IMEX_ENABLE_SYCL_RUNTIME@
 
-if config.imex_enable_l0_runtime:
-    config.gpu_skip = "false"
-else:
-    config.gpu_skip = "true"
-
 if sys.platform.startswith('win32'):
     config.shlib_prefix = ""
 else:

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -44,9 +44,12 @@ else:
 config.imex_runner = os.path.normpath(os.path.join(config.imex_tools_dir, "imex-runner.py"))
 config.mlir_runner_utils = os.path.normpath(os.path.join(config.mlir_runner_utils_dir, config.shlib_prefix + "mlir_runner_utils" + config.llvm_shlib_ext))
 config.mlir_c_runner_utils = os.path.normpath(os.path.join(config.mlir_runner_utils_dir, config.shlib_prefix + "mlir_c_runner_utils" + config.llvm_shlib_ext))
-config.vulkan_runtime_wrappers = os.path.normpath(os.path.join(config.mlir_runner_utils_dir, config.shlib_prefix + "vulkan-runtime-wrappers" + config.llvm_shlib_ext))
-config.sycl_runtime = os.path.normpath(os.path.join(config.imex_lib_dir, config.shlib_prefix + "sycl-runtime" + config.llvm_shlib_ext))
-config.levelzero_runtime = os.path.normpath(os.path.join(config.imex_lib_dir, config.shlib_prefix + "level-zero-runtime" + config.llvm_shlib_ext))
+if config.enable_vulkan_runner:
+    config.vulkan_runtime_wrappers = os.path.normpath(os.path.join(config.mlir_runner_utils_dir, config.shlib_prefix + "vulkan-runtime-wrappers" + config.llvm_shlib_ext))
+if config.imex_enable_sycl_runtime:
+    config.sycl_runtime = os.path.normpath(os.path.join(config.imex_lib_dir, config.shlib_prefix + "sycl-runtime" + config.llvm_shlib_ext))
+if config.imex_enable_l0_runtime:
+    config.levelzero_runtime = os.path.normpath(os.path.join(config.imex_lib_dir, config.shlib_prefix + "level-zero-runtime" + config.llvm_shlib_ext))
 
 # Support substitution of the tools_dir with user parameters. This is
 # used when we can't determine the tool dir at configuration time.

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,3 +1,6 @@
 add_subdirectory(imex-runner)
 add_subdirectory(imex-opt)
+if(IMEX_ENABLE_L0_RUNTIME OR IMEX_ENABLE_SYCL_RUNTIME)
+    add_subdirectory(l0-fp64-checker)
+endif()
 set(IMEX_TOOLS_DIR ${IMEX_BINARY_DIR}/bin PARENT_SCOPE)

--- a/tools/imex-runner/imex-runner.py.in
+++ b/tools/imex-runner/imex-runner.py.in
@@ -56,7 +56,7 @@ imex_enable_sycl_runtime = @IMEX_ENABLE_SYCL_RUNTIME@
 
 runner_choices = ['mlir-cpu-runner']
 enabled_features = []
-all_features = ['vulkan-runner', 'l0-runtime', 'sycl-runtime']
+all_features = ['vulkan-runner', 'l0-runtime', 'sycl-runtime', 'igpu-fp64']
 if imex_enable_vulkan_runner:
     runner_choices.append('mlir-vulkan-runner')
     enabled_features.append('vulkan-runner')
@@ -83,6 +83,8 @@ parser.add_argument("--filecheck", action='store_true', dest='run_filecheck', he
 parser.add_argument("--check-prefix", default=None, help="change check prefix (default: CHECK) used by FileCheck")
 parser.add_argument("--runner", "-r", default="mlir-cpu-runner", choices=runner_choices, help="mlir runner name")
 parser.add_argument('--requires', default=enabled_features, action=SplitArgs, help="skip if any of the required in the comma separated list is missing.")
+parser.add_argument("--igpu-fp64", action='store_true', dest='igpu_has_fp64', help="notify runner that igpu has fp64 support")
+parser.add_argument("--no-igpu-fp64", action='store_false', dest='igpu_has_fp64', help="notify runner that igpu does not have fp64 support")
 
 args, unknown = parser.parse_known_args()
 
@@ -93,6 +95,9 @@ if not set(required_features) <= set(all_features):
     print('your options were: ', *required_features)
     print('valid options are: ', *all_features)
     exit(1)
+
+if args.igpu_has_fp64:
+    enabled_features.append('igpu-fp64')
 
 # Skip runner if requirements are not met be enabled features
 if not set(required_features) <= set(enabled_features):

--- a/tools/l0-fp64-checker/CMakeLists.txt
+++ b/tools/l0-fp64-checker/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if(NOT LEVEL_ZERO_DIR)
+    message(FATAL_ERROR "LEVEL_ZERO_DIR is not set")
+endif()
+
+add_imex_tool(l0-fp64-checker l0-fp64-checker.cpp)
+
+target_compile_options (l0-fp64-checker PUBLIC -fexceptions)
+
+target_include_directories(l0-fp64-checker PRIVATE
+    ${LEVEL_ZERO_DIR}/include/
+    )
+
+target_link_directories(l0-fp64-checker PRIVATE
+    ${LEVEL_ZERO_DIR}/lib
+    )
+
+target_link_libraries(l0-fp64-checker PRIVATE ze_loader)

--- a/tools/l0-fp64-checker/l0-fp64-checker.cpp
+++ b/tools/l0-fp64-checker/l0-fp64-checker.cpp
@@ -17,57 +17,57 @@
 #include <iostream>
 #include <vector>
 
-#define VALIDATECALL(zeCall) \
-    if (zeCall != ZE_RESULT_SUCCESS){ \
-        exit(1); \
-    }
+#define VALIDATECALL(zeCall)                                                   \
+  if (zeCall != ZE_RESULT_SUCCESS) {                                           \
+    exit(1);                                                                   \
+  }
 
 // Find the first GPU device and check fp64 support
 int main() {
-    // Initialization
-    VALIDATECALL(zeInit(ZE_INIT_FLAG_GPU_ONLY));
+  // Initialization
+  VALIDATECALL(zeInit(ZE_INIT_FLAG_GPU_ONLY));
 
-    // Get drivers
-    uint32_t driverCount = 0;
-    VALIDATECALL(zeDriverGet(&driverCount, nullptr));
+  // Get drivers
+  uint32_t driverCount = 0;
+  VALIDATECALL(zeDriverGet(&driverCount, nullptr));
 
-    if(driverCount == 0) {
-        return 1;
-    }
-
-    std::vector<ze_driver_handle_t> drivers( driverCount );
-    VALIDATECALL(zeDriverGet( &driverCount, drivers.data() ));
-
-    for (uint32_t i = 0; i < driverCount; ++i) {
-        auto driver = drivers[i];
-        // Get the device
-        uint32_t deviceCount = 0;
-        VALIDATECALL(zeDeviceGet(driver, &deviceCount, nullptr));
-
-        if(deviceCount == 0) {
-            continue;
-        }
-
-        std::vector<ze_device_handle_t> devices(deviceCount);
-        VALIDATECALL(zeDeviceGet(driver, &deviceCount, devices.data()));
-        for (uint32_t j = 0; j < deviceCount; ++j) {
-            auto device = devices[j];
-            ze_device_properties_t deviceProperties;
-            deviceProperties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
-            VALIDATECALL(zeDeviceGetProperties(device, &deviceProperties));
-            if (ZE_DEVICE_TYPE_GPU == deviceProperties.type) {
-                ze_device_module_properties_t moduleProperties;
-                moduleProperties.stype = ZE_STRUCTURE_TYPE_DEVICE_MODULE_PROPERTIES;
-                VALIDATECALL(zeDeviceGetModuleProperties(device, &moduleProperties));
-
-                // GPU does not have fp64
-                if(moduleProperties.fp64flags == 0) {
-                    return 1;
-                } else {
-                    return 0;
-                }
-            }
-        }
-    }
+  if (driverCount == 0) {
     return 1;
+  }
+
+  std::vector<ze_driver_handle_t> drivers(driverCount);
+  VALIDATECALL(zeDriverGet(&driverCount, drivers.data()));
+
+  for (uint32_t i = 0; i < driverCount; ++i) {
+    auto driver = drivers[i];
+    // Get the device
+    uint32_t deviceCount = 0;
+    VALIDATECALL(zeDeviceGet(driver, &deviceCount, nullptr));
+
+    if (deviceCount == 0) {
+      continue;
+    }
+
+    std::vector<ze_device_handle_t> devices(deviceCount);
+    VALIDATECALL(zeDeviceGet(driver, &deviceCount, devices.data()));
+    for (uint32_t j = 0; j < deviceCount; ++j) {
+      auto device = devices[j];
+      ze_device_properties_t deviceProperties;
+      deviceProperties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
+      VALIDATECALL(zeDeviceGetProperties(device, &deviceProperties));
+      if (ZE_DEVICE_TYPE_GPU == deviceProperties.type) {
+        ze_device_module_properties_t moduleProperties;
+        moduleProperties.stype = ZE_STRUCTURE_TYPE_DEVICE_MODULE_PROPERTIES;
+        VALIDATECALL(zeDeviceGetModuleProperties(device, &moduleProperties));
+
+        // GPU does not have fp64
+        if (moduleProperties.fp64flags == 0) {
+          return 1;
+        } else {
+          return 0;
+        }
+      }
+    }
+  }
+  return 1;
 }

--- a/tools/l0-fp64-checker/l0-fp64-checker.cpp
+++ b/tools/l0-fp64-checker/l0-fp64-checker.cpp
@@ -1,0 +1,55 @@
+//===- l0-fp64-checker.cpp --------------------------------------*- C++ -*-===//
+//
+// Copyright 2022 Intel Corporation
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines gpu fp64 support utility.
+//
+//===----------------------------------------------------------------------===//
+
+#include <level_zero/ze_api.h>
+
+#include <cstring>
+#include <iostream>
+
+#define VALIDATECALL(zeCall) \
+    if (zeCall != ZE_RESULT_SUCCESS){ \
+	exit(1); \
+    }
+
+int main() {
+
+    // Initialization
+    VALIDATECALL(zeInit(ZE_INIT_FLAG_GPU_ONLY));
+
+    // Get the driver
+    uint32_t driverCount = 0;
+    VALIDATECALL(zeDriverGet(&driverCount, nullptr));
+
+    if(driverCount == 0) {
+	exit(1);
+    }
+    ze_driver_handle_t driverHandle;
+    VALIDATECALL(zeDriverGet(&driverCount, &driverHandle));
+
+    // Get the device
+    uint32_t deviceCount = 0;
+    VALIDATECALL(zeDeviceGet(driverHandle, &deviceCount, nullptr));
+
+    if(deviceCount == 0) {
+	exit(1);
+    }
+    ze_device_handle_t device;
+    VALIDATECALL(zeDeviceGet(driverHandle, &deviceCount, &device));
+
+    ze_device_module_properties_t moduleProperties;
+    VALIDATECALL(zeDeviceGetModuleProperties(device, &moduleProperties));
+
+    if(moduleProperties.fp64flags == 0)
+	exit(1);
+    return 0;
+}

--- a/tools/l0-fp64-checker/l0-fp64-checker.cpp
+++ b/tools/l0-fp64-checker/l0-fp64-checker.cpp
@@ -15,41 +15,59 @@
 
 #include <cstring>
 #include <iostream>
+#include <vector>
 
 #define VALIDATECALL(zeCall) \
     if (zeCall != ZE_RESULT_SUCCESS){ \
-	exit(1); \
+        exit(1); \
     }
 
+// Find the first GPU device and check fp64 support
 int main() {
-
     // Initialization
     VALIDATECALL(zeInit(ZE_INIT_FLAG_GPU_ONLY));
 
-    // Get the driver
+    // Get drivers
     uint32_t driverCount = 0;
     VALIDATECALL(zeDriverGet(&driverCount, nullptr));
 
     if(driverCount == 0) {
-	exit(1);
+        return 1;
     }
-    ze_driver_handle_t driverHandle;
-    VALIDATECALL(zeDriverGet(&driverCount, &driverHandle));
 
-    // Get the device
-    uint32_t deviceCount = 0;
-    VALIDATECALL(zeDeviceGet(driverHandle, &deviceCount, nullptr));
+    std::vector<ze_driver_handle_t> drivers( driverCount );
+    VALIDATECALL(zeDriverGet( &driverCount, drivers.data() ));
 
-    if(deviceCount == 0) {
-	exit(1);
+    for (uint32_t i = 0; i < driverCount; ++i) {
+        auto driver = drivers[i];
+        // Get the device
+        uint32_t deviceCount = 0;
+        VALIDATECALL(zeDeviceGet(driver, &deviceCount, nullptr));
+
+        if(deviceCount == 0) {
+            continue;
+        }
+
+        std::vector<ze_device_handle_t> devices(deviceCount);
+        VALIDATECALL(zeDeviceGet(driver, &deviceCount, devices.data()));
+        for (uint32_t j = 0; j < deviceCount; ++j) {
+            auto device = devices[j];
+            ze_device_properties_t deviceProperties;
+            deviceProperties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
+            VALIDATECALL(zeDeviceGetProperties(device, &deviceProperties));
+            if (ZE_DEVICE_TYPE_GPU == deviceProperties.type) {
+                ze_device_module_properties_t moduleProperties;
+                moduleProperties.stype = ZE_STRUCTURE_TYPE_DEVICE_MODULE_PROPERTIES;
+                VALIDATECALL(zeDeviceGetModuleProperties(device, &moduleProperties));
+
+                // GPU does not have fp64
+                if(moduleProperties.fp64flags == 0) {
+                    return 1;
+                } else {
+                    return 0;
+                }
+            }
+        }
     }
-    ze_device_handle_t device;
-    VALIDATECALL(zeDeviceGet(driverHandle, &deviceCount, &device));
-
-    ze_device_module_properties_t moduleProperties;
-    VALIDATECALL(zeDeviceGetModuleProperties(device, &moduleProperties));
-
-    if(moduleProperties.fp64flags == 0)
-	exit(1);
-    return 0;
+    return 1;
 }


### PR DESCRIPTION
- Use imex-runner.py's "--requires" option to control conditionally running gpu tests.
- Add a new tool l0-fp64-checker that checks if underlying IGPU has fp64 support.
- Skip gpu test that require fp64 support on systems that do not have gpu fp64. Tested with Tiger Lake Gen 12 graphics on WSL.
- Limit number of LIT workers to 1 if gpu tests are enabled. Running multiple gpu tests concurrently causes non deterministic failures due to running out of gpu resource.
- Added unified way of setting new cmake variable "LINUX" introduced in cmake 3.25 

Please review these guidelines to help with the review process:
- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
- [x] Have you organized your commits logically and ensured each can be built by itself?
