### PR TITLE
Fix shape inference

### DIFF
--- a/mlir/lib/Transforms/ShapeIntegerRangePropagation.cpp
+++ b/mlir/lib/Transforms/ShapeIntegerRangePropagation.cpp
@@ -109,7 +109,9 @@ public:
     if (isUninitialized()) {
       os << "None";
     } else {
+      os << "[";
       llvm::interleaveComma(*shapeRanges, os);
+      os << "]";
     }
   }
 
@@ -507,6 +509,9 @@ public:
         if (!newRange)
           continue;
 
+        LLVM_DEBUG(llvm::dbgs() << "ShapeValueAnalysis: initialize: " << arg
+                                << " " << *newRange << "\n");
+
         auto *lattice = getLatticeElement(arg);
         assert(lattice);
         assert(lattice->getValue().isUninitialized());
@@ -558,6 +563,8 @@ public:
       }();
 
       if (newRange) {
+        LLVM_DEBUG(llvm::dbgs() << "IntegerRangeAnalysisEx: New dim val: "
+                                << newRange << "\n");
         auto changed =
             lattice->join(mlir::dataflow::IntegerValueRange{newRange});
         propagateIfChanged(lattice, changed);

--- a/mlir/lib/Transforms/ShapeIntegerRangePropagation.cpp
+++ b/mlir/lib/Transforms/ShapeIntegerRangePropagation.cpp
@@ -572,6 +572,19 @@ public:
       return;
     }
 
+    // TODO: upstream
+    if (!mlir::isa<mlir::InferIntRangeInterface>(op)) {
+      for (auto [lattice, value] : llvm::zip(results, op->getResults())) {
+        if (value.getType().isIntOrIndex()) {
+          propagateIfChanged(
+              lattice,
+              lattice->join(
+                  mlir::dataflow::IntegerValueRange::getMaxRange(value)));
+        }
+      }
+      return setAllToEntryStates(results);
+    }
+
     mlir::dataflow::IntegerRangeAnalysis::visitOperation(op, operands, results);
   }
 };

--- a/mlir/test/Transforms/shape-int-range-opts.mlir
+++ b/mlir/test/Transforms/shape-int-range-opts.mlir
@@ -180,7 +180,28 @@ func.func @test(%arg1: tensor<?xf32> {imex.shape_range = [#imex_util.index_range
 
 // -----
 
-// Negative testm as it not yet possble to make linalg.generic work.
+// CHECK-LABEL: func private @test_nested(
+//       CHECK:   %[[C:.*]] = arith.constant false
+//       CHECK:   return %[[C]]
+// CHECK-LABEL: func @test(
+func.func private @test_nested(%arg1: tensor<?xf32>) -> i1 {
+  %cst0 = arith.constant 0 : index
+  %cst1 = arith.constant 1 : index
+  %0 = tensor.dim %arg1, %cst0 : tensor<?xf32>
+  %1 = tensor.empty(%0) : tensor<?xf32>
+  %2 = tensor.dim %1, %cst0 : tensor<?xf32>
+  %3 = arith.cmpi eq, %2, %cst1 : index
+  return %3: i1
+}
+
+func.func @test(%arg1: tensor<?xf32> {imex.shape_range = [#imex_util.index_range<[2,10]>]}) -> i1 {
+  %0 = func.call @test_nested(%arg1) : (tensor<?xf32>) -> i1
+  return %0: i1
+}
+
+// -----
+
+// Negative test, as it not yet possble to make linalg.generic work.
 // CHECK-LABEL: func @test
 //   CHECK-NOT:   %[[C:.*]] = arith.constant false
 //   CHECK-NOT:   return %[[C]]

--- a/mlir/test/Transforms/shape-int-range-opts.mlir
+++ b/mlir/test/Transforms/shape-int-range-opts.mlir
@@ -213,6 +213,28 @@ func.func @test(%arg1: tensor<?xf32> {imex.shape_range = [#imex_util.index_range
 
 // -----
 
+// CHECK-LABEL: func private @test_nested(
+//       CHECK:   %[[C:.*]] = arith.constant false
+//       CHECK:   "test.test"(%[[C]]) : (i1) -> ()
+// CHECK-LABEL: func @test(
+func.func private @test_nested(%arg1: tensor<?xf32>, %arg2: i1) {
+  %cst = arith.constant 0 : index
+  scf.if %arg2 {
+    %0 = tensor.dim %arg1, %cst : tensor<?xf32>
+    %1 = arith.cmpi eq, %0, %cst : index
+    "test.test"(%1) : (i1) -> ()
+  }
+  return
+}
+
+func.func @test(%arg1: tensor<?xf32> {imex.shape_range = [#imex_util.index_range<[2,10]>]}, %arg2: i1) {
+  func.call @test_nested(%arg1, %arg2) : (tensor<?xf32>, i1) -> ()
+  return
+}
+
+
+// -----
+
 // Negative test, as it not yet possble to make linalg.generic work.
 // CHECK-LABEL: func @test
 //   CHECK-NOT:   %[[C:.*]] = arith.constant false

--- a/mlir/test/Transforms/shape-int-range-opts.mlir
+++ b/mlir/test/Transforms/shape-int-range-opts.mlir
@@ -232,6 +232,23 @@ func.func @test(%arg1: tensor<?xf32> {imex.shape_range = [#imex_util.index_range
   return
 }
 
+// -----
+
+// CHECK-LABEL: func @test
+//       CHECK:   %[[C:.*]] = arith.constant false
+//       CHECK:   "test.test"(%[[C]]) : (i1) -> ()
+func.func @test(%arg1: tensor<?xf32> {imex.shape_range = [#imex_util.index_range<[1,10]>]}, %arg2: f32) {
+  %cst = arith.constant 0 : index
+  %cst1 = arith.constant 0 : i32
+  %1 = llvm.fptosi %arg2 : f32 to i32
+  %2 = arith.cmpi eq, %1, %cst1 : i32
+  scf.if %2 {
+    %3 = tensor.dim %arg1, %cst : tensor<?xf32>
+    %4 = arith.cmpi eq, %3, %cst : index
+    "test.test"(%4) : (i1) -> ()
+  }
+  return
+}
 
 // -----
 


### PR DESCRIPTION
There is an issue upstream in propagating integer ranges in presence of ops which are not implementing `InferIntRangeInterface`.
Workaround it.