### PR TITLE
Fix linearize for non-vectors

### DIFF
--- a/lib/Transforms/VectorLinearize.cpp
+++ b/lib/Transforms/VectorLinearize.cpp
@@ -34,6 +34,7 @@ struct VectorLinearizePass final
     mlir::RewritePatternSet patterns(context);
     mlir::ConversionTarget target(*context);
 
+    typeConverter.addConversion([](mlir::Type type) { return type; });
     mlir::vector::populateVectorLinearizeTypeConversionsAndLegality(
         typeConverter, patterns, target);
     if (mlir::failed(mlir::applyPartialConversion(getOperation(), target,

--- a/test/Transforms/vector-linearize.mlir
+++ b/test/Transforms/vector-linearize.mlir
@@ -17,3 +17,13 @@ func.func @test_linearize(%arg0: vector<2x2xf32>) -> vector<2x2xf32> {
 //       CHECK: return %[[RES]] : vector<2x2xf32>
   return %0 : vector<2x2xf32>
 }
+
+// -----
+
+// CHECK-LABEL: test_const_novector
+//       CHECK:  %[[R:.*]] = arith.constant 42 : i32
+//       CHECK:  return %[[R]] : i32
+func.func @test_const_novector() -> i32 {
+  %0 = arith.constant 42 : i32
+  return %0 : i32
+}


### PR DESCRIPTION
`populateVectorLinearizeTypeConversionsAndLegality` populates conversion for vector types, but we need to add identity conversion before for all other types so they will stay unchanged.