### PR TITLE
Add XeTile examples 

### DIFF
--- a/docs/rfcs/XeTile.md
+++ b/docs/rfcs/XeTile.md
@@ -555,7 +555,7 @@ func.func @test_gemm(%a : memref<4096x4096xf16>,
        %a3_r  = load_tile %a3_glb : tile<256x32xf16  #mp_a_cop > -> vector<256x32xf16>
        %b3_r = load_tile %b3_glb  : tile<32x256xf16 #mp_b_cop> -> vector<32x256xf16>
 
-       gpu.barrier 
+       gpu.barrier
        store_tile %a1_r, %a1_slm: tile<256x32xf16, #mp_a_cop>, vector<256x256xf32>
        store_tile %b1_r, %b1_slm: tile<32x256xf16, #mp_b_cop>, vector<256x256xf32>
        store_tile %a2_r, %a2_slm: tile<256x32xf16, #mp_a_cop>, vector<256x256xf32>
@@ -564,12 +564,12 @@ func.func @test_gemm(%a : memref<4096x4096xf16>,
        store_tile %b3_r, %b3_slm: tile<32x256xf16, #mp_b_cop>, vector<256x256xf32>
 
        gpu.barrier
-       
+
        %a1_load = init_tile %a[%i, %c0] : memref<4096x4096xf16, slm> -> tile<256x32xf16, #mp_a >   // sg_layout=[8, 8]
        %b1_load = init_tile %b[%c0, %j] : memref<4096x4096xf16, slm > -> tile<32x256xf16, #mp_b >   // sg_layout=[8,8]
 
        %c_glb = init_tile %c[%i, %j] : memref<4096x4096xf32> -> tile<256x256xf32, #mp_c>         // sg_layout=[8, 8]
-         
+
        %slm_offset = 0
 
        scf.for %k= %c0 to %c4096 step %c32 {
@@ -583,7 +583,7 @@ func.func @test_gemm(%a : memref<4096x4096xf16>,
 
            %slm_offset = add %slm_offset,  %c32
            %slm_offset = mod %slm_offset,  %c128
-    
+
            %a1_load = update_tile_offset  %a1_load, %c0, %slm_offset :  tile<256x32xf16, #mp_a> -> tile<256x32xf16, #mp_a>
            %b1_load = update_tile_offset  %b1_load, %slm_offset, %c0 :  tile<32x256xf16, #mp_b> -> tile<256x32xf16, #mp_b>
            %a4_glb = update_tile_offset   %a4_glb, %c0, %c32 : tile<256x32xf16, #mp_a_pft> -> tile<256x32xf16, #mp_a_pft>
@@ -593,18 +593,18 @@ func.func @test_gemm(%a : memref<4096x4096xf16>,
 
            %c_r = tile_mma %a1_rr, %b1_rr #mp_a #mp_b #mp_c:
                    (vector<256x32xf16>, vector<32x256xf16>) -> vector<256x256xf32> // sg_layout=[8,8], sg_data=[32,32]
-     
+
            gpu.barrier
 
            // cooperative save to slm
 	   store_tile %a4_r, %a4_slm: tile<256x32xf16, #mp_a_cop>, vector<256x256xf32>
            store_tile %b4_r, %b4_slm: tile<32x256x f16, #mp_b_cop>, vector<256x256xf32>
-  
+
            %a4_slm = %a4_slm’
            %b4_slm = %b4_slm’
         }
         store_tile %c_r, %c_glb: (tile<256x256xf32, #mp_c>, vector<256x256xf32>)                    // sg_layout=[8, 8]
-    } 
+    }
   }
 }
 ```
@@ -667,7 +667,7 @@ func.func @test_gemm(%a : memref<4096x4096xf16>,
         scf.for %k= %c0 to %c4096 step %c32 {
             %a1_r = load_tile %a1_load : tile<256x32xf16  #mp_a > -> vector<512x32xf16>
             %b1_r = load_tile %b1_load  : tile<32x256xf16 #mp_b> -> vector<32x256xf16>
-          
+
             Scf.if (%k %4 == 0) {
                 gpu.barrier
                 prefetch_tile %a2_l2’ locality<2>: tile<512x128xf16, #mp_a_copl2>
@@ -690,5 +690,3 @@ func.func @test_gemm(%a : memref<4096x4096xf16>,
    }
 }
 ```
-
-

--- a/docs/rfcs/XeTile.md
+++ b/docs/rfcs/XeTile.md
@@ -626,26 +626,26 @@ func.func @test_gemm(%a : memref<4096x4096xf16>,
        %c: memref<4096xf32> ) {
    scf.for %i = %c0 to %c4096 step %c256 {
      scf.for %j = %c0 to %c4096 step %c256 {
-       %a1_l2 = init_tile %a[%i, %c0] : memref<4096x4096xf16> -> tile<512x128xf16, #mp_a_copl2>
-       %b1_l2 = init_tile %b[%c0, %j] : memref<4096x4096xf16> -> tile<128x256xf16, #mp_b_copl2> 
-       %a2_l2 = init_tile %a[%i, %c256] : memref<4096x4096xf16> -> tile<512x128xf16, #mp_a_copl2>
-       %b2_l2 = init_tile %b[%c256, %j] : memref<4096x4096xf16> -> tile<128x256xf16, #mp_b_copl2> 
+        %a1_l2 = init_tile %a[%i, %c0] : memref<4096x4096xf16> -> tile<512x128xf16, #mp_a_copl2>
+        %b1_l2 = init_tile %b[%c0, %j] : memref<4096x4096xf16> -> tile<128x256xf16, #mp_b_copl2> 
+        %a2_l2 = init_tile %a[%i, %c256] : memref<4096x4096xf16> -> tile<512x128xf16, #mp_a_copl2>
+        %b2_l2 = init_tile %b[%c256, %j] : memref<4096x4096xf16> -> tile<128x256xf16, #mp_b_copl2> 
 
         prefetch_tile %a1_l2 locality<2>: tile<512x128xf16, #mp_a_copl2> 
         prefetch_tile %b1_l2 locality<2>: tile<128x256xf16, #mp_b_copl2> 
-		prefetch_tile %a2_l2 locality<2>: tile<512x128xf16, #mp_a_copl2> 
+	prefetch_tile %a2_l2 locality<2>: tile<512x128xf16, #mp_a_copl2> 
         prefetch_tile %b2_l2 locality<2>: tile<128x256xf16, #mp_b_copl2> 
         %a2_l2’ = update_tile_offset   %a2_l2, %c0, %c32 :  tile<512x128xf16, #mp_b_copl2>
         %b2_l2’ = update_tile_offset   %b2_l2, %c32, %c0 :  tile<128x256xf16, #mp_b_copl2>
 
-       %a1_l1 = init_tile %a[%i, %c0] : memref<4096x4096xf16> -> tile<512x32xf16, #mp_a_copl1>
-       %b1_l1 = init_tile %b[%c0, %j] : memref<4096x4096xf16> -> tile<32x256xf16, #mp_b_copl1> 
-       %a2_l1 = init_tile %a[%i, %c32] : memref<4096x4096xf16> -> tile<512x32xf16, #mp_a_copl1>
-       %b2_l1 = init_tile %b[%c32, %j] : memref<4096x4096xf16> -> tile<32x256xf16, #mp_b_copl1>
-       %a3_l1 = init_tile %a[%i, %c64] : memref<4096x4096xf16> -> tile<512x32xf16, #mp_a_copl1>
-       %b3_l1 = init_tile %b[%c64, %j] : memref<4096x4096xf16> -> tile<32x256xf16, #mp_b_copl1>
-       %a4_l1 = init_tile %a[%i, %c96] : memref<4096x4096xf16> -> tile<512x32xf16, #mp_a_copl1>
-       %b4_l1 = init_tile %b[%c96, %j] : memref<4096x4096xf16> -> tile<32x256xf16, #mp_b_copl1>
+        %a1_l1 = init_tile %a[%i, %c0] : memref<4096x4096xf16> -> tile<512x32xf16, #mp_a_copl1>
+        %b1_l1 = init_tile %b[%c0, %j] : memref<4096x4096xf16> -> tile<32x256xf16, #mp_b_copl1> 
+        %a2_l1 = init_tile %a[%i, %c32] : memref<4096x4096xf16> -> tile<512x32xf16, #mp_a_copl1>
+        %b2_l1 = init_tile %b[%c32, %j] : memref<4096x4096xf16> -> tile<32x256xf16, #mp_b_copl1>
+        %a3_l1 = init_tile %a[%i, %c64] : memref<4096x4096xf16> -> tile<512x32xf16, #mp_a_copl1>
+        %b3_l1 = init_tile %b[%c64, %j] : memref<4096x4096xf16> -> tile<32x256xf16, #mp_b_copl1>
+        %a4_l1 = init_tile %a[%i, %c96] : memref<4096x4096xf16> -> tile<512x32xf16, #mp_a_copl1>
+        %b4_l1 = init_tile %b[%c96, %j] : memref<4096x4096xf16> -> tile<32x256xf16, #mp_b_copl1>
 
         prefetch_tile %a1_l1 locality<3>: tile<512x32xf16, #mp_a_copl1> 
         prefetch_tile %b1_l1 locality<3>: tile<32x256xf16, #mp_b_copl1>
@@ -658,8 +658,8 @@ func.func @test_gemm(%a : memref<4096x4096xf16>,
         %a4_l1’ = update_tile_offset   % a4_l1, %c0, %c128 :  tile<512x32xf16, #mp_a_copl1>
         %b4_l1’ = update_tile_offset   % b4_l1, %c128, %c0 :  tile<32x256xf16, #mp_b_copl1>
 
-       %a1_load = init_tile %a[%i, %c0] : memref<4096x4096xf16> -> tile<512x32xf16, #mp_a >
-       %b1_load = init_tile %b[%c0, %j] : memref<4096x4096xf16> -> tile<32x256xf16, #mp_b > 
+        %a1_load = init_tile %a[%i, %c0] : memref<4096x4096xf16> -> tile<512x32xf16, #mp_a >
+        %b1_load = init_tile %b[%c0, %j] : memref<4096x4096xf16> -> tile<32x256xf16, #mp_b > 
 
         %c = init_tile %c[%i, %j] : memref<4096x4096xf32> -> tile<512x256xf32, #mp_c>           
 

--- a/docs/rfcs/XeTile.md
+++ b/docs/rfcs/XeTile.md
@@ -518,6 +518,7 @@ With the optimized mapping, the tile_transpose below could be implemented with i
 ```
 
 ## Appendix 2.4 Gemm implementation using cooperative load through shared local memory 
+For GPU doesn't support high-performance prefetch, the example code shows how to overlap the mma operation and tile load through shared local memory buffer to hide the load latency.   
 ```mlir
 #mp_a     = #wg_map<sg_layout=[8,8], sg_data=[32,32]>
 #mp_a_cop = #wg_map<sg_layout=[64,1], sg_data=[4,32]>  
@@ -610,6 +611,7 @@ func.func @test_gemm(%a : memref<4096x4096xf16>,
 ```
 
 ## Appendix 2.5 Gemm implementation with two cache levels
+For GPU support high-performance prefetch through two level of caches.   
 ```mlir
 #mp_a = #wg_map<sg_layout=[8,4], sg_data=[64,32]>
 #mp_b = #wg_map<sg_layout=[8,4], sg_data=[32,64]>


### PR DESCRIPTION
Add two examples to illustrate how to use WG-level XeTile to implement GEMM algorithms: using shared local memory, or using two cache levels. 
Added prefetch locality attribute to support cache levels for tile_prefetch. 