### PR TITLE
Minmax uplifting

### DIFF
--- a/mlir/lib/Transforms/UpliftMath.cpp
+++ b/mlir/lib/Transforms/UpliftMath.cpp
@@ -158,7 +158,7 @@ struct UpliftMinMax : public mlir::OpRewritePattern<mlir::arith::SelectOp> {
         return mlir::failure();
 
       auto cmp = cond.getDefiningOp<mlir::arith::CmpFOp>();
-      if (cmp.getLhs() != lhs || cmp.getRhs() != rhs)
+      if (!cmp || cmp.getLhs() != lhs || cmp.getRhs() != rhs)
         return mlir::failure();
 
       using Pred = mlir::arith::CmpFPredicate;
@@ -172,7 +172,7 @@ struct UpliftMinMax : public mlir::OpRewritePattern<mlir::arith::SelectOp> {
       }
     } else {
       auto cmp = cond.getDefiningOp<mlir::arith::CmpIOp>();
-      if (cmp.getLhs() != lhs || cmp.getRhs() != rhs)
+      if (!cmp || cmp.getLhs() != lhs || cmp.getRhs() != rhs)
         return mlir::failure();
 
       using Pred = mlir::arith::CmpIPredicate;

--- a/mlir/lib/Transforms/UpliftMath.cpp
+++ b/mlir/lib/Transforms/UpliftMath.cpp
@@ -139,6 +139,60 @@ struct UpliftCabsCalls : public mlir::OpRewritePattern<mlir::func::CallOp> {
   }
 };
 
+struct UpliftMinMax : public mlir::OpRewritePattern<mlir::arith::SelectOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::arith::SelectOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto type = op.getType();
+    if (!type.isIntOrIndexOrFloat())
+      return mlir::failure();
+
+    auto lhs = op.getTrueValue();
+    auto rhs = op.getFalseValue();
+    auto cond = op.getCondition();
+    if (mlir::isa<mlir::FloatType>(type)) {
+      auto func = op->getParentOfType<mlir::func::FuncOp>();
+      if (!func || !func->hasAttr(imex::util::attributes::getFastmathName()))
+        return mlir::failure();
+
+      auto cmp = cond.getDefiningOp<mlir::arith::CmpFOp>();
+      if (cmp.getLhs() != lhs || cmp.getRhs() != rhs)
+        return mlir::failure();
+
+      using Pred = mlir::arith::CmpFPredicate;
+      auto pred = cmp.getPredicate();
+      if (pred == Pred::OLT || pred == Pred::ULT) {
+        rewriter.replaceOpWithNewOp<mlir::arith::MinFOp>(op, lhs, rhs);
+      } else if (pred == Pred::OGT || pred == Pred::UGT) {
+        rewriter.replaceOpWithNewOp<mlir::arith::MaxFOp>(op, lhs, rhs);
+      } else {
+        return mlir::failure();
+      }
+    } else {
+      auto cmp = cond.getDefiningOp<mlir::arith::CmpIOp>();
+      if (cmp.getLhs() != lhs || cmp.getRhs() != rhs)
+        return mlir::failure();
+
+      using Pred = mlir::arith::CmpIPredicate;
+      auto pred = cmp.getPredicate();
+      if (pred == Pred::slt) {
+        rewriter.replaceOpWithNewOp<mlir::arith::MinSIOp>(op, lhs, rhs);
+      } else if (pred == Pred::ult) {
+        rewriter.replaceOpWithNewOp<mlir::arith::MinUIOp>(op, lhs, rhs);
+      } else if (pred == Pred::sgt) {
+        rewriter.replaceOpWithNewOp<mlir::arith::MaxSIOp>(op, lhs, rhs);
+      } else if (pred == Pred::ugt) {
+        rewriter.replaceOpWithNewOp<mlir::arith::MaxUIOp>(op, lhs, rhs);
+      } else {
+        return mlir::failure();
+      }
+    }
+    return mlir::success();
+  }
+};
+
 struct UpliftFma : public mlir::OpRewritePattern<mlir::arith::AddFOp> {
   using OpRewritePattern::OpRewritePattern;
 
@@ -206,8 +260,9 @@ struct UpliftFMAPass
 } // namespace
 
 void imex::populateUpliftMathPatterns(mlir::RewritePatternSet &patterns) {
-  patterns.insert<UpliftMathCalls, UpliftFabsCalls, UpliftCabsCalls>(
-      patterns.getContext());
+  patterns
+      .insert<UpliftMathCalls, UpliftFabsCalls, UpliftCabsCalls, UpliftMinMax>(
+          patterns.getContext());
 }
 
 void imex::populateUpliftFMAPatterns(mlir::RewritePatternSet &patterns) {

--- a/mlir/lib/Transforms/UpliftMath.cpp
+++ b/mlir/lib/Transforms/UpliftMath.cpp
@@ -153,9 +153,7 @@ struct UpliftMinMax : public mlir::OpRewritePattern<mlir::arith::SelectOp> {
     auto rhs = op.getFalseValue();
     auto cond = op.getCondition();
     if (mlir::isa<mlir::FloatType>(type)) {
-      auto func = op->getParentOfType<mlir::func::FuncOp>();
-      if (!func || !func->hasAttr(imex::util::attributes::getFastmathName()))
-        return mlir::failure();
+      // TODO: clarify mlir minf/maxf wrt nans and singed zeros semantics
 
       auto cmp = cond.getDefiningOp<mlir::arith::CmpFOp>();
       if (!cmp || cmp.getLhs() != lhs || cmp.getRhs() != rhs)

--- a/numba_dpcomp/numba_dpcomp/mlir/numpy/funcs.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/numpy/funcs.py
@@ -214,7 +214,7 @@ def _get_max_init_value(builder, dtype):
 @register_func("numpy.amax", numpy.amax)
 def min_impl(builder, arg, axis=None):
     return _array_reduce(
-        builder, arg, axis, lambda a, b: a if a > b else b, _get_max_init_value
+        builder, arg, axis, lambda a, b: max(a, b), _get_max_init_value
     )
 
 
@@ -228,7 +228,7 @@ def _get_min_init_value(builder, dtype):
 @register_func("numpy.amin", numpy.amin)
 def min_impl(builder, arg, axis=None):
     return _array_reduce(
-        builder, arg, axis, lambda a, b: a if a < b else b, _get_min_init_value
+        builder, arg, axis, lambda a, b: min(a, b), _get_min_init_value
     )
 
 

--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_basic.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_basic.py
@@ -233,6 +233,22 @@ def test_math_uplifting2(val, name):
         assert ir.count(f"math.{name}") == 1, ir
 
 
+@pytest.mark.parametrize("a", [-2, 0, 1, -2.5, 0.0, 3.5])
+@pytest.mark.parametrize("b", [-2, 0, 1, -2.5, 0.0, 3.5])
+@pytest.mark.parametrize(
+    "body, op", [("a if a < b else b", "arith.min"), ("a if a > b else b", "arith.max")]
+)
+def test_math_uplifting_minmax(a, b, body, op):
+    py_func = eval(f"lambda a, b: {body}")
+    jit_func = njit(py_func, fastmath=True)
+
+    with print_pass_ir([], ["UpliftMathPass"]):
+
+        assert_equal(py_func(a, b), jit_func(a, b))
+        ir = get_print_buffer()
+        assert ir.count(op) == 1, ir
+
+
 @parametrize_function_variants(
     "py_func",
     [

--- a/numba_dpcomp/numba_dpcomp/mlir/tests/test_numba_parfor.py
+++ b/numba_dpcomp/numba_dpcomp/mlir/tests/test_numba_parfor.py
@@ -61,8 +61,6 @@ def _gen_tests():
         "test_kmeans",  # List suport
         "test_ndarray_fill",  # array.fill
         "test_fuse_argmin_argmax_max_min",  # numpy argmin, argmax
-        "test_max",  # max reduction
-        "test_min",  # min reduction
         "test_arange",  # select issue, complex
         "test_pi",  # np.random.ranf
         "test_simple24",  # getitem with array


### PR DESCRIPTION
Uplift `cmp` + `select` pair to corresponding min/max ops to help later reduction passes.
