### PR TITLE
Some cleanup

### DIFF
--- a/mlir/lib/Dialect/imex_util/Dialect.cpp
+++ b/mlir/lib/Dialect/imex_util/Dialect.cpp
@@ -2054,10 +2054,10 @@ void EnvironmentRegionOp::build(
         bodyBuilder) {
   build(odsBuilder, odsState, results, environment, args);
   mlir::Region *bodyRegion = odsState.regions.back().get();
-  if (bodyBuilder) {
-    bodyRegion->push_back(new mlir::Block);
-    mlir::Block &bodyBlock = bodyRegion->front();
 
+  bodyRegion->push_back(new mlir::Block);
+  mlir::Block &bodyBlock = bodyRegion->front();
+  if (bodyBuilder) {
     mlir::OpBuilder::InsertionGuard guard(odsBuilder);
     odsBuilder.setInsertionPointToStart(&bodyBlock);
     bodyBuilder(odsBuilder, odsState.location);

--- a/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/Lowering.cpp
+++ b/numba_dpcomp/numba_dpcomp/mlir_compiler/lib/Lowering.cpp
@@ -255,6 +255,7 @@ private:
 
   void lowerBlock(mlir::Block *bb, py::handle irBlock) {
     assert(nullptr != bb);
+    mlir::OpBuilder::InsertionGuard g(builder);
     builder.setInsertionPointToEnd(bb);
     for (auto it : getBody(irBlock))
       lowerInst(it);


### PR DESCRIPTION
* Always create block in `EnvironmentRegionOp` builder
* Add insertion guard in `lowerBlock` to preserve previous insertion pos