### PR TITLE
[WIP] Parfor lowering

### DIFF
--- a/numba_dpcomp/numba_dpcomp/decorators.py
+++ b/numba_dpcomp/numba_dpcomp/decorators.py
@@ -6,7 +6,11 @@
 Define @jit and related decorators.
 """
 
-from .mlir.compiler import mlir_compiler_pipeline, mlir_compiler_gpu_pipeline
+from .mlir.compiler import (
+    mlir_compiler_pipeline,
+    mlir_compiler_gpu_pipeline,
+    mlir_compiler_replace_parfors_pipeline,
+)
 from .mlir.vectorize import vectorize as mlir_vectorize
 from .mlir.settings import USE_MLIR
 
@@ -32,11 +36,14 @@ def mlir_jit(
             **options
         )
 
-    pipeline = (
-        mlir_compiler_gpu_pipeline
-        if options.get("enable_gpu_pipeline", True)
-        else mlir_compiler_pipeline
-    )
+    if options.get("replace_parfors", False):
+        pipeline = mlir_compiler_replace_parfors_pipeline
+    elif options.get("enable_gpu_pipeline", True):
+        pipeline = mlir_compiler_gpu_pipeline
+    else:
+        pipeline = mlir_compiler_pipeline
+
+    options.pop("replace_parfors", None)
     options.pop("enable_gpu_pipeline", None)
     options.pop(
         "access_types", None

--- a/numba_dpcomp/numba_dpcomp/mlir/passes.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/passes.py
@@ -237,7 +237,7 @@ class MlirReplaceParfors(MlirBackendBase):
     _name = "mlir_replace_parfors"
 
     def __init__(self):
-        FunctionPass.__init__(self)
+        MlirBackendBase.__init__(self, push_func_stack=False)
 
     def run_pass(self, state):
         print("-=-=-=-=-=- MlirReplaceParfors -=-=-=-=-=-")

--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_basic.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_basic.py
@@ -885,3 +885,14 @@ def test_fastmath_indirect():
         assert_equal(py_func2(a, b, c), jit_func2(a, b, c))
         ir = get_print_buffer()
         assert ir.count("math.fma") > 0, ir
+
+
+def test_replace_parfor():
+    def py_func(a):
+        res = 0
+        for i in numba.prange(a):
+            res = res + i
+        return res
+
+    jit_func = njit(py_func, parallel=True, replace_parfors=True)
+    assert_equal(py_func(10), jit_func(10))

--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_basic.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_basic.py
@@ -891,7 +891,8 @@ def test_replace_parfor():
     def py_func(c):
         res = 0
         for i in numba.prange(len(c)):
-            res = res + c[i]
+            ind = 2 if i == 4 else i
+            res = res + c[ind]
         return res
 
     import numpy as np

--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_basic.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_basic.py
@@ -888,11 +888,15 @@ def test_fastmath_indirect():
 
 
 def test_replace_parfor():
-    def py_func(a):
+    def py_func(c):
         res = 0
-        for i in numba.prange(a):
-            res = res + i
+        for i in numba.prange(len(c)):
+            res = res + c[i]
         return res
 
+    import numpy as np
+
+    a = np.arange(10)
+
     jit_func = njit(py_func, parallel=True, replace_parfors=True)
-    assert_equal(py_func(10), jit_func(10))
+    assert_equal(py_func(a), jit_func(a))

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/Lowering.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/Lowering.cpp
@@ -325,6 +325,12 @@ private:
         index = b.create<imex::util::BuildTupleOp>(l, resType, indices);
       }
 
+      for (auto [i, redvar] : llvm::enumerate(parforInst.attr("redvars"))) {
+        assert(i < iterVars.size());
+        auto name = redvar.cast<std::string>();
+        varsMap[name] = iterVars[i];
+      }
+
       auto indexVar = parforInst.attr("index_var");
       auto indexType = getObjType(typemap(indexVar));
       index = b.create<plier::CastOp>(l, indexType, index);

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/Lowering.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/Lowering.cpp
@@ -327,9 +327,11 @@ private:
       assert(llvm::hasSingleElement(regionBlock));
       regionBlock.getTerminator()->erase();
       builder.setInsertionPointToStart(&regionBlock);
-    }
 
-    lowerBlock(block, parforInst.attr("init_block"));
+      lowerBlock(&regionBlock, parforInst.attr("init_block"));
+    } else {
+      lowerBlock(block, parforInst.attr("init_block"));
+    }
 
     auto bodyBuilder = [&](mlir::OpBuilder &b, mlir::Location l,
                            mlir::ValueRange indices,

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/Lowering.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/Lowering.cpp
@@ -265,7 +265,6 @@ private:
 
   void lowerParforBody(py::handle parforInst) {
     auto block = func.addEntryBlock();
-    //    blocks.emplace_back(block);
     mlir::ValueRange blockArgs = block->getArguments();
 
     auto getNextBlockArg = [&]() -> mlir::Value {
@@ -341,7 +340,7 @@ private:
 
       blocks.reserve(irBlocks.size());
       mlir::OpBuilder::InsertionGuard g(b);
-      for (auto [i, irBlock] : llvm::enumerate(irBlocks)) {
+      for (auto irBlock : irBlocks) {
         auto block = b.createBlock(&region, region.end());
         blocks.emplace_back(block);
         blocksMap[irBlock.first] = block;

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/Lowering.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/Lowering.cpp
@@ -328,7 +328,7 @@ private:
       }
 
       auto indexVar = parforInst.attr("index_var");
-      auto indexType = getObjType(indexVar);
+      auto indexType = getObjType(typemap(indexVar));
       index = b.create<plier::CastOp>(l, indexType, index);
       auto indexVarName = indexVar.attr("name").cast<std::string>();
       varsMap[indexVarName] = index;

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/Lowering.hpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/Lowering.hpp
@@ -21,6 +21,10 @@ pybind11::capsule lowerFunction(const pybind11::object &compilationContext,
                                 const pybind11::capsule &pyMod,
                                 const pybind11::object &funcIr);
 
+pybind11::capsule lowerParfor(const pybind11::object &compilationContext,
+                              const pybind11::capsule &pyMod,
+                              const pybind11::object &parforInst);
+
 pybind11::capsule compileModule(const pybind11::capsule &compiler,
                                 const pybind11::object &compilationContext,
                                 const pybind11::capsule &pyMod);

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/PyModule.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/PyModule.cpp
@@ -28,6 +28,7 @@ PYBIND11_MODULE(mlir_compiler, m) {
   m.def("init_compiler", &initCompiler, "No docs");
   m.def("create_module", &createModule, "No docs");
   m.def("lower_function", &lowerFunction, "No docs");
+  m.def("lower_parfor", &lowerParfor, "No docs");
   m.def("compile_module", &compileModule, "No docs");
   m.def("register_symbol", &registerSymbol, "No docs");
   m.def("get_function_pointer", &getFunctionPointer, "No docs");


### PR DESCRIPTION
Add API to outline parfor nodes as separate MLIR functions.
Testing: `pytest -vv --capture=tee-sys -rXF "numba_dpcomp/mlir/tests/test_basic.py::test_replace_parfor"`

TODO:
* Replace parfor node with call to resulted function pointer
* ~~Device name/filter_string support~~ done
* ~~Current test is not being parallelized, need fix to `PromoteToParallel` rewrite.~~ done
* ~~Properly support control flow inside loop body~~ done