### PR TITLE
Problem: Using more than 1 test worker for gpu tests can cause non-de…

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,10 +44,19 @@ configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
   )
 
-add_lit_testsuite(check-imex "Running the IMEX regression tests"
+# limit number of workers for lit test when gpu test is enabled
+if(IMEX_ENABLE_L0_RUNTIME OR IMEX_ENABLE_SYCL_RUNTIME OR IMEX_ENABLE_VULKAN_RUNNER)
+    add_lit_testsuite(check-imex "Running the IMEX regression tests"
+        ${CMAKE_CURRENT_BINARY_DIR}
+        DEPENDS ${IMEX_TEST_DEPENDS}
+        ARGS "--workers=1"
+        )
+else()
+    add_lit_testsuite(check-imex "Running the IMEX regression tests"
         ${CMAKE_CURRENT_BINARY_DIR}
         DEPENDS ${IMEX_TEST_DEPENDS}
         )
+endif()
 set_target_properties(check-imex PROPERTIES FOLDER "Tests")
 
 add_lit_testsuite(check-ptensor "Running the IMEX/ptensor regression tests"


### PR DESCRIPTION
…terminitic failures.

Fix: Use 1 test worker if gpu tests are enabled.

This is part of #587 created as a separate PR.

Please review these guidelines to help with the review process:
- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [ ] Have you organized your commits logically and ensured each can be built by itself?
