### PR TITLE
Add SPV_AMD_shader_ballot extension for OpenCL environment

### DIFF
--- a/lib/Transforms/SetSPIRVCapabilities.cpp
+++ b/lib/Transforms/SetSPIRVCapabilities.cpp
@@ -72,7 +72,8 @@ public:
     };
     spirv::Extension exts_opencl[] = {
         spirv::Extension::SPV_EXT_shader_atomic_float_add,
-        spirv::Extension::SPV_KHR_expect_assume};
+        spirv::Extension::SPV_KHR_expect_assume,
+        spirv::Extension::SPV_AMD_shader_ballot};
     spirv::Extension exts_vulkan[] = {
         spirv::Extension::SPV_KHR_storage_buffer_storage_class};
     if (m_clientAPI == "opencl") {

--- a/test/Conversion/GPUToSPIRV/loadstore.mlir
+++ b/test/Conversion/GPUToSPIRV/loadstore.mlir
@@ -2,7 +2,7 @@
 
 module attributes {
   gpu.container_module,
-  spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume]>, #spirv.resource_limits<>>
+  spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_AMD_shader_ballot]>, #spirv.resource_limits<>>
 } {
   func.func @load_store(%arg0: memref<2x5xf32>, %arg1: memref<2x5xf32>, %arg2: memref<2x5xf32>) {
     %c5 = arith.constant 5 : index

--- a/test/Conversion/GPUToSPIRV/scf.mlir
+++ b/test/Conversion/GPUToSPIRV/scf.mlir
@@ -2,7 +2,7 @@
 
 module attributes {
     gpu.container_module,
-    spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume]>, #spirv.resource_limits<>>
+    spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_AMD_shader_ballot]>, #spirv.resource_limits<>>
 } {
   gpu.module @kernels {
     // CHECK:       spirv.module @{{.*}} Physical64 OpenCL

--- a/test/Transforms/set-spirv-capability.mlir
+++ b/test/Transforms/set-spirv-capability.mlir
@@ -4,7 +4,7 @@
 module attributes {gpu.container_module} {
 
 // OPENCL: module attributes {gpu.container_module} {
-// OPENCL: gpu.module @main_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume]>, api=OpenCL, #spirv.resource_limits<>>} {
+// OPENCL: gpu.module @main_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_AMD_shader_ballot]>, api=OpenCL, #spirv.resource_limits<>>} {
 // VULKAN: module attributes {gpu.container_module} {
 // VULKAN: gpu.module @main_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]>, api=Vulkan, #spirv.resource_limits<>>} {
   gpu.module @main_kernel {


### PR DESCRIPTION
set-spirv-capabilities pass adds "Group" capability for OpenCL environment. However, capability "Group" is part of "SPV_AMD_shader_ballot" extension, this extension was not added previously.

Please review these guidelines to help with the review process:
- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [ ] Have you organized your commits logically and ensured each can be built by itself?
