### PR TITLE
Return correct data type in Load2D

### DIFF
--- a/lib/Conversion/GPUToSPIRV/GPUToSPIRVPass.cpp
+++ b/lib/Conversion/GPUToSPIRV/GPUToSPIRVPass.cpp
@@ -338,15 +338,6 @@ void GPUXToSPIRVPass::runOnOperation() {
         if (rank < 1 || type.getNumElements() == 1)
           return elemType;
 
-        // load2d/store2d is 3-d with vnni format, and 4d with array_length
-        // TODO: what if load without any vnni? are we going to transform all
-        // fp16/bf16
-        auto factor = 32 / elemType.getIntOrFloatBitWidth();
-        if ((rank == 3 || rank == 4) && type.getShape()[rank - 1] == factor) {
-          elemType = ::mlir::IntegerType::get(context, 32);
-          rank--;
-        }
-
         unsigned sum = 1;
         for (unsigned i = 0; i < rank; i++) {
           sum *= type.getShape()[i];

--- a/test/Conversion/XeGPUToSPIRV/gemm_basic_preop.vc.mlir
+++ b/test/Conversion/XeGPUToSPIRV/gemm_basic_preop.vc.mlir
@@ -1,0 +1,100 @@
+// RUN: imex-opt -imex-convert-gpu-to-spirv='enable-vc-intrinsic=true'  %s | FileCheck %s
+// RUN: IMEX_NOT_PREFER_RAWSEND=1 imex-opt -imex-convert-gpu-to-spirv='enable-vc-intrinsic=true'  %s | FileCheck %s --check-prefix=LSC
+module @gemm attributes {gpu.container_module} {
+  memref.global "private" constant @__constant_8x16xf16 : memref<8x16xf16> = dense<5.000000e-01>
+  memref.global "private" constant @__constant_16x16xf16 : memref<16x16xf16> = dense<1.099610e+00>
+  func.func @test(%arg0: memref<8x16xf16>, %arg1: memref<16x16xf16>) -> memref<8x16xf32> attributes {llvm.emit_c_interface} {
+    %c1 = arith.constant 1 : index
+    %memref = gpu.alloc  host_shared () : memref<8x16xf16>
+    memref.copy %arg0, %memref : memref<8x16xf16> to memref<8x16xf16>
+    %memref_0 = gpu.alloc  host_shared () : memref<16x16xf16>
+    memref.copy %arg1, %memref_0 : memref<16x16xf16> to memref<16x16xf16>
+    %memref_1 = gpu.alloc  host_shared () : memref<8x16xf32>
+    gpu.launch_func  @test_kernel::@test_kernel blocks in (%c1, %c1, %c1) threads in (%c1, %c1, %c1) args(%memref : memref<8x16xf16>, %memref_0 : memref<16x16xf16>, %memref_1 : memref<8x16xf32>)
+    gpu.dealloc  %memref : memref<8x16xf16>
+    gpu.dealloc  %memref_0 : memref<16x16xf16>
+    return %memref_1 : memref<8x16xf32>
+  }
+  gpu.module @test_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
+    gpu.func @test_kernel(%A: memref<8x16xf16>, %B: memref<16x16xf16>, %C: memref<8x16xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      // LSC: spirv.FunctionCall @llvm_genx_lsc_prefetch2d_stateless_i1_i64
+      // LSC: spirv.FunctionCall @llvm_genx_lsc_prefetch2d_stateless_i1_i64
+      // LSC: spirv.FunctionCall @llvm_genx_lsc_load2d_stateless_v64i32_i1_i64
+      // LSC: spirv.FunctionCall @llvm_genx_lsc_load2d_stateless_v128i32_i1_i64
+      // LSC: spirv.FunctionCall @llvm_genx_dpas_nosrc0_v128f32_v128i32_v64i32
+      // LSC: spirv.FunctionCall @llvm_genx_lsc_store2d_stateless_i1_i64_v128f32
+
+      // CHECK: %[[A_tile_desc_base:.*]] = spirv.ConvertPtrToU %arg0 : !spirv.ptr<!spirv.array<128 x f16>, CrossWorkgroup> to i64
+      // CHECK: %[[A_tile_payload_idx0:.*]] = spirv.VectorInsertDynamic %[[A_tile_desc_base]]
+      // CHECK: %[[A_tile_payload_idx0_i32:.*]] = spirv.Bitcast %[[A_tile_payload_idx0]] : vector<4xi64> to vector<8xi32>
+      // CHECK: %[[A_tile_payload_idx2:.*]] = spirv.VectorInsertDynamic
+      // CHECK: %[[A_tile_payload_idx3:.*]] = spirv.VectorInsertDynamic
+      // CHECK: %[[A_tile_payload_idx4:.*]] = spirv.VectorInsertDynamic
+      // CHECK: %[[A_tile_payload_idx5:.*]] = spirv.VectorInsertDynamic
+      // CHECK: %[[A_tile_payload_idx6:.*]] = spirv.VectorInsertDynamic
+      // CHECK: %[[A_tile_payload_idx7:.*]] = spirv.VectorInsertDynamic
+
+      // CHECK: %[[B_tile_desc_base:.*]] = spirv.ConvertPtrToU %arg1 : !spirv.ptr<!spirv.array<256 x f16>, CrossWorkgroup> to i64
+      // CHECK: %[[B_tile_payload_idx0:.*]] = spirv.VectorInsertDynamic %[[B_tile_desc_base]]
+      // CHECK: %[[B_tile_payload_idx0_i32:.*]] = spirv.Bitcast %[[B_tile_payload_idx0]] : vector<4xi64> to vector<8xi32>
+      // CHECK: %[[B_tile_payload_idx2:.*]] = spirv.VectorInsertDynamic
+      // CHECK: %[[B_tile_payload_idx3:.*]] = spirv.VectorInsertDynamic
+      // CHECK: %[[B_tile_payload_idx4:.*]] = spirv.VectorInsertDynamic
+      // CHECK: %[[B_tile_payload_idx5:.*]] = spirv.VectorInsertDynamic
+      // CHECK: %[[B_tile_payload_idx6:.*]] = spirv.VectorInsertDynamic
+      // CHECK: %[[B_tile_payload_idx7:.*]] = spirv.VectorInsertDynamic
+
+      // CHECK: %[[C_tile_desc_base:.*]] = spirv.ConvertPtrToU %arg2 : !spirv.ptr<!spirv.array<128 x f32>, CrossWorkgroup> to i64
+      // CHECK: %[[C_tile_payload_idx0:.*]] = spirv.VectorInsertDynamic %[[C_tile_desc_base]]
+      // CHECK: %[[C_tile_payload_idx0_i32:.*]] = spirv.Bitcast %[[C_tile_payload_idx0]] : vector<4xi64> to vector<8xi32>
+      // CHECK: %[[C_tile_payload_idx2:.*]] = spirv.VectorInsertDynamic
+      // CHECK: %[[C_tile_payload_idx3:.*]] = spirv.VectorInsertDynamic
+      // CHECK: %[[C_tile_payload_idx4:.*]] = spirv.VectorInsertDynamic
+      // CHECK: %[[C_tile_payload_idx5:.*]] = spirv.VectorInsertDynamic
+      // CHECK: %[[C_tile_payload_idx6:.*]] = spirv.VectorInsertDynamic
+      // CHECK: %[[C_tile_payload_idx7:.*]] = spirv.VectorInsertDynamic
+
+      // CHECK: spirv.FunctionCall @llvm_genx_raw_send2_noresult_i1_v8i32(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[A_tile_payload_idx7]])
+
+      // CHECK: spirv.FunctionCall @llvm_genx_raw_send2_noresult_i1_v8i32(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[B_tile_payload_idx7]])
+
+      // CHECK: %[[A_increment:.*]] = spirv.Constant dense<1.000000e+00> : vector<128xf16>
+
+      // CHECK: %[[A_i32:.*]] = spirv.FunctionCall @llvm_genx_raw_send2_v64i32_i1_v8i32(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[A_tile_payload_idx7]], %{{.*}})
+      // CHECK: %[[A_f16:.*]] = spirv.Bitcast %[[A_i32]] : vector<64xi32> to vector<128xf16>
+      // CHECK: %[[A_f16_inc:.*]] = spirv.FAdd %[[A_f16]], %[[A_increment]] : vector<128xf16>
+
+      // CHECK: %[[B_i32:.*]] = spirv.FunctionCall @llvm_genx_raw_send2_v128i32_i1_v8i32(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[B_tile_payload_idx7]], %{{.*}})
+      // CHECK: %[[B_f16:.*]] = spirv.Bitcast %[[B_i32]] : vector<128xi32> to vector<256xf16>
+
+      // CHECK: %[[A_back_i32:.*]] = spirv.Bitcast %[[A_f16_inc]] : vector<128xf16> to vector<64xi32>
+      // CHECK: %[[B_back_i32:.*]] = spirv.Bitcast %[[B_f16]] : vector<256xf16> to vector<128xi32>
+      // CHECK: %[[DPAS_RES:.*]] = spirv.FunctionCall @llvm_genx_dpas_nosrc0_v128f32_v128i32_v64i32(%[[B_back_i32]], %[[A_back_i32]], %{{.*}})
+
+      // CHECK: spirv.FunctionCall @llvm_genx_raw_sends2_noresult_i1_v8i32_v128f32(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[C_tile_payload_idx7]], %[[DPAS_RES]])
+      %A_tdesc = xegpu.create_nd_tdesc %A[0, 0] {mode = vc} : memref<8x16xf16> -> !xegpu.tensor_desc<8x16xf16>
+      %B_tdesc = xegpu.create_nd_tdesc %B[0, 0] {mode = vc} : memref<16x16xf16> -> !xegpu.tensor_desc<16x16xf16>
+      %C_tdesc = xegpu.create_nd_tdesc %C[0, 0] {mode = vc} : memref<8x16xf32> -> !xegpu.tensor_desc<8x16xf32>
+      xegpu.prefetch_nd %A_tdesc {mode = vc} : !xegpu.tensor_desc<8x16xf16>
+      xegpu.prefetch_nd %B_tdesc {mode = vc} : !xegpu.tensor_desc<16x16xf16>
+      %A_increment = arith.constant dense<1.0> : vector<128xf16>
+      %A_increment_ = vector.shape_cast %A_increment : vector<128xf16> to vector<8x8x2xf16>
+
+      %A_tensor = xegpu.load_nd %A_tdesc  {mode = vc, vnni_axis = 1} : !xegpu.tensor_desc<8x16xf16> -> vector<8x8x2xf16>
+      %A_tensor_incremented = arith.addf %A_tensor, %A_increment_ : vector<8x8x2xf16>
+      %B_tensor = xegpu.load_nd %B_tdesc  {mode = vc, vnni_axis = 0} : !xegpu.tensor_desc<16x16xf16> -> vector<8x16x2xf16>
+      %dpas_result = xegpu.dpas %A_tensor_incremented, %B_tensor {mode = vc} : vector<8x8x2xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
+      xegpu.store_nd %dpas_result, %C_tdesc {mode = vc} : vector<8x16xf32>, !xegpu.tensor_desc<8x16xf32>
+      gpu.return
+    }
+  }
+  func.func @main() attributes {llvm.emit_c_interface} {
+    %0 = memref.get_global @__constant_8x16xf16 : memref<8x16xf16>
+    %1 = memref.get_global @__constant_16x16xf16 : memref<16x16xf16>
+    %2 = call @test(%0, %1) : (memref<8x16xf16>, memref<16x16xf16>) -> memref<8x16xf32>
+    %cast = memref.cast %2 : memref<8x16xf32> to memref<*xf32>
+    //call @printMemrefF32(%cast) : (memref<*xf32>) -> ()
+    return
+  }
+  func.func private @printMemrefF32(memref<*xf32>) attributes {llvm.emit_c_interface}
+}

--- a/test/Conversion/XeGPUToSPIRV/xegpu-to-vc.mlir
+++ b/test/Conversion/XeGPUToSPIRV/xegpu-to-vc.mlir
@@ -30,9 +30,11 @@ gpu.module @test attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.
   // CHECK: -> vector<128xf32> "None" attributes {VectorComputeFunctionINTEL, linkage_attributes =
   // CHECK:  #spirv.linkage_attributes<linkage_name = "llvm.genx.dpas.nosrc0.v128f32.v128i32.v64i32", linkage_type = <Import>>}
   // CHECK-LABEL: spirv.func @dpas
-  // CHECK: (%[[A:.*]]: vector<64xi32>, %[[B:.*]]: vector<128xi32>)
+  // CHECK: (%[[A:.*]]: vector<128xf16>, %[[B:.*]]: vector<256xf16>)
   // CHECK-NEXT: %[[cst134744586_i32:.*]] = spirv.Constant 134744586 : i32
-  // CHECK-NEXT: %{{.*}} = spirv.FunctionCall @llvm_genx_dpas_nosrc0_v128f32_v128i32_v64i32(%[[B]], %[[A]], %[[cst134744586_i32]])
+  // CHECK-NEXT: %[[A_cast:.*]] = spirv.Bitcast %[[A]] : vector<128xf16> to vector<64xi32>
+  // CHECK-NEXT: %[[B_cast:.*]] = spirv.Bitcast %[[B]] : vector<256xf16> to vector<128xi32>
+  // CHECK-NEXT: %{{.*}} = spirv.FunctionCall @llvm_genx_dpas_nosrc0_v128f32_v128i32_v64i32(%[[B_cast]], %[[A_cast]], %[[cst134744586_i32]])
   // CHECK: (vector<128xi32>, vector<64xi32>, i32) -> vector<128xf32>
   gpu.func @dpas(%A : vector<8x8x2xf16>, %B : vector<8x16x2xf16>)
     kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {

--- a/test/Integration/Dialect/XeGPU/preop_dpas.mlir
+++ b/test/Integration/Dialect/XeGPU/preop_dpas.mlir
@@ -1,0 +1,98 @@
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-llvm.pp \
+// RUN:                                       --runner imex-cpu-runner -e main \
+// RUN:                                       --entry-point-result=void \
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
+// RUN: %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-llvm.pp \
+// RUN:                                        --runner imex-cpu-runner -e main \
+// RUN:                                        --entry-point-result=void \
+// RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck
+module @gemm attributes {gpu.container_module} {
+  memref.global "private" @__constant_8x16xf32 : memref<8x16xf32> = dense<0.0>
+  func.func @test(%arg0: memref<8x16xf16>, %arg1: memref<16x16xf16>) -> memref<8x16xf32> attributes {llvm.emit_c_interface} {
+    %c64 = arith.constant 64 : index
+    %c128 = arith.constant 128 : index
+    %c1 = arith.constant 1 : index
+    %memref = gpu.alloc  host_shared () : memref<8x16xf16>
+    memref.copy %arg0, %memref : memref<8x16xf16> to memref<8x16xf16>
+    %memref_0 = gpu.alloc  host_shared () : memref<16x16xf16>
+    memref.copy %arg1, %memref_0 : memref<16x16xf16> to memref<16x16xf16>
+    %memref_1 = gpu.alloc  host_shared () : memref<8x16xf32>
+    gpu.launch_func  @test_kernel::@test_kernel blocks in (%c128, %c64, %c1) threads in (%c1, %c1, %c1) args(%memref : memref<8x16xf16>, %memref_0 : memref<16x16xf16>, %memref_1 : memref<8x16xf32>)
+    gpu.dealloc  %memref : memref<8x16xf16>
+    gpu.dealloc  %memref_0 : memref<16x16xf16>
+    return %memref_1 : memref<8x16xf32>
+  }
+
+  gpu.module @test_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
+    gpu.func @test_kernel(%A: memref<8x16xf16>, %B: memref<16x16xf16>, %C: memref<8x16xf32>) kernel attributes {VectorComputeFunctionINTEL, gpu.known_block_size = array<i32: 1, 1, 1>, gpu.known_grid_size = array<i32: 128, 64, 1>, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %c0 = arith.constant 0 : index
+      %c16 = arith.constant 16 : index
+      %c8 = arith.constant 8 : index
+      %c1024 = arith.constant 1024 : index
+      %cst = arith.constant dense<1.0> : vector<8x8x2xf16>
+      %0 = gpu.block_id  x
+      %1 = gpu.block_id  y
+      %4 = xegpu.create_nd_tdesc %C[%c0, %c0] {mode = vc} : memref<8x16xf32> -> !xegpu.tensor_desc<8x16xf32>
+      %7 = xegpu.create_nd_tdesc %A[%c0, %c0] {mode = vc} : memref<8x16xf16> -> !xegpu.tensor_desc<8x16xf16>
+      %8 = xegpu.create_nd_tdesc %B[%c0, %c0] {mode = vc} : memref<16x16xf16> -> !xegpu.tensor_desc<16x16xf16>
+      %9 = xegpu.load_nd %7  {mode = vc, vnni_axis = 1}: !xegpu.tensor_desc<8x16xf16> -> vector<8x8x2xf16>
+      %10 = xegpu.load_nd %8  {mode = vc, vnni_axis = 0} : !xegpu.tensor_desc<16x16xf16> -> vector<8x16x2xf16>
+      %13 = arith.addf %9, %cst : vector<8x8x2xf16>
+      %11 = xegpu.dpas %13, %10 {mode = vc} : vector<8x8x2xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
+      xegpu.store_nd %11, %4 {mode = vc} : vector<8x16xf32>, !xegpu.tensor_desc<8x16xf32>
+      gpu.return
+    }
+  }
+
+  func.func @main() attributes {llvm.emit_c_interface} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    %c16 = arith.constant 16 : index
+    %c128 = arith.constant 128 : index
+
+    %rand_lower = arith.constant -2.0 : f32
+    %rand_upper = arith.constant 2.0 : f32
+    %gen_int = arith.constant 1 : i1
+
+    %A = memref.alloc() : memref<8x16xf16>
+    %B = memref.alloc() : memref<16x16xf16>
+    %C_ref = memref.get_global @__constant_8x16xf32 : memref<8x16xf32>
+    %A_random = memref.cast %A : memref<8x16xf16> to memref<*xf16>
+    %B_random = memref.cast %B : memref<16x16xf16> to memref<*xf16>
+    call @fillResource1DRandomF16(%A_random, %rand_lower, %rand_upper, %gen_int) : (memref<*xf16>, f32, f32, i1) -> ()
+    call @fillResource1DRandomF16(%B_random, %rand_lower, %rand_upper, %gen_int) : (memref<*xf16>, f32, f32, i1) -> ()
+    // caculate the result C matrix
+    scf.for %i = %c0 to %c8 step %c1 {
+      scf.for %j = %c0 to %c16 step %c1 {
+        %acc = memref.load %C_ref[%i, %j] : memref<8x16xf32>
+        %res = scf.for %k = %c0 to %c16 step %c1 iter_args(%acc1 = %acc) -> f32 {
+          %a = memref.load %A[%i, %k] : memref<8x16xf16>
+          %b = memref.load %B[%k, %j] : memref<16x16xf16>
+          // adjust for preop in GPU kernel, where we add 1 between load and dpas
+          %cst1 = arith.constant 1.0 : f16
+          %a_adj = arith.addf %a, %cst1 : f16
+          %c = arith.mulf %a_adj, %b : f16
+          %cc = arith.extf %c : f16 to f32
+          %ccc = arith.addf %cc, %acc1 : f32
+          scf.yield %ccc : f32
+        }
+        memref.store %res, %C_ref[%i, %j] : memref<8x16xf32>
+      }
+    }
+
+    %2 = call @test(%A, %B) : (memref<8x16xf16>, memref<16x16xf16>) -> memref<8x16xf32>
+    %cast = memref.cast %2 : memref<8x16xf32> to memref<*xf32>
+    // call @printMemrefF32(%cast) : (memref<*xf32>) -> ()
+    %cast_ref = memref.cast %C_ref : memref<8x16xf32> to memref<*xf32>
+    // call @printMaxErrorF32(%cast, %cast_ref) : (memref<*xf32>, memref<*xf32>) -> ()
+    // call @printMemrefF32(%cast_ref) : (memref<*xf32>) -> ()
+    // CHECK:   [ALLCLOSE: TRUE]
+    call @printAllcloseF32(%cast, %cast_ref) : (memref<*xf32>, memref<*xf32>) -> ()
+    return
+  }
+  func.func private @fillResource1DRandomF16(memref<*xf16>, f32, f32, i1) attributes {llvm.emit_c_interface}
+  func.func private @printMemrefF32(memref<*xf32>) attributes {llvm.emit_c_interface}
+  func.func private @printAllcloseF32(memref<*xf32>, memref<*xf32>) attributes {llvm.emit_c_interface}
+  func.func private @printMaxErrorF32(memref<*xf32>, memref<*xf32>) attributes {llvm.emit_c_interface}
+}


### PR DESCRIPTION
With this PR, XeGpu loads return the flattened vector of the **original element type** (instead of `i32`) by putting a cast after the intrinsic call. Dpas correspondingly casts any incoming vectors to element type `i32` before the intrinsic call. This way we can apply element-wise operations between loads and dpas ops.
