### PR TITLE
Move FMA uplifting after main optimization pass

### DIFF
--- a/mlir/include/imex/Transforms/UpliftMath.hpp
+++ b/mlir/include/imex/Transforms/UpliftMath.hpp
@@ -13,7 +13,12 @@ class Pass;
 } // namespace mlir
 
 namespace imex {
-void populateUpliftmathPatterns(mlir::RewritePatternSet &patterns);
+void populateUpliftMathPatterns(mlir::RewritePatternSet &patterns);
+void populateUpliftFMAPatterns(mlir::RewritePatternSet &patterns);
 
+/// This pass tries to uplift libm-style func call to math dialect ops.
 std::unique_ptr<mlir::Pass> createUpliftMathPass();
+
+/// This pass tries to uplift sequence of arith ops to math.fma op.
+std::unique_ptr<mlir::Pass> createUpliftFMAPass();
 } // namespace imex

--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_basic.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_basic.py
@@ -245,14 +245,14 @@ def test_math_uplifting_fma(py_func):
     y = 3.0
     z = 4.0
 
-    with print_pass_ir([], ["UpliftMathPass"]):
+    with print_pass_ir([], ["UpliftFMAPass"]):
         jit_func = njit(py_func, fastmath=False)
 
         assert_equal(py_func(x, y, z), jit_func(x, y, z))
         ir = get_print_buffer()
         assert ir.count(f"math.fma") == 0, ir
 
-    with print_pass_ir([], ["UpliftMathPass"]):
+    with print_pass_ir([], ["UpliftFMAPass"]):
         jit_func = njit(py_func, fastmath=True)
 
         assert_equal(py_func(x, y, z), jit_func(x, y, z))
@@ -860,12 +860,12 @@ def test_fastmath_indirect():
     jit_func2 = njit(py_func2)
 
     a, b, c = (2.0, 3.5, 4.7)
-    with print_pass_ir([], ["UpliftMathPass"]):
+    with print_pass_ir([], ["UpliftFMAPass"]):
         assert_equal(py_func1(a, b, c), jit_func1(a, b, c))
         ir = get_print_buffer()
         assert ir.count("math.fma") > 0, ir
 
-    with print_pass_ir([], ["UpliftMathPass"]):
+    with print_pass_ir([], ["UpliftFMAPass"]):
         assert_equal(py_func2(a, b, c), jit_func2(a, b, c))
         ir = get_print_buffer()
         assert ir.count("math.fma") > 0, ir

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -3215,6 +3215,10 @@ static void populatePlierToLinalgOptPipeline(mlir::OpPassManager &pm) {
             std::make_unique<PostLinalgOptInnerPass>());
       }));
 
+  // Uplifting FMAs con interfere with other optimizations, like loop reduction
+  // uplifting. Move it after main optimization pass.
+  pm.addNestedPass<mlir::func::FuncOp>(imex::createUpliftFMAPass());
+  pm.addNestedPass<mlir::func::FuncOp>(mlir::createCanonicalizerPass());
   pm.addNestedPass<mlir::func::FuncOp>(
       std::make_unique<FixDeallocPlacementPass>());
 


### PR DESCRIPTION
FMA uplifting can interfere with other optimizations, like loop reductions uplifting. Move it after main optimization pass.