### PR TITLE
[xegpu] Add nbarrier to VC func lowering

### DIFF
--- a/build_tools/patches/0010-Add-SPIRV_ExecutionModeAttributesAttr.patch
+++ b/build_tools/patches/0010-Add-SPIRV_ExecutionModeAttributesAttr.patch
@@ -1,0 +1,123 @@
+From a18280b49a33d421477db322d642aff187b029f8 Mon Sep 17 00:00:00 2001
+From: Dimple Prajapati <dimpalben.r.prajapati@intel.com>
+Date: Tue, 7 May 2024 23:26:34 +0000
+Subject: [PATCH] Add SPIRV_ExecutionModeAttributesAttr
+
+add spirv.ExecutionMode Op during GPUToSPIRV Pass lowering
+---
+ .../mlir/Dialect/SPIRV/IR/SPIRVAttributes.td   | 11 +++++++++++
+ .../mlir/Dialect/SPIRV/IR/TargetAndABI.h       |  8 ++++++++
+ mlir/lib/Conversion/GPUToSPIRV/GPUToSPIRV.cpp  | 14 ++++++++++++++
+ mlir/lib/Dialect/SPIRV/IR/SPIRVDialect.cpp     |  4 ++++
+ mlir/lib/Dialect/SPIRV/IR/TargetAndABI.cpp     | 18 ++++++++++++++++++
+ 5 files changed, 55 insertions(+)
+
+diff --git a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVAttributes.td b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVAttributes.td
+index 3a11284da051..1267ecd251ae 100644
+--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVAttributes.td
++++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVAttributes.td
+@@ -56,6 +56,17 @@ def SPIRV_LinkageAttributesAttr : SPIRV_Attr<"LinkageAttributes", "linkage_attri
+   let assemblyFormat = "`<` struct(params) `>`";
+ }
+
++// This attribute specifies SPIR-V execution mode information via GPU functions
++// 1) Execution mode attribute.
++// 2) [optional] Execution mode value.
++def SPIRV_ExecutionModeFuncAttributeAttr : SPIRV_Attr<"ExecutionModeFuncAttribute", "execution_mode_func_attribute"> {
++  let parameters = (ins
++    "mlir::spirv::ExecutionModeAttr":$execution_mode,
++    OptionalParameter<"std::optional<uint32_t>">:$value
++  );
++  let assemblyFormat = "`<` struct(params) `>`";
++}
++
+ // Description of cooperative matrix operations supported on the
+ // target. Represents `VkCooperativeMatrixPropertiesKHR`. See
+ // https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkCooperativeMatrixPropertiesKHR.html
+diff --git a/mlir/include/mlir/Dialect/SPIRV/IR/TargetAndABI.h b/mlir/include/mlir/Dialect/SPIRV/IR/TargetAndABI.h
+index 24574bfaf619..f64f99294038 100644
+--- a/mlir/include/mlir/Dialect/SPIRV/IR/TargetAndABI.h
++++ b/mlir/include/mlir/Dialect/SPIRV/IR/TargetAndABI.h
+@@ -137,6 +137,14 @@ FailureOr<ExecutionModel> getExecutionModel(TargetEnvAttr targetAttr);
+ /// Returns failure if it cannot be selected.
+ FailureOr<MemoryModel> getMemoryModel(TargetEnvAttr targetAttr);
+
++/// Returns the attribute name for specifying execution mode attribute
++/// information.
++StringRef getExecutionModeFuncAttrName();
++
++/// Queries the Execution Mode Attribute on the nearest function-like op
++/// containing the given `op`. Returns null attribute if not found.
++ExecutionModeFuncAttributeAttr lookupExecModeFuncAttr(Operation *op);
++
+ } // namespace spirv
+ } // namespace mlir
+
+diff --git a/mlir/lib/Conversion/GPUToSPIRV/GPUToSPIRV.cpp b/mlir/lib/Conversion/GPUToSPIRV/GPUToSPIRV.cpp
+index d7885e035959..5195035f088f 100644
+--- a/mlir/lib/Conversion/GPUToSPIRV/GPUToSPIRV.cpp
++++ b/mlir/lib/Conversion/GPUToSPIRV/GPUToSPIRV.cpp
+@@ -343,6 +343,20 @@ LogicalResult GPUFuncOpConversion::matchAndRewrite(
+     return failure();
+   newFuncOp->removeAttr(
+       rewriter.getStringAttr(gpu::GPUDialect::getKernelFuncAttrName()));
++
++  auto execModeFuncAttr = spirv::lookupExecModeFuncAttr(funcOp);
++  if (execModeFuncAttr) {
++    spirv::ExecutionModeAttr executionMode =
++        execModeFuncAttr.getExecutionMode();
++    std::optional<uint32_t> modeVal = execModeFuncAttr.getValue();
++
++    OpBuilder::InsertionGuard guard(rewriter);
++    rewriter.setInsertionPointAfter(newFuncOp);
++
++    rewriter.create<spirv::ExecutionModeOp>(funcOp.getLoc(), newFuncOp,
++                                            executionMode.getValue(), *modeVal);
++  }
++
+   return success();
+ }
+
+diff --git a/mlir/lib/Dialect/SPIRV/IR/SPIRVDialect.cpp b/mlir/lib/Dialect/SPIRV/IR/SPIRVDialect.cpp
+index 65aaafa55386..b9f906ada3ee 100644
+--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVDialect.cpp
++++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVDialect.cpp
+@@ -948,6 +948,10 @@ LogicalResult SPIRVDialect::verifyOperationAttribute(Operation *op,
+   } else if (symbol == spirv::getTargetEnvAttrName()) {
+     if (!llvm::isa<spirv::TargetEnvAttr>(attr))
+       return op->emitError("'") << symbol << "' must be a spirv::TargetEnvAttr";
++  } else if (symbol == spirv::getExecutionModeFuncAttrName()) {
++    if (!llvm::isa<spirv::ExecutionModeFuncAttributeAttr>(attr))
++      return op->emitError("'")
++             << symbol << "' must be a spirv::ExecutionModeFuncAttributeAttr";
+   } else {
+     return op->emitError("found unsupported '")
+            << symbol << "' attribute on operation";
+diff --git a/mlir/lib/Dialect/SPIRV/IR/TargetAndABI.cpp b/mlir/lib/Dialect/SPIRV/IR/TargetAndABI.cpp
+index bbc318e17300..56251a8f3990 100644
+--- a/mlir/lib/Dialect/SPIRV/IR/TargetAndABI.cpp
++++ b/mlir/lib/Dialect/SPIRV/IR/TargetAndABI.cpp
+@@ -242,3 +242,21 @@ spirv::getMemoryModel(spirv::TargetEnvAttr targetAttr) {
+   }
+   return failure();
+ }
++
++StringRef spirv::getExecutionModeFuncAttrName() {
++  return "spirv.execution_mode";
++}
++
++spirv::ExecutionModeFuncAttributeAttr
++spirv::lookupExecModeFuncAttr(Operation *op) {
++  while (op && !isa<FunctionOpInterface>(op))
++    op = op->getParentOp();
++  if (!op)
++    return {};
++
++  if (auto attr = op->getAttrOfType<spirv::ExecutionModeFuncAttributeAttr>(
++          spirv::getExecutionModeFuncAttrName()))
++    return attr;
++
++  return {};
++}
+--
+2.34.1

--- a/test/Conversion/XeGPUToVC/barrier.mlir
+++ b/test/Conversion/XeGPUToVC/barrier.mlir
@@ -1,0 +1,51 @@
+// RUN: imex-opt -convert-xegpu-to-vc='enable-vc-intrinsic=true useRawSend=false' %s | FileCheck %s
+module @gemm attributes {gpu.container_module} {
+  gpu.module @test_kernel {
+    // CHECK: func.func private @llvm.genx.nbarrier(i8, i8, i8) attributes {VectorComputeFunctionINTEL, linkage_attributes = #spirv.linkage_attributes<linkage_name = "llvm.genx.nbarrier", linkage_type = <Import>>}
+    // CHECK: func.func private @llvm.genx.lsc.fence.i1(i1, i8, i8, i8) attributes {VectorComputeFunctionINTEL, linkage_attributes = #spirv.linkage_attributes<linkage_name = "llvm.genx.lsc.fence.i1", linkage_type = <Import>>}
+    // CHECK: func.func private @llvm.genx.raw.send2.noresult.i1.v8i32(i8, i8, i1, i8, i8, i32, i32, vector<8xi32>) attributes {VectorComputeFunctionINTEL, linkage_attributes = #spirv.linkage_attributes<linkage_name = "llvm.genx.raw.send2.noresult.i1.v8i32", linkage_type = <Import>>}
+
+    gpu.func @test_kernel(%arg0: memref<8x16xf16>, %arg1: memref<16x16xf16>, %arg2: memref<8x16xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      // TODO: spirv.ExecutionMode @test_kernel "NamedBarrierCountINTEL", 16
+     xegpu.alloc_nbarrier 16
+      // CHECK: %[[c1:.*]] = arith.constant 1 : i8
+      // CHECK: %[[c0:.*]] = arith.constant 0 : i8
+      // CHECK: %[[c0_i32:.*]] = arith.constant 0 : i32
+      %nbarrier_id = arith.constant 1 : i8
+      %nbarrier_role = arith.constant 0 : i8
+      // CHECK: %[[ROLE_i32:.*]] = arith.extui %[[c0]] : i8 to i32
+      // CHECK: %[[NBARRIER_SRC:.*]] = arith.constant dense<0> : vector<8xi32>
+      // CHECK: %[[ID:.*]] = arith.extui %[[c1]] : i8 to i32
+      // CHECK: %[[c14:.*]] = arith.constant 14 : i32
+      // CHECK: %[[ROLE:.*]] = arith.shli %[[c0_i32]], %[[c14]] : i32
+      // CHECK: %[[P0:.*]] = arith.ori %[[ID]], %[[ROLE]] : i32
+      // CHECK: %[[c16:.*]] = arith.constant 16 : i32
+      // CHECK: %[[PRODUCERS:.*]] = arith.shli %[[ROLE_i32]], %[[c16]] : i32
+      // CHECK: %[[P1:.*]] = arith.ori %[[P0]], %[[PRODUCERS]] : i32
+      // CHECK: %[[c24:.*]] = arith.constant 24 : i32
+      // CHECK: %[[P2:.*]] = arith.shli %[[ROLE_i32]], %[[c24]] : i32
+      // CHECK: %[[PAYLOAD:.*]] = arith.ori %[[P1]], %[[P2]] : i32
+      // CHECK: %[[NBARRIER:.*]] = vector.insert %[[PAYLOAD]], %[[NBARRIER_SRC]] [2] : i32 into vector<8xi32>
+      %payload = xegpu.init_nbarrier %nbarrier_id, %nbarrier_role : i8, i8 -> !xegpu.nbarrier
+
+      // CHECK: func.call @llvm.genx.raw.send2.noresult.i1.v8i32({{.*}}, %[[NBARRIER]]) : (i8, i8, i1, i8, i8, i32, i32, vector<8xi32>) -> ()
+      xegpu.nbarrier_arrive %payload : !xegpu.nbarrier
+
+      // CHECK: %[[TRUE:.*]] = arith.constant true
+      // CHECK: func.call @llvm.genx.lsc.fence.i1(%[[TRUE]], {{.*}}) : (i1, i8, i8, i8) -> ()
+      xegpu.fence memory_kind = global , fence_scope = workgroup
+
+      // ADD CHECK %[[c128:.*]] = arith.constant -128 : i8
+      // ADD CHECK func.call @llvm.genx.fence(%[[c128]]) : (i8) -> ()
+      // xegpu.compile_hint
+
+      // CHECK: %[[NBARRIER_VAL:.*]] = vector.extract %[[NBARRIER]][2] : i32 from vector<8xi32>
+      // CHECK: %[[c255:.*]] = arith.constant 255 : i32
+      // CHECK: %[[NBARRIER_ID:.*]] = arith.andi %[[NBARRIER_VAL]], %[[c255]] : i32
+      // CHECK: %[[NBARRIER_PAYLOAD:.*]] = arith.trunci %[[NBARRIER_ID]] : i32 to i8
+      // CHECK: func.call @llvm.genx.nbarrier(%{{.*}}, %[[NBARRIER_PAYLOAD]], %{{.*}}) : (i8, i8, i8) -> ()
+      xegpu.nbarrier_wait %payload : !xegpu.nbarrier
+      gpu.return
+    }
+  }
+  }

--- a/test/Integration/Dialect/XeGPU/flash_attention_fwd.mlir
+++ b/test/Integration/Dialect/XeGPU/flash_attention_fwd.mlir
@@ -1,8 +1,8 @@
-// RUN: IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-llvm.pp \
+// RUN: IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
 // RUN:                                       --runner imex-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
-// RUN: IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-llvm.pp \
+// RUN: IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
 // RUN:                                        --runner imex-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck

--- a/test/Integration/Dialect/XeGPU/gemm_4kx4kx4k_dpas_sized_loads_f16_f16_f32.mlir
+++ b/test/Integration/Dialect/XeGPU/gemm_4kx4kx4k_dpas_sized_loads_f16_f16_f32.mlir
@@ -101,13 +101,13 @@ module @gemm attributes {gpu.container_module} {
       %A_sg_prefetch_tile_iter0 = xegpu.create_nd_tdesc %A[%A_sg_prefetch_offset_x, %c0] : memref<4096x4096xf16> -> !xegpu.tensor_desc<8x32xf16>
       xegpu.prefetch_nd %A_sg_prefetch_tile_iter0 {l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>} : !xegpu.tensor_desc<8x32xf16>
       // stage 2 (move 32 elements in the y direction and prefetch next 8x32 tile)
-      %A_sg_prefetch_tile_iter1 = xegpu.update_nd_offset %A_sg_prefetch_tile_iter0, [%c0, %c32] : !xegpu.tensor_desc<8x32xf16> -> !xegpu.tensor_desc<8x32xf16>
+      %A_sg_prefetch_tile_iter1 = xegpu.update_nd_offset %A_sg_prefetch_tile_iter0, [%c0, %c32] : !xegpu.tensor_desc<8x32xf16>
       xegpu.prefetch_nd %A_sg_prefetch_tile_iter1 {l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>} : !xegpu.tensor_desc<8x32xf16>
       // stage 3
-      %A_sg_prefetch_tile_iter2 = xegpu.update_nd_offset %A_sg_prefetch_tile_iter1, [%c0, %c32] : !xegpu.tensor_desc<8x32xf16> -> !xegpu.tensor_desc<8x32xf16>
+      %A_sg_prefetch_tile_iter2 = xegpu.update_nd_offset %A_sg_prefetch_tile_iter1, [%c0, %c32] : !xegpu.tensor_desc<8x32xf16>
       xegpu.prefetch_nd %A_sg_prefetch_tile_iter2 {l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>} : !xegpu.tensor_desc<8x32xf16>
       // compute the next tile to prefetch within K loop
-      %A_sg_prefetch_tile_iter3 = xegpu.update_nd_offset %A_sg_prefetch_tile_iter2, [%c0, %c32] : !xegpu.tensor_desc<8x32xf16> -> !xegpu.tensor_desc<8x32xf16>
+      %A_sg_prefetch_tile_iter3 = xegpu.update_nd_offset %A_sg_prefetch_tile_iter2, [%c0, %c32] : !xegpu.tensor_desc<8x32xf16>
 
       // prefetch the entire 32x256 slice of B WG tile, we still use the prefetch size 8x32.
       // SGs have 8x4 layout. In this case 8 subgroups must do a colloborative  prefetch of 32x64 tile.
@@ -138,34 +138,34 @@ module @gemm attributes {gpu.container_module} {
       %B_sg_prefetch_tile_iter0 = xegpu.create_nd_tdesc %B[%B_sg_prefetch_offset_x, %B_sg_prefetch_offset_y] : memref<4096x4096xf16> -> !xegpu.tensor_desc<8x32xf16>
       xegpu.prefetch_nd %B_sg_prefetch_tile_iter0 {l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>} : !xegpu.tensor_desc<8x32xf16>
       // stage 2 (move 32 elements in the x direction and prefetch next 8x32 tile)
-      %B_sg_prefetch_tile_iter1 = xegpu.update_nd_offset %B_sg_prefetch_tile_iter0, [%c32, %c0] : !xegpu.tensor_desc<8x32xf16> -> !xegpu.tensor_desc<8x32xf16>
+      %B_sg_prefetch_tile_iter1 = xegpu.update_nd_offset %B_sg_prefetch_tile_iter0, [%c32, %c0] : !xegpu.tensor_desc<8x32xf16>
       xegpu.prefetch_nd %B_sg_prefetch_tile_iter1 {l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>} : !xegpu.tensor_desc<8x32xf16>
       // stage 3
-      %B_sg_prefetch_tile_iter2 = xegpu.update_nd_offset %B_sg_prefetch_tile_iter1, [%c32, %c0] : !xegpu.tensor_desc<8x32xf16> -> !xegpu.tensor_desc<8x32xf16>
+      %B_sg_prefetch_tile_iter2 = xegpu.update_nd_offset %B_sg_prefetch_tile_iter1, [%c32, %c0] : !xegpu.tensor_desc<8x32xf16>
       xegpu.prefetch_nd %B_sg_prefetch_tile_iter2 {l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>} : !xegpu.tensor_desc<8x32xf16>
       // compute the next tile to prefetch inside K loop
-      %B_sg_prefetch_tile_iter3 = xegpu.update_nd_offset %B_sg_prefetch_tile_iter2, [%c32, %c0] : !xegpu.tensor_desc<8x32xf16> -> !xegpu.tensor_desc<8x32xf16>
+      %B_sg_prefetch_tile_iter3 = xegpu.update_nd_offset %B_sg_prefetch_tile_iter2, [%c32, %c0] : !xegpu.tensor_desc<8x32xf16>
 
 
       // create A tiles
       %A_sg_init_tile_0_0 = xegpu.create_nd_tdesc %A[%C_sg_tile_offset_x, %c0] : memref<4096x4096xf16> -> !xegpu.tensor_desc<8x16xf16>
-      %A_sg_init_tile_1_0 =  xegpu.update_nd_offset %A_sg_init_tile_0_0, [%c8, %c0]  : !xegpu.tensor_desc<8x16xf16> -> !xegpu.tensor_desc<8x16xf16>
-      %A_sg_init_tile_2_0 =  xegpu.update_nd_offset %A_sg_init_tile_1_0, [%c8, %c0]  : !xegpu.tensor_desc<8x16xf16> -> !xegpu.tensor_desc<8x16xf16>
-      %A_sg_init_tile_3_0 =  xegpu.update_nd_offset %A_sg_init_tile_2_0, [%c8, %c0]  : !xegpu.tensor_desc<8x16xf16> -> !xegpu.tensor_desc<8x16xf16>
-      %A_sg_init_tile_0_1 =  xegpu.update_nd_offset %A_sg_init_tile_0_0, [%c0, %c16]  : !xegpu.tensor_desc<8x16xf16> -> !xegpu.tensor_desc<8x16xf16>
-      %A_sg_init_tile_1_1 =  xegpu.update_nd_offset %A_sg_init_tile_0_1, [%c8, %c0]  : !xegpu.tensor_desc<8x16xf16> -> !xegpu.tensor_desc<8x16xf16>
-      %A_sg_init_tile_2_1 =  xegpu.update_nd_offset %A_sg_init_tile_1_1, [%c8, %c0]  : !xegpu.tensor_desc<8x16xf16> -> !xegpu.tensor_desc<8x16xf16>
-      %A_sg_init_tile_3_1 =  xegpu.update_nd_offset %A_sg_init_tile_2_1, [%c8, %c0]  : !xegpu.tensor_desc<8x16xf16> -> !xegpu.tensor_desc<8x16xf16>
+      %A_sg_init_tile_1_0 =  xegpu.update_nd_offset %A_sg_init_tile_0_0, [%c8, %c0]  : !xegpu.tensor_desc<8x16xf16>
+      %A_sg_init_tile_2_0 =  xegpu.update_nd_offset %A_sg_init_tile_1_0, [%c8, %c0]  : !xegpu.tensor_desc<8x16xf16>
+      %A_sg_init_tile_3_0 =  xegpu.update_nd_offset %A_sg_init_tile_2_0, [%c8, %c0]  : !xegpu.tensor_desc<8x16xf16>
+      %A_sg_init_tile_0_1 =  xegpu.update_nd_offset %A_sg_init_tile_0_0, [%c0, %c16]  : !xegpu.tensor_desc<8x16xf16>
+      %A_sg_init_tile_1_1 =  xegpu.update_nd_offset %A_sg_init_tile_0_1, [%c8, %c0]  : !xegpu.tensor_desc<8x16xf16>
+      %A_sg_init_tile_2_1 =  xegpu.update_nd_offset %A_sg_init_tile_1_1, [%c8, %c0]  : !xegpu.tensor_desc<8x16xf16>
+      %A_sg_init_tile_3_1 =  xegpu.update_nd_offset %A_sg_init_tile_2_1, [%c8, %c0]  : !xegpu.tensor_desc<8x16xf16>
 
       //create B tiles
       %B_sg_init_tile_0_0 = xegpu.create_nd_tdesc %B[%c0, %C_sg_tile_offset_y] : memref<4096x4096xf16> -> !xegpu.tensor_desc<16x16xf16>
-      %B_sg_init_tile_0_1 =  xegpu.update_nd_offset %B_sg_init_tile_0_0, [%c0, %c16]  : !xegpu.tensor_desc<16x16xf16> -> !xegpu.tensor_desc<16x16xf16>
-      %B_sg_init_tile_0_2 =  xegpu.update_nd_offset %B_sg_init_tile_0_1, [%c0, %c16]  : !xegpu.tensor_desc<16x16xf16> -> !xegpu.tensor_desc<16x16xf16>
-      %B_sg_init_tile_0_3 =  xegpu.update_nd_offset %B_sg_init_tile_0_2, [%c0, %c16]  : !xegpu.tensor_desc<16x16xf16> -> !xegpu.tensor_desc<16x16xf16>
-      %B_sg_init_tile_1_0 =  xegpu.update_nd_offset %B_sg_init_tile_0_0, [%c16, %c0]  : !xegpu.tensor_desc<16x16xf16> -> !xegpu.tensor_desc<16x16xf16>
-      %B_sg_init_tile_1_1 =  xegpu.update_nd_offset %B_sg_init_tile_1_0, [%c0, %c16]  : !xegpu.tensor_desc<16x16xf16> -> !xegpu.tensor_desc<16x16xf16>
-      %B_sg_init_tile_1_2 =  xegpu.update_nd_offset %B_sg_init_tile_1_1, [%c0, %c16]  : !xegpu.tensor_desc<16x16xf16> -> !xegpu.tensor_desc<16x16xf16>
-      %B_sg_init_tile_1_3 =  xegpu.update_nd_offset %B_sg_init_tile_1_2, [%c0, %c16]  : !xegpu.tensor_desc<16x16xf16> -> !xegpu.tensor_desc<16x16xf16>
+      %B_sg_init_tile_0_1 =  xegpu.update_nd_offset %B_sg_init_tile_0_0, [%c0, %c16]  : !xegpu.tensor_desc<16x16xf16>
+      %B_sg_init_tile_0_2 =  xegpu.update_nd_offset %B_sg_init_tile_0_1, [%c0, %c16]  : !xegpu.tensor_desc<16x16xf16>
+      %B_sg_init_tile_0_3 =  xegpu.update_nd_offset %B_sg_init_tile_0_2, [%c0, %c16]  : !xegpu.tensor_desc<16x16xf16>
+      %B_sg_init_tile_1_0 =  xegpu.update_nd_offset %B_sg_init_tile_0_0, [%c16, %c0]  : !xegpu.tensor_desc<16x16xf16>
+      %B_sg_init_tile_1_1 =  xegpu.update_nd_offset %B_sg_init_tile_1_0, [%c0, %c16]  : !xegpu.tensor_desc<16x16xf16>
+      %B_sg_init_tile_1_2 =  xegpu.update_nd_offset %B_sg_init_tile_1_1, [%c0, %c16]  : !xegpu.tensor_desc<16x16xf16>
+      %B_sg_init_tile_1_3 =  xegpu.update_nd_offset %B_sg_init_tile_1_2, [%c0, %c16]  : !xegpu.tensor_desc<16x16xf16>
 
       // init 16 C tiles of size 8x16 each is initialized to 0.0 assuming a zero C matrix
       %zero_vec = arith.constant dense<0.0> : vector<128xf32>
@@ -189,8 +189,8 @@ module @gemm attributes {gpu.container_module} {
 
       xegpu.alloc_nbarrier 16
       %nbarrier_id = arith.constant 1 : i8
-      %nbarrier_role = arith.constant 0 : i8
-      %nbarrier = xegpu.create_nbarrier %nbarrier_id, %nbarrier_role {num_producers = 32 : i8, num_consumers = 32 : i8} : (i8, i8) -> !xegpu.nbarrier
+      %num_threads = arith.constant 8 : i8
+      %nbarrier = xegpu.init_nbarrier %nbarrier_id, %num_threads : i8, i8 -> !xegpu.nbarrier
       // K loop advances in 32 steps
       %k_loop_result:34 = scf.for %k = %c0 to %c4096 step %c32 iter_args (
           %A_tile_0_0 = %A_sg_init_tile_0_0,
@@ -267,26 +267,26 @@ module @gemm attributes {gpu.container_module} {
         xegpu.compile_hint
 
         // advance A and B prefetch tiles
-        %next_A_prefetch_tile = xegpu.update_nd_offset %A_prefetch_tile, [%c0, %c32] : !xegpu.tensor_desc<8x32xf16> -> !xegpu.tensor_desc<8x32xf16>
-        %next_B_prefetch_tile = xegpu.update_nd_offset %B_prefetch_tile, [%c32, %c0] : !xegpu.tensor_desc<8x32xf16> -> !xegpu.tensor_desc<8x32xf16>
+        %next_A_prefetch_tile = xegpu.update_nd_offset %A_prefetch_tile, [%c0, %c32] : !xegpu.tensor_desc<8x32xf16>
+        %next_B_prefetch_tile = xegpu.update_nd_offset %B_prefetch_tile, [%c32, %c0] : !xegpu.tensor_desc<8x32xf16>
         // advance A and B tiles
-        %next_A_tile_0_0 = xegpu.update_nd_offset %A_tile_0_0, [%c0, %c32] : !xegpu.tensor_desc<8x16xf16> -> !xegpu.tensor_desc<8x16xf16>
-        %next_A_tile_1_0 = xegpu.update_nd_offset %A_tile_1_0, [%c0, %c32] : !xegpu.tensor_desc<8x16xf16> -> !xegpu.tensor_desc<8x16xf16>
-        %next_A_tile_2_0 = xegpu.update_nd_offset %A_tile_2_0, [%c0, %c32] : !xegpu.tensor_desc<8x16xf16> -> !xegpu.tensor_desc<8x16xf16>
-        %next_A_tile_3_0 = xegpu.update_nd_offset %A_tile_3_0, [%c0, %c32] : !xegpu.tensor_desc<8x16xf16> -> !xegpu.tensor_desc<8x16xf16>
-        %next_A_tile_0_1 = xegpu.update_nd_offset %A_tile_0_1, [%c0, %c32] : !xegpu.tensor_desc<8x16xf16> -> !xegpu.tensor_desc<8x16xf16>
-        %next_A_tile_1_1 = xegpu.update_nd_offset %A_tile_1_1, [%c0, %c32] : !xegpu.tensor_desc<8x16xf16> -> !xegpu.tensor_desc<8x16xf16>
-        %next_A_tile_2_1 = xegpu.update_nd_offset %A_tile_2_1, [%c0, %c32] : !xegpu.tensor_desc<8x16xf16> -> !xegpu.tensor_desc<8x16xf16>
-        %next_A_tile_3_1 = xegpu.update_nd_offset %A_tile_3_1, [%c0, %c32] : !xegpu.tensor_desc<8x16xf16> -> !xegpu.tensor_desc<8x16xf16>
+        %next_A_tile_0_0 = xegpu.update_nd_offset %A_tile_0_0, [%c0, %c32] : !xegpu.tensor_desc<8x16xf16>
+        %next_A_tile_1_0 = xegpu.update_nd_offset %A_tile_1_0, [%c0, %c32] : !xegpu.tensor_desc<8x16xf16>
+        %next_A_tile_2_0 = xegpu.update_nd_offset %A_tile_2_0, [%c0, %c32] : !xegpu.tensor_desc<8x16xf16>
+        %next_A_tile_3_0 = xegpu.update_nd_offset %A_tile_3_0, [%c0, %c32] : !xegpu.tensor_desc<8x16xf16>
+        %next_A_tile_0_1 = xegpu.update_nd_offset %A_tile_0_1, [%c0, %c32] : !xegpu.tensor_desc<8x16xf16>
+        %next_A_tile_1_1 = xegpu.update_nd_offset %A_tile_1_1, [%c0, %c32] : !xegpu.tensor_desc<8x16xf16>
+        %next_A_tile_2_1 = xegpu.update_nd_offset %A_tile_2_1, [%c0, %c32] : !xegpu.tensor_desc<8x16xf16>
+        %next_A_tile_3_1 = xegpu.update_nd_offset %A_tile_3_1, [%c0, %c32] : !xegpu.tensor_desc<8x16xf16>
 
-        %next_B_tile_0_0 = xegpu.update_nd_offset %B_tile_0_0, [%c32, %c0] : !xegpu.tensor_desc<16x16xf16> -> !xegpu.tensor_desc<16x16xf16>
-        %next_B_tile_0_1 = xegpu.update_nd_offset %B_tile_0_1, [%c32, %c0] : !xegpu.tensor_desc<16x16xf16> -> !xegpu.tensor_desc<16x16xf16>
-        %next_B_tile_0_2 = xegpu.update_nd_offset %B_tile_0_2, [%c32, %c0] : !xegpu.tensor_desc<16x16xf16> -> !xegpu.tensor_desc<16x16xf16>
-        %next_B_tile_0_3 = xegpu.update_nd_offset %B_tile_0_3, [%c32, %c0] : !xegpu.tensor_desc<16x16xf16> -> !xegpu.tensor_desc<16x16xf16>
-        %next_B_tile_1_0 = xegpu.update_nd_offset %B_tile_1_0, [%c32, %c0] : !xegpu.tensor_desc<16x16xf16> -> !xegpu.tensor_desc<16x16xf16>
-        %next_B_tile_1_1 = xegpu.update_nd_offset %B_tile_1_1, [%c32, %c0] : !xegpu.tensor_desc<16x16xf16> -> !xegpu.tensor_desc<16x16xf16>
-        %next_B_tile_1_2 = xegpu.update_nd_offset %B_tile_1_2, [%c32, %c0] : !xegpu.tensor_desc<16x16xf16> -> !xegpu.tensor_desc<16x16xf16>
-        %next_B_tile_1_3 = xegpu.update_nd_offset %B_tile_1_3, [%c32, %c0] : !xegpu.tensor_desc<16x16xf16> -> !xegpu.tensor_desc<16x16xf16>
+        %next_B_tile_0_0 = xegpu.update_nd_offset %B_tile_0_0, [%c32, %c0] : !xegpu.tensor_desc<16x16xf16>
+        %next_B_tile_0_1 = xegpu.update_nd_offset %B_tile_0_1, [%c32, %c0] : !xegpu.tensor_desc<16x16xf16>
+        %next_B_tile_0_2 = xegpu.update_nd_offset %B_tile_0_2, [%c32, %c0] : !xegpu.tensor_desc<16x16xf16>
+        %next_B_tile_0_3 = xegpu.update_nd_offset %B_tile_0_3, [%c32, %c0] : !xegpu.tensor_desc<16x16xf16>
+        %next_B_tile_1_0 = xegpu.update_nd_offset %B_tile_1_0, [%c32, %c0] : !xegpu.tensor_desc<16x16xf16>
+        %next_B_tile_1_1 = xegpu.update_nd_offset %B_tile_1_1, [%c32, %c0] : !xegpu.tensor_desc<16x16xf16>
+        %next_B_tile_1_2 = xegpu.update_nd_offset %B_tile_1_2, [%c32, %c0] : !xegpu.tensor_desc<16x16xf16>
+        %next_B_tile_1_3 = xegpu.update_nd_offset %B_tile_1_3, [%c32, %c0] : !xegpu.tensor_desc<16x16xf16>
 
         xegpu.compile_hint
 
@@ -345,24 +345,24 @@ module @gemm attributes {gpu.container_module} {
       // advance 8 in x dim and, advance 16 in y dim
       // row 1
       %c_sg_tile_0_0 = xegpu.create_nd_tdesc %C[%C_sg_tile_offset_x, %C_sg_tile_offset_y] : memref<4096x4096xf32> -> !xegpu.tensor_desc<8x16xf32>
-      %c_sg_tile_0_1 = xegpu.update_nd_offset %c_sg_tile_0_0, [%c0, %c16]  : !xegpu.tensor_desc<8x16xf32> -> !xegpu.tensor_desc<8x16xf32>
-      %c_sg_tile_0_2 =  xegpu.update_nd_offset %c_sg_tile_0_1, [%c0, %c16] : !xegpu.tensor_desc<8x16xf32> -> !xegpu.tensor_desc<8x16xf32>
-      %c_sg_tile_0_3 =  xegpu.update_nd_offset %c_sg_tile_0_2, [%c0, %c16] : !xegpu.tensor_desc<8x16xf32> -> !xegpu.tensor_desc<8x16xf32>
+      %c_sg_tile_0_1 = xegpu.update_nd_offset %c_sg_tile_0_0, [%c0, %c16]  : !xegpu.tensor_desc<8x16xf32>
+      %c_sg_tile_0_2 =  xegpu.update_nd_offset %c_sg_tile_0_1, [%c0, %c16] : !xegpu.tensor_desc<8x16xf32>
+      %c_sg_tile_0_3 =  xegpu.update_nd_offset %c_sg_tile_0_2, [%c0, %c16] : !xegpu.tensor_desc<8x16xf32>
       // row 2
-      %c_sg_tile_1_0 = xegpu.update_nd_offset %c_sg_tile_0_0, [%c8, %c0]  : !xegpu.tensor_desc<8x16xf32> -> !xegpu.tensor_desc<8x16xf32>
-      %c_sg_tile_1_1 = xegpu.update_nd_offset %c_sg_tile_1_0, [%c0, %c16] : !xegpu.tensor_desc<8x16xf32> -> !xegpu.tensor_desc<8x16xf32>
-      %c_sg_tile_1_2 = xegpu.update_nd_offset %c_sg_tile_1_1, [%c0, %c16] : !xegpu.tensor_desc<8x16xf32> -> !xegpu.tensor_desc<8x16xf32>
-      %c_sg_tile_1_3 = xegpu.update_nd_offset %c_sg_tile_1_2, [%c0, %c16] : !xegpu.tensor_desc<8x16xf32> -> !xegpu.tensor_desc<8x16xf32>
+      %c_sg_tile_1_0 = xegpu.update_nd_offset %c_sg_tile_0_0, [%c8, %c0]  : !xegpu.tensor_desc<8x16xf32>
+      %c_sg_tile_1_1 = xegpu.update_nd_offset %c_sg_tile_1_0, [%c0, %c16] : !xegpu.tensor_desc<8x16xf32>
+      %c_sg_tile_1_2 = xegpu.update_nd_offset %c_sg_tile_1_1, [%c0, %c16] : !xegpu.tensor_desc<8x16xf32>
+      %c_sg_tile_1_3 = xegpu.update_nd_offset %c_sg_tile_1_2, [%c0, %c16] : !xegpu.tensor_desc<8x16xf32>
       // row 3
-      %c_sg_tile_2_0 = xegpu.update_nd_offset %c_sg_tile_0_0, [%c16, %c0] : !xegpu.tensor_desc<8x16xf32> -> !xegpu.tensor_desc<8x16xf32>
-      %c_sg_tile_2_1 = xegpu.update_nd_offset %c_sg_tile_2_0, [%c0, %c16] : !xegpu.tensor_desc<8x16xf32> -> !xegpu.tensor_desc<8x16xf32>
-      %c_sg_tile_2_2 = xegpu.update_nd_offset %c_sg_tile_2_1, [%c0, %c16]  : !xegpu.tensor_desc<8x16xf32> -> !xegpu.tensor_desc<8x16xf32>
-      %c_sg_tile_2_3 = xegpu.update_nd_offset %c_sg_tile_2_2, [%c0, %c16] : !xegpu.tensor_desc<8x16xf32> -> !xegpu.tensor_desc<8x16xf32>
+      %c_sg_tile_2_0 = xegpu.update_nd_offset %c_sg_tile_0_0, [%c16, %c0] : !xegpu.tensor_desc<8x16xf32>
+      %c_sg_tile_2_1 = xegpu.update_nd_offset %c_sg_tile_2_0, [%c0, %c16] : !xegpu.tensor_desc<8x16xf32>
+      %c_sg_tile_2_2 = xegpu.update_nd_offset %c_sg_tile_2_1, [%c0, %c16]  : !xegpu.tensor_desc<8x16xf32>
+      %c_sg_tile_2_3 = xegpu.update_nd_offset %c_sg_tile_2_2, [%c0, %c16] : !xegpu.tensor_desc<8x16xf32>
       // row 4
-      %c_sg_tile_3_0 = xegpu.update_nd_offset %c_sg_tile_0_0, [%c24, %c0] : !xegpu.tensor_desc<8x16xf32> -> !xegpu.tensor_desc<8x16xf32>
-      %c_sg_tile_3_1 = xegpu.update_nd_offset %c_sg_tile_3_0, [%c0, %c16] : !xegpu.tensor_desc<8x16xf32> -> !xegpu.tensor_desc<8x16xf32>
-      %c_sg_tile_3_2 = xegpu.update_nd_offset %c_sg_tile_3_1, [%c0, %c16] : !xegpu.tensor_desc<8x16xf32> -> !xegpu.tensor_desc<8x16xf32>
-      %c_sg_tile_3_3 = xegpu.update_nd_offset %c_sg_tile_3_2, [%c0, %c16] : !xegpu.tensor_desc<8x16xf32> -> !xegpu.tensor_desc<8x16xf32>
+      %c_sg_tile_3_0 = xegpu.update_nd_offset %c_sg_tile_0_0, [%c24, %c0] : !xegpu.tensor_desc<8x16xf32>
+      %c_sg_tile_3_1 = xegpu.update_nd_offset %c_sg_tile_3_0, [%c0, %c16] : !xegpu.tensor_desc<8x16xf32>
+      %c_sg_tile_3_2 = xegpu.update_nd_offset %c_sg_tile_3_1, [%c0, %c16] : !xegpu.tensor_desc<8x16xf32>
+      %c_sg_tile_3_3 = xegpu.update_nd_offset %c_sg_tile_3_2, [%c0, %c16] : !xegpu.tensor_desc<8x16xf32>
       // do store_nd
       xegpu.store_nd %k_loop_result#16, %c_sg_tile_0_0 {l1_hint = #xegpu.cache_hint<write_back>, l2_hint = #xegpu.cache_hint<write_back>, l3_hint = #xegpu.cache_hint<write_back>} : vector<8x16xf32>, !xegpu.tensor_desc<8x16xf32>
       xegpu.store_nd %k_loop_result#17, %c_sg_tile_0_1 {l1_hint = #xegpu.cache_hint<write_back>, l2_hint = #xegpu.cache_hint<write_back>, l3_hint = #xegpu.cache_hint<write_back>} : vector<8x16xf32>, !xegpu.tensor_desc<8x16xf32>

--- a/test/Integration/Dialect/XeGPU/gemm_4kx4kx4k_f16_f16_f16.mlir
+++ b/test/Integration/Dialect/XeGPU/gemm_4kx4kx4k_f16_f16_f16.mlir
@@ -1,8 +1,8 @@
-// RUN: IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-llvm.pp \
+// RUN: IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
 // RUN:                                       --runner imex-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
-// RUN: IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-llvm.pp \
+// RUN: IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
 // RUN:                                        --runner imex-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck

--- a/test/Integration/Dialect/XeGPU/gemm_4kx4kx4k_f16_f16_f16_w_8x32xf16_stores.mlir
+++ b/test/Integration/Dialect/XeGPU/gemm_4kx4kx4k_f16_f16_f16_w_8x32xf16_stores.mlir
@@ -1,8 +1,8 @@
-// RUN: IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-llvm.pp \
+// RUN: IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
 // RUN:                                       --runner imex-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
-// RUN: IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-llvm.pp \
+// RUN: IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
 // RUN:                                        --runner imex-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck

--- a/test/Integration/Dialect/XeGPU/gemm_4kx4kx4k_f16_f16_f16_w_simple_B_prefetch.mlir
+++ b/test/Integration/Dialect/XeGPU/gemm_4kx4kx4k_f16_f16_f16_w_simple_B_prefetch.mlir
@@ -1,8 +1,8 @@
-// RUN: IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-llvm.pp \
+// RUN: IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
 // RUN:                                       --runner imex-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
-// RUN: IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-llvm.pp \
+// RUN: IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
 // RUN:                                        --runner imex-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck

--- a/test/Integration/Dialect/XeGPU/xegpu-to-llvm.pp
+++ b/test/Integration/Dialect/XeGPU/xegpu-to-llvm.pp
@@ -1,3 +1,7 @@
+//// ------------- DISCLAIMER: DO NOT USE THIS PASS PIPELINE !! ----------- ////
+//// This pass pipeline is deprecated and may not contain all the intended  ////
+//// optimizations!! Please use xegpu-to-func-vc.pp !!                      ////
+
 // linalg dialect to gpu dialect lowering pipeline
 // Ready for vulkan runner or narrow scope l0/sycl runner starting from GPU dialect.
 builtin.module(

--- a/test/Integration/Dialect/XeGPU/xegpu-to-vc.mlir
+++ b/test/Integration/Dialect/XeGPU/xegpu-to-vc.mlir
@@ -28,6 +28,7 @@ spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer,
   }
   gpu.module @test_kernel {
    gpu.func @test_kernel(%arg0: memref<8x16xf16>, %arg1: memref<16x16xf16>, %arg2: memref<8x16xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>}{
+
      %arg00 = memref.reinterpret_cast %arg0 to offset: [0], sizes: [128], strides: [1] : memref<8x16xf16> to memref<128xf16>
      %0 = xegpu.create_nd_tdesc %arg00[0]: memref<128xf16> -> !xegpu.tensor_desc<128xf16>
      %1 = xegpu.create_nd_tdesc %arg1[0, 0] {boundary_check = true} : memref<16x16xf16> -> !xegpu.tensor_desc<16x16xf16>


### PR DESCRIPTION
    This change contains following changes:
    - adds necessary lowering for alloc_nbarrier op and
      minor fixes in other barrier related ops.
    - upstream patch to add support for propagating ExecutionMode Attribute
      from gpu.func op. This gets processed in GPUToSPIRV pass and relevant
      spirv.ExecutionMode op gets added as per given func attribute and value.
    - Below test cases are transitioned to new xegpu-to-vc pass pipeline.
            flash_attention_fwd.mlir
            gemm_4kx4kx4k_dpas_sized_loads_f16_f16_f32.mlir
            gemm_4kx4kx4k_f16_f16_f16.mlir
            gemm_4kx4kx4k_f16_f16_f16_w_8x32xf16_stores.mlir
            gemm_4kx4kx4k_f16_f16_f16_w_simple_B_prefetch.mlir

Please review these guidelines to help with the review process:
- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [ ] Have you organized your commits logically and ensured each can be built by itself?
