### PR TITLE
Add capability to attach appropriate inner block size attribute

### DIFF
--- a/include/imex/Dialect/XeTile/Transforms/Passes.h
+++ b/include/imex/Dialect/XeTile/Transforms/Passes.h
@@ -16,6 +16,7 @@
 #ifndef _XeTile_PASSES_H_INCLUDED_
 #define _XeTile_PASSES_H_INCLUDED_
 
+#include "imex/Utils/XeArch.h"
 #include <mlir/Pass/Pass.h>
 
 namespace mlir {
@@ -35,7 +36,9 @@ class XeTypeConverter;
 //===----------------------------------------------------------------------===//
 
 std::unique_ptr<mlir::Pass> createXeTileInitDuplicatePass();
-std::unique_ptr<mlir::Pass> createXeTileBlockingPass();
+
+std::unique_ptr<mlir::Pass>
+createXeTileBlockingPass(const std::string &device = "pvc");
 
 ///
 void populateXeTileInitDuplicatePatterns(imex::XeTypeConverter &converter,
@@ -43,7 +46,8 @@ void populateXeTileInitDuplicatePatterns(imex::XeTypeConverter &converter,
 
 ///
 void populateXeTileBlockingPatterns(imex::XeTypeConverter &converter,
-                                    mlir::RewritePatternSet &patterns);
+                                    mlir::RewritePatternSet &patterns,
+                                    std::shared_ptr<XeuArchInterface> ptruArch);
 
 //===----------------------------------------------------------------------===//
 // Registration

--- a/include/imex/Dialect/XeTile/Transforms/Passes.td
+++ b/include/imex/Dialect/XeTile/Transforms/Passes.td
@@ -54,10 +54,10 @@ def XeTileBlocking : Pass<"xetile-blocking", "::mlir::gpu::GPUModuleOp">{
                            "mlir::vector::VectorDialect"];
 
   let options = [
-    Option<"device", "device", "std::string", /*default=*/"\"default\"",
-           "Specify the target device arch. Available examples are pvc. "
-           "If not specified a default one will be used.">
-  ];
+     Option<"device", "device", "std::string",
+            /*default=*/"\"pvc\"",
+            "gpu platform architecture where these ops are running">
+ ];
 }
 
 #endif // _XeTile_PASSES_TD_INCLUDED_

--- a/lib/Utils/XeArch.cpp
+++ b/lib/Utils/XeArch.cpp
@@ -152,7 +152,6 @@ XePVCuArch::get2DLoadConfig(mlir::Operation *op, int element_data_size,
            << "Given element data size: d" << element_data_size;
     break;
   }
-
   loadParams.GRFDataSize.load = 2048;
   return loadParams;
 }


### PR DESCRIPTION
This PR adds appropriate inner_block_size attribute to init/load/store tile op based on the hardware configuration.