### PR TITLE
ndarray.reshape et all (dist, distruntime, passes, tests)

### DIFF
--- a/include/imex/Dialect/Dist/Utils/Utils.h
+++ b/include/imex/Dialect/Dist/Utils/Utils.h
@@ -206,7 +206,7 @@ inline ::mlir::ValueRange createLocalOffsetsOf(const ::mlir::Location &loc,
   return builder.create<::imex::dist::LocalOffsetsOfOp>(loc, ary).getLOffsets();
 }
 
-// create operation returning halo of distributed array
+// create operation returning all parts (owned + halos) of distributed array
 inline ::mlir::ValueRange createPartsOf(const ::mlir::Location &loc,
                                         ::mlir::OpBuilder &builder,
                                         ::mlir::Value ary) {

--- a/include/imex/Dialect/DistRuntime/IR/DistRuntimeOps.td
+++ b/include/imex/Dialect/DistRuntime/IR/DistRuntimeOps.td
@@ -191,6 +191,37 @@ def GetHaloOp : DistRuntime_Op<"get_halo",
   let hasCanonicalizer = 1;
 }
 
+def CopyReshapeOp : DistRuntime_Op<"copy_reshape",
+    [Pure, DeclareOpInterfaceMethods<AsyncOpInterface>, AttrSizedOperandSegments]> {
+  let summary = "Copy adequate data from input to a new reshaped output";
+  let description = [{
+    Copy the necessary data from the distributed input array to the locally owned part of the output array.
+    The shape of the output array is assumed to be a reshaped version of the input's shape.
+
+    The local data is not modified.
+
+    Arguments:
+
+    - `team`: the distributed team owning the distributed array
+    - `gShape`: the global shape of the distributed array
+    - `lOffsets`: the offset of the local data within the global array
+    - `lArray`: the locally owned data
+    - `ngShape`: the global shape of the distributed output array
+    - `nlOffsets`: the offsets of the locally owned output array
+
+    `gShape`, `lOffsets` are variadic arguments with same size `ri` where `ri` is the rank of the global input array (e.g., one number for each dimension of the global input array).
+    `ngShape`, `nlOffsets` are variadic arguments with same size `ro` where `ro` is the rank of the global output array (e.g., one number for each dimension of the global output array).
+  }];
+  let arguments = (ins AnyAttr:$team,
+                       AnyType:$lArray, Variadic<Index>:$gShape, Variadic<Index>:$lOffsets,
+                       Variadic<Index>:$ngShape, Variadic<Index>:$nlOffsets, Variadic<Index>:$nlShape);
+  let results = (outs DistRuntime_AsyncHandle:$handle, AnyType:$nlArray);
+  let assemblyFormat = [{
+    $lArray `g_shape` $gShape `l_offs` $lOffsets `to` `n_g_shape` $ngShape `n_offs` $nlOffsets `n_shape` $nlShape attr-dict `:` `(` type(operands) `)` `->` `(` qualified(type(results)) `)`
+  }];
+  let hasCanonicalizer = 1;
+}
+
 def WaitOp : DistRuntime_Op<"wait", []> {
   let summary = "Wait for asynchronous operation to finish.";
   let description = [{

--- a/include/imex/Dialect/NDArray/IR/NDArrayOps.td
+++ b/include/imex/Dialect/NDArray/IR/NDArrayOps.td
@@ -875,11 +875,11 @@ def ReshapeOp : NDArray_Op<"reshape", []> {
       See Array API.
   }];
 
-  let arguments = (ins AnyType:$src, Variadic<Index>:$shape, OptionalAttr<I1Attr>:$copy);
+  let arguments = (ins AnyType:$source, Variadic<Index>:$shape, OptionalAttr<I1Attr>:$copy);
   let results = (outs AnyType);
 
   let assemblyFormat = [{
-    $src $shape attr-dict `:` qualified(type($src)) `->` qualified(type(results))
+    $source $shape attr-dict `:` qualified(type($source)) `->` qualified(type(results))
   }];
 }
 

--- a/lib/Conversion/NDArrayToLinalg/NDArrayToLinalg.cpp
+++ b/lib/Conversion/NDArrayToLinalg/NDArrayToLinalg.cpp
@@ -646,13 +646,13 @@ struct ReshapeLowering
     // check output type and get operands
     auto retArTyp = op.getType().dyn_cast<::imex::ndarray::NDArrayType>();
     auto srcArTyp =
-        op.getSrc().getType().dyn_cast<::imex::ndarray::NDArrayType>();
+        op.getSource().getType().dyn_cast<::imex::ndarray::NDArrayType>();
     if (!(retArTyp && srcArTyp)) {
       return ::mlir::failure();
     }
 
     auto loc = op.getLoc();
-    auto src = adaptor.getSrc();
+    auto src = adaptor.getSource();
     auto srcTnsr = src.getType().cast<::mlir::TensorType>();
     auto shape = adaptor.getShape();
     auto elTyp = srcTnsr.getElementType();

--- a/lib/Dialect/DistRuntime/IR/CMakeLists.txt
+++ b/lib/Dialect/DistRuntime/IR/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_imex_dialect_library(IMEXDistRuntimeDialect
   DistRuntimeOps.cpp
   GetHaloOp.cpp
+  CopyReshapeOp.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/include/imex/Dialect/DistRuntime

--- a/lib/Dialect/DistRuntime/IR/CopyReshapeOp.cpp
+++ b/lib/Dialect/DistRuntime/IR/CopyReshapeOp.cpp
@@ -1,0 +1,91 @@
+//===- CopyReshapeOp.cpp - distruntime dialect  -----------------*- C++ -*-===//
+//
+// Copyright 2023 Intel Corporation
+// Part of the IMEX Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements the CopyReshapeOp of the DistRuntime dialect.
+///
+//===----------------------------------------------------------------------===//
+
+#include <imex/Dialect/DistRuntime/IR/DistRuntimeOps.h>
+#include <imex/Dialect/NDArray/IR/NDArrayOps.h>
+#include <imex/Utils/PassUtils.h>
+
+namespace imex {
+namespace distruntime {
+
+::mlir::SmallVector<::mlir::Value> CopyReshapeOp::getDependent() {
+  return {getNlArray()};
+}
+
+} // namespace distruntime
+} // namespace imex
+
+namespace {
+
+/// Pattern to replace dynamically shaped result types
+/// by statically shaped result types.
+class CopyReshapeOpResultCanonicalizer final
+    : public mlir::OpRewritePattern<::imex::distruntime::CopyReshapeOp> {
+public:
+  using mlir::OpRewritePattern<
+      ::imex::distruntime::CopyReshapeOp>::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(::imex::distruntime::CopyReshapeOp op,
+                  ::mlir::PatternRewriter &rewriter) const override {
+
+    // check input type
+    auto nlArray = op.getNlArray();
+    auto nlType = nlArray.getType().dyn_cast<::imex::ndarray::NDArrayType>();
+    if (!nlType) {
+      return ::mlir::failure();
+    }
+    auto resShape = nlType.getShape();
+    if (!::mlir::ShapedType::isDynamicShape(resShape)) {
+      return ::mlir::failure();
+    }
+
+    // we compare result shape with expected shape and bail out if no new
+    // static info found
+    auto nlShape = ::imex::getShapeFromValues(op.getNlShape());
+    bool found = false;
+    for (auto i = 0u; i < nlShape.size(); ++i) {
+      if (::mlir::ShapedType::isDynamic(resShape[i]) &&
+          !::mlir::ShapedType::isDynamic(nlShape[i])) {
+        found = true;
+      }
+    }
+    if (!found) {
+      return ::mlir::failure();
+    }
+
+    auto elType = nlType.getElementType();
+    auto nType = nlType.cloneWith(nlShape, elType);
+    auto hType = ::imex::distruntime::AsyncHandleType::get(getContext());
+
+    auto newOp = rewriter.create<::imex::distruntime::CopyReshapeOp>(
+        op.getLoc(), ::mlir::TypeRange{hType, nType}, op.getTeamAttr(),
+        op.getLArray(), op.getGShape(), op.getLOffsets(), op.getNgShape(),
+        op.getNlOffsets(), op.getNlShape());
+
+    // cast to original types and replace op
+    auto res = rewriter.create<imex::ndarray::CastOp>(op.getLoc(), nlType,
+                                                      newOp.getNlArray());
+    rewriter.replaceOp(op, {newOp.getHandle(), res});
+
+    return ::mlir::success();
+  }
+};
+
+} // namespace
+
+void imex::distruntime::CopyReshapeOp::getCanonicalizationPatterns(
+    mlir::RewritePatternSet &results, mlir::MLIRContext *context) {
+  results.add<CopyReshapeOpResultCanonicalizer>(context);
+}

--- a/lib/Dialect/DistRuntime/IR/GetHaloOp.cpp
+++ b/lib/Dialect/DistRuntime/IR/GetHaloOp.cpp
@@ -1,4 +1,4 @@
-//===- GetHaloOp.cpp - NDArray dialect  ----------------------*- C++ -*-===//
+//===- GetHaloOp.cpp - distruntime dialect  ---------------------*- C++ -*-===//
 //
 // Copyright 2023 Intel Corporation
 // Part of the IMEX Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -82,7 +82,7 @@ add_lit_testsuite(check-static "Running the IMEX regression tests"
 set_target_properties(check-static PROPERTIES FOLDER "Tests")
 
 add_custom_target(check-imex
-        DEPENDS check-gen check-static
+        DEPENDS check-static
         )
 
 add_lit_testsuites(IMEX ${CMAKE_CURRENT_SOURCE_DIR} DEPENDS ${IMEX_TEST_DEPENDS})

--- a/test/Dialect/DistRuntime/IR/DistRuntimeOps.mlir
+++ b/test/Dialect/DistRuntime/IR/DistRuntimeOps.mlir
@@ -27,3 +27,14 @@ func.func @test_allreduce(%arg0: memref<i64>) {
 }
 // CHECK-LABEL: func.func @test_allreduce(%arg0: memref<i64>) {
 // CHECK-NEXT: "distruntime.allreduce"(%arg0) <{op = 4 : i32}> : (memref<i64>) -> ()
+
+// -----
+func.func @test_copy_reshape(%arg0: !ndarray.ndarray<?x?xi64>) {
+    %c1 = arith.constant 1 : index
+    %c3 = arith.constant 3 : index
+    %c9 = arith.constant 9 : index
+    %h, %a = distruntime.copy_reshape %arg0 g_shape %c3, %c3 l_offs %c1, %c1 to n_g_shape %c9 n_offs %c3 n_shape %c3 {team=22 : i64} : (!ndarray.ndarray<?x?xi64>, index, index, index, index, index, index, index) -> (!distruntime.asynchandle, !ndarray.ndarray<?xi64>)
+    return
+}
+// CHECK-LABEL: func.func @test_copy_reshape(%arg0: !ndarray.ndarray<?x?xi64>) {
+// CHECK: distruntime.copy_reshape %arg0 g_shape %c3, %c3 l_offs %c1, %c1 to n_g_shape %c9 n_offs %c3 n_shape %c3 {team = 22 : i64} : (!ndarray.ndarray<?x?xi64>, index, index, index, index, index, index, index) -> (!distruntime.asynchandle, !ndarray.ndarray<?xi64>)

--- a/test/Dialect/DistRuntime/Transforms/DistRuntimeCanonicalize.mlir
+++ b/test/Dialect/DistRuntime/Transforms/DistRuntimeCanonicalize.mlir
@@ -20,3 +20,24 @@ module {
 // CHECK-SAME: -> (!distruntime.asynchandle, !ndarray.ndarray<0x2x2xf64>, !ndarray.ndarray<0x2x2xf64>)
 // CHECK: "distruntime.get_halo"
 // CHECK-SAME: -> (!distruntime.asynchandle, !ndarray.ndarray<?x2x2xf64>, !ndarray.ndarray<?x2x2xf64>)
+
+module {
+  func.func @test_canonicalize_reshape() {
+    %c1_i32 = arith.constant 1 : i32
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %0 = ndarray.create %c2, %c4 value %c1_i32 : (index, index, i32) -> !ndarray.ndarray<?x?xi32>
+    %handle, %nlArray = distruntime.copy_reshape %0 g_shape %c3, %c4 l_offs %c1, %c0 to n_g_shape %c2, %c3, %c2 n_offs %c1, %c0, %c0 n_shape %c1, %c3, %c2 {team = 22 : i64} : (!ndarray.ndarray<?x?xi32>, index, index, index, index, index, index, index, index, index, index, index, index, index) -> (!distruntime.asynchandle, !ndarray.ndarray<?x?x?xi32>)
+    "distruntime.wait"(%handle) : (!distruntime.asynchandle) -> ()
+    return
+  }
+}
+// CHECK-LABEL: func.func @test_canonicalize_reshape
+// CHECK: ndarray.create
+// CHECK-SAME: -> !ndarray.ndarray<2x4xi32>
+// CHECK: distruntime.copy_reshape
+// CHECK-SAME: -> (!distruntime.asynchandle, !ndarray.ndarray<1x3x2xi32>)
+// CHECK: "distruntime.wait"

--- a/test/imex-runner/dist_to_fusion.mlir
+++ b/test/imex-runner/dist_to_fusion.mlir
@@ -61,17 +61,17 @@ module {
 }
 // CHECK-LABEL: func.func @test
 // CHECK: call @_idtr_update_halo_f32
-// CHECK: call @_idtr_wait_f32
+// CHECK: call @_idtr_wait
 // CHECK: call @_idtr_update_halo_f32
 // CHECK: call @_idtr_update_halo_f32
-// CHECK: call @_idtr_wait_f32
+// CHECK: call @_idtr_wait
 // CHECK-LABEL: linalg.generic
 // CHECK-NEXT: ^bb0
 // CHECK-NEXT-COUNT-9: arith.mulf
 // CHECK-COUNT-9: arith.addf
 // CHECK-NEXT: linalg.yield
 // CHECK-NEXT: } -> tensor<167x508xf32>
-// CHECK: call @_idtr_wait_f32
+// CHECK: call @_idtr_wait
 // CHECK-LABEL: linalg.generic
 // CHECK-NEXT: ^bb0
 // CHECK-NEXT: arith.mulf


### PR DESCRIPTION
- adding async distruntime::CopyReshapeOp
- fixing idtr_wait: accepting no arg except handle, no dtype specialization in name
- fixing reshape lowering in DistToStandard (going to distruntime::CopyReShapeOp)
- canonicalizer for distruntime::CopyReshapeOp
- testing reshape lowering all the way down to library call

@tkarna