### PR TITLE
[XeTile][Code generator] Update XeTile code generator to remove regis…

### DIFF
--- a/scripts/xetile-test-gen/xetile_testgen.py
+++ b/scripts/xetile-test-gen/xetile_testgen.py
@@ -245,7 +245,8 @@ class GPUCode:
             %B_sg_init_tile = xetile.init_tile %B[%B_global_start_x, %C_sg_tile_offset_y] : memref<{self.params.B.memref()}> -> !xetile.tile<{self.params.SG.B_tile.memref()}>
 
             %c_sg_tile = xetile.init_tile %C[%C_sg_tile_offset_x_global, %C_sg_tile_offset_y] : memref<{self.params.C.memref()}> -> !xetile.tile<{self.params.SG.C_tile.memref()}>
-            %c_init_val = xetile.load_tile %c_sg_tile : !xetile.tile<{self.params.SG.C_tile.memref()}> -> vector<{self.params.SG.C_tile.memref()}>
+            // %c_init_val = xetile.load_tile %c_sg_tile : !xetile.tile<{self.params.SG.C_tile.memref()}> -> vector<{self.params.SG.C_tile.memref()}>
+            %c_init_val = arith.constant dense<0.0> : vector<{self.params.SG.C_tile.memref()}>
 """
         if self.params.test_args.code_version == "prefetch":
             dpas_shape = Grid(x=8, y=16)

--- a/test/Integration/Dialect/XeTile/xetile-to-llvm.pp
+++ b/test/Integration/Dialect/XeTile/xetile-to-llvm.pp
@@ -4,6 +4,7 @@ builtin.module(
         xetile-blocking
         convert-xetile-to-xegpu)
     cse
+    imex-vector-linearize
     imex-convert-gpu-to-spirv{enable-vc-intrinsic=true}
     cse
     spirv.module(spirv-lower-abi-attrs


### PR DESCRIPTION
…ter spill

Update XeTile code generator to replace C tile load with constant 0-valued C matrix tile. Removes register spill issue and provides performance on par with XeGPU versio with similar optimization enabled.

Please review these guidelines to help with the review process:
- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [x] Have you organized your commits logically and ensured each can be built by itself?
