### PR TITLE
bf16 enabling for vector type.

### DIFF
--- a/lib/Transforms/BF16ToGPU.cpp
+++ b/lib/Transforms/BF16ToGPU.cpp
@@ -17,6 +17,7 @@
 
 #include "PassDetail.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/TypeUtilities.h"
@@ -79,7 +80,11 @@ public:
               if (!oname.starts_with("arith.bitcast")) {
                 bool needWidening = false;
                 for (const auto &oper : lop->getOperands()) {
-                  if (oper.getType().isBF16()) {
+                  if (auto vecTy = mlir::dyn_cast<VectorType>(oper.getType())) {
+                    if (vecTy.getElementType().isBF16()) {
+                      needWidening = true;
+                    }
+                  } else if (oper.getType().isBF16()) {
                     needWidening = true;
                   }
                 }
@@ -94,7 +99,15 @@ public:
         builder.setInsertionPoint(o);
         unsigned int idx = 0;
         for (const auto &oper : o->getOperands()) {
-          if (oper.getType().isBF16()) {
+          if (auto vecTy = mlir::dyn_cast<VectorType>(oper.getType())) {
+            if (vecTy.getElementType().isBF16()) {
+              auto newTy =
+                  VectorType::get(vecTy.getShape(), builder.getF32Type());
+              auto newOp =
+                  builder.create<arith::ExtFOp>(o->getLoc(), newTy, oper);
+              o->setOperand(idx, newOp);
+            }
+          } else if (oper.getType().isBF16()) {
             auto newOp = builder.create<arith::ExtFOp>(
                 o->getLoc(), builder.getF32Type(), oper);
             o->setOperand(idx, newOp);
@@ -102,7 +115,19 @@ public:
           idx++;
         }
         for (mlir::OpResult res : o->getResults()) {
-          if (res.getType().isBF16()) {
+          if (auto vecTy = mlir::dyn_cast<VectorType>(res.getType())) {
+            if (vecTy.getElementType().isBF16()) {
+              auto resTy =
+                  VectorType::get(vecTy.getShape(), builder.getF32Type());
+              res.setType(resTy);
+              builder.setInsertionPointAfter(o);
+              auto newTy =
+                  VectorType::get(vecTy.getShape(), builder.getBF16Type());
+              auto newRes =
+                  builder.create<arith::TruncFOp>(o->getLoc(), newTy, res);
+              res.replaceAllUsesExcept(newRes, newRes);
+            }
+          } else if (res.getType().isBF16()) {
             res.setType(builder.getF32Type());
             builder.setInsertionPointAfter(o);
             auto newRes = builder.create<arith::TruncFOp>(
@@ -129,26 +154,87 @@ public:
       (void)op.getRegion().walk<WalkOrder::PreOrder>(
           [&](Operation *lop) -> WalkResult {
             if (dyn_cast<arith::ExtFOp>(lop)) {
+              auto src = lop->getOperand(0);
+              auto res = lop->getResult(0);
               // if extf i16 -> f32 : "i16" is not a typo
-              if (lop->getOperand(0).getType().isInteger(16)) {
-                if (lop->getResult(0).getType().isF32()) {
+              auto srcTy = dyn_cast<VectorType>(src.getType());
+              auto resTy = dyn_cast<VectorType>(res.getType());
+              if (srcTy && resTy) {
+                if (srcTy.getElementType().isInteger(16) &&
+                    resTy.getElementType().isF32()) {
                   builder.setInsertionPoint(lop);
-                  auto bcast = builder.create<arith::BitcastOp>(
-                      lop->getLoc(), builder.getBF16Type(), lop->getOperand(0));
+                  auto newTy =
+                      VectorType::get(srcTy.getShape(), builder.getBF16Type());
+                  auto bcast = builder.create<arith::BitcastOp>(lop->getLoc(),
+                                                                newTy, src);
                   lop->setOperand(0, bcast);
                 }
+              } else if (src.getType().isInteger(16) && res.getType().isF32()) {
+                builder.setInsertionPoint(lop);
+                auto bcast = builder.create<arith::BitcastOp>(
+                    lop->getLoc(), builder.getBF16Type(), src);
+                lop->setOperand(0, bcast);
               }
             } else if (dyn_cast<arith::TruncFOp>(lop)) {
+              auto src = lop->getOperand(0);
+              auto res = lop->getResult(0);
               // if truncf f32 -> bf16
-              if (lop->getOperand(0).getType().isF32()) {
-                if (lop->getResult(0).getType().isBF16()) {
+              auto srcTy = dyn_cast<VectorType>(src.getType());
+              auto resTy = dyn_cast<VectorType>(res.getType());
+              if (srcTy && resTy) {
+                if (srcTy.getElementType().isF32() &&
+                    resTy.getElementType().isBF16()) {
                   builder.setInsertionPointAfter(lop);
-                  auto bcast = builder.create<arith::BitcastOp>(
-                      lop->getLoc(), builder.getI16Type(), lop->getResult(0));
-                  lop->getResult(0).replaceAllUsesExcept(bcast, bcast);
+                  auto newTy =
+                      VectorType::get(resTy.getShape(), builder.getI16Type());
+                  auto bcast = builder.create<arith::BitcastOp>(lop->getLoc(),
+                                                                newTy, res);
+                  res.replaceAllUsesExcept(bcast, bcast);
                 }
+              } else if (src.getType().isF32() && res.getType().isBF16()) {
+                builder.setInsertionPointAfter(lop);
+                auto bcast = builder.create<arith::BitcastOp>(
+                    lop->getLoc(), builder.getI16Type(), res);
+                res.replaceAllUsesExcept(bcast, bcast);
               }
             } else {
+              if (auto callOp = dyn_cast<func::CallOp>(lop)) {
+                auto name = callOp.getCallee();
+                auto module = lop->getParentOfType<gpu::GPUModuleOp>();
+                if (!module)
+                  op.emitError("Parent gpu module not found!");
+                auto result = SymbolRefAttr::get(module.getContext(), name);
+                auto func = module.lookupSymbol<func::FuncOp>(result.getAttr());
+                if (!func)
+                  op.emitError("Callee not found!");
+                auto ftype = func.getFunctionType();
+                SmallVector<Type, 8> newArgTypes;
+                bool needFuncArgUpdate = false;
+                for (auto iTy : ftype.getInputs()) {
+                  if (auto vecTy = dyn_cast<VectorType>(iTy)) {
+                    if (vecTy.getElementType().isBF16()) {
+                      auto newTy = vecTy.cloneWith(vecTy.getShape(),
+                                                   builder.getI16Type());
+                      newArgTypes.push_back(newTy);
+                      needFuncArgUpdate = true;
+                    } else {
+                      newArgTypes.push_back(iTy);
+                    }
+                  } else if (iTy.isBF16()) {
+                    newArgTypes.push_back(builder.getI16Type());
+                    needFuncArgUpdate = true;
+                  } else {
+                    // TODO: Can callee arg type be bf16 memref?
+                    newArgTypes.push_back(iTy);
+                  }
+                }
+                // TODO: Can callee return type be bf16?
+                if (needFuncArgUpdate) {
+                  auto nftype = dyn_cast<FunctionType>(
+                      func.cloneTypeWith(newArgTypes, ftype.getResults()));
+                  func.setFunctionType(nftype);
+                }
+              }
               if (lop->getNumResults() > 0) {
                 // Foreach result
                 //   if elemType is bf16, change it to i16
@@ -176,6 +262,7 @@ public:
     SmallVector<Operation *, 8> replacedAllocOps;
     (void)mod.walk<WalkOrder::PreOrder>([&](gpu::LaunchFuncOp op)
                                             -> WalkResult {
+      bool hasPassthroughArgs = false;
       for (const auto &kop : op.getKernelOperands()) {
         auto mem = kop;
         Type memt = mem.getType();
@@ -195,8 +282,11 @@ public:
           mem = parentView.getViewSource();
         }
         auto dop = mem.getDefiningOp();
+        if (!dop) {
+          hasPassthroughArgs = true;
+        }
         // op is the defining Operation*
-        if (isa<gpu::AllocOp>(dop)) {
+        else if (isa<gpu::AllocOp>(dop)) {
           auto alloc = dyn_cast<gpu::AllocOp>(dop);
           // TODO: Support dynamic size
           if (alloc.getDynamicSizes().size() != 0) {
@@ -339,7 +429,73 @@ public:
           op->emitError("Expected gpu.alloc memref producer for bf16 memref "
                         "arg or arith.ConstantOp for bf16 scalar arg.");
         }
-        //}
+      }
+      // Passthrough arguments are gpu.func arguments directly forwarded
+      // from caller function arguments.
+      // In such case, caller function argument type is updated to i16
+      // This requries updating the FunctionType of caller function and
+      // and the block argument type of the entry block.
+      if (hasPassthroughArgs) {
+        if (auto caller =
+                mlir::dyn_cast<mlir::func::FuncOp>(op->getParentOp())) {
+          auto oftype = caller.getFunctionType();
+          llvm::SmallVector<mlir::Type, 4> argTypes;
+          ArrayRef<Type> resultTypes;
+          Block &eblock = caller.getBlocks().front();
+          unsigned int arg_idx = 0;
+          for (mlir::BlockArgument arg : eblock.getArguments()) {
+            bool isPassThroughArg = true;
+            Type t = oftype.getInput(arg_idx);
+            for (auto use : arg.getUsers()) {
+              auto callOp = dyn_cast<gpu::LaunchFuncOp>(use);
+              if (!callOp) {
+                isPassThroughArg = false;
+                break;
+              }
+            }
+            if (isPassThroughArg) {
+              // Update block arg element type to i16
+              Type argt = arg.getType();
+              MemRefType mt = dyn_cast<MemRefType>(argt);
+              if (mt) {
+                if (mt.getElementType().isBF16()) {
+                  MemRefType newMt = dyn_cast<MemRefType>(
+                      mt.cloneWith(mt.getShape(), builder.getI16Type()));
+                  arg.setType(newMt);
+                }
+              } else if (argt.isBF16()) {
+                arg.setType(builder.getI16Type());
+              }
+              MemRefType m = mlir::dyn_cast<MemRefType>(t);
+              if (m) {
+                Type et = m.getElementType();
+                if (et.isBF16()) {
+                  if (m.hasStaticShape()) {
+                    llvm::ArrayRef<int64_t> s = m.getShape();
+                    auto i = MemRefType::get(s, builder.getI16Type());
+                    argTypes.push_back(i);
+                  } else {
+                    // TODO: Support dynamic shape
+                    caller.emitError(
+                        "Non static shape bf16 MemRefType in FuncOp inputs");
+                  }
+                } else {
+                  argTypes.push_back(t);
+                }
+              } else if (t.isBF16()) {
+                argTypes.push_back(builder.getI16Type());
+              } else {
+                argTypes.push_back(t);
+              }
+            } else {
+              argTypes.push_back(t);
+            }
+            arg_idx++;
+          }
+          auto nftype = dyn_cast<FunctionType>(
+              caller.cloneTypeWith(argTypes, resultTypes));
+          caller.setFunctionType(nftype);
+        }
       }
       return WalkResult::advance();
     });

--- a/test/Integration/Dialect/XeTile/sg_gemm_1kx1kx1k_preop_postop_bf16_bf16_f32.mlir
+++ b/test/Integration/Dialect/XeTile/sg_gemm_1kx1kx1k_preop_postop_bf16_bf16_f32.mlir
@@ -1,8 +1,8 @@
-// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xetile-to-func-vc.pp \
+// RUN: IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xetile-to-func-vc.pp \
 // RUN:                                       --runner imex-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
-// RUN: %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xetile-to-func-vc.pp \
+// RUN: IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xetile-to-func-vc.pp \
 // RUN:                                        --runner imex-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck
@@ -12,7 +12,7 @@
 // done by a single subgroup.
 
 module @gemm attributes {gpu.container_module} {
-  func.func @test(%A: memref<1024x1024xbf16>, %B: memref<1024x1024xbf16>, %C: memref<1024x1024xf32>) -> memref<1024x1024xf32> attributes {llvm.emit_c_interface} {
+  func.func @test(%A: memref<1024x1024xbf16>, %B: memref<1024x1024xbf16>, %C: memref<1024x1024xf32>, %Bias: memref<1024x1024xf32>) -> memref<1024x1024xf32> attributes {llvm.emit_c_interface} {
     %c1 = arith.constant 1 : index
     %c4 = arith.constant 4 : index
     %c8 = arith.constant 8 : index
@@ -27,13 +27,18 @@ module @gemm attributes {gpu.container_module} {
     memref.copy %B, %B_gpu : memref<1024x1024xbf16> to memref<1024x1024xbf16>
     %C_gpu = gpu.alloc  host_shared () : memref<1024x1024xf32>
     memref.copy %C, %C_gpu : memref<1024x1024xf32> to memref<1024x1024xf32>
-    gpu.launch_func  @test_kernel::@test_kernel blocks in (%c64, %c32, %c1) threads in (%c1, %c1, %c1) args(%A_gpu : memref<1024x1024xbf16>, %B_gpu : memref<1024x1024xbf16>, %C_gpu : memref<1024x1024xf32>)
+    %Bias_gpu = gpu.alloc  host_shared () : memref<1024x1024xf32>
+    memref.copy %Bias, %Bias_gpu : memref<1024x1024xf32> to memref<1024x1024xf32>
+    gpu.launch_func  @test_kernel::@test_kernel blocks in (%c64, %c32, %c1) threads in (%c1, %c1, %c1) args(%A_gpu : memref<1024x1024xbf16>, %B_gpu : memref<1024x1024xbf16>, %C_gpu : memref<1024x1024xf32>, %Bias_gpu : memref<1024x1024xf32>)
     gpu.dealloc  %A_gpu : memref<1024x1024xbf16>
     gpu.dealloc  %B_gpu : memref<1024x1024xbf16>
-    return %C_gpu : memref<1024x1024xf32>
+    gpu.dealloc  %Bias_gpu : memref<1024x1024xf32>
+    memref.copy %C_gpu, %C : memref<1024x1024xf32> to memref<1024x1024xf32>
+    gpu.dealloc  %C_gpu : memref<1024x1024xf32>
+    return %C : memref<1024x1024xf32>
   }
   gpu.module @test_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL, Bfloat16ConversionINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute, SPV_INTEL_bfloat16_conversion]>, api=OpenCL, #spirv.resource_limits<>>} {
-    gpu.func @test_kernel(%A: memref<1024x1024xbf16>, %B: memref<1024x1024xbf16>, %C: memref<1024x1024xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+    gpu.func @test_kernel(%A: memref<1024x1024xbf16>, %B: memref<1024x1024xbf16>, %C: memref<1024x1024xf32>, %Bias: memref<1024x1024xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
       %c0 = arith.constant 0 : index
       %c1 = arith.constant 1 : index
       %c8 = arith.constant 8 : index
@@ -47,6 +52,9 @@ module @gemm attributes {gpu.container_module} {
       // intialize C tile and load it
       %c_init_tile = xetile.init_tile %C[%m, %n] : memref<1024x1024xf32> -> !xetile.tile<16x32xf32>
       %c_init_value = xetile.load_tile %c_init_tile  : !xetile.tile<16x32xf32> -> vector<16x32xf32>
+      // intialize Bias tile and load it
+      %bias_init_tile = xetile.init_tile %Bias[%m, %n] : memref<1024x1024xf32> -> !xetile.tile<16x32xf32>
+      %bias_init_value = xetile.load_tile %bias_init_tile  : !xetile.tile<16x32xf32> -> vector<16x32xf32>
       // initalize A and B tiles
       %a_init_tile = xetile.init_tile %A[%m, %c0] : memref<1024x1024xbf16> -> !xetile.tile<16x32xbf16>
       %b_init_tile = xetile.init_tile %B[%c0, %n] : memref<1024x1024xbf16> -> !xetile.tile<32x32xbf16>
@@ -58,8 +66,10 @@ module @gemm attributes {gpu.container_module} {
         // load A and B tiles
         %a_value = xetile.load_tile %a_tile  : !xetile.tile<16x32xbf16> -> vector<16x32xbf16>
         %b_value = xetile.load_tile %b_tile  : !xetile.tile<32x32xbf16> -> vector<32x32xbf16>
+        %a_value_preop = arith.addf %a_value, %a_value : vector<16x32xbf16>
+        %b_value_preop = arith.addf %b_value, %b_value : vector<32x32xbf16>
         // perform dpas and accumulate
-        %c_new_value = xetile.tile_mma %a_value, %b_value, %c_value
+        %c_new_value = xetile.tile_mma %a_value_preop, %b_value_preop, %c_value
           : vector<16x32xbf16>, vector<32x32xbf16>, vector<16x32xf32> -> vector<16x32xf32>
         // update the offsets for A and B tiles
         %a_next_tile = xetile.update_tile_offset %a_tile, [%c0, %c32]
@@ -70,8 +80,10 @@ module @gemm attributes {gpu.container_module} {
         scf.yield %a_next_tile, %b_next_tile, %c_new_value
           : !xetile.tile<16x32xbf16>, !xetile.tile<32x32xbf16>, vector<16x32xf32>
       }
+      // add bias to the final C tile result
+      %c_bias = arith.addf %out#2, %bias_init_value : vector<16x32xf32>
       // store the final accumulated C tile result back to memory
-      xetile.store_tile %out#2, %c_init_tile: vector<16x32xf32>, !xetile.tile<16x32xf32>
+      xetile.store_tile %c_bias, %c_init_tile: vector<16x32xf32>, !xetile.tile<16x32xf32>
       gpu.return
     }
   }
@@ -85,6 +97,7 @@ module @gemm attributes {gpu.container_module} {
     %B = memref.alloc() : memref<1024x1024xbf16>
     %C = memref.alloc() : memref<1024x1024xf32>
     %C_ref = memref.alloc() : memref<1024x1024xf32>
+    %Bias = memref.alloc() : memref<1024x1024xf32>
     // intialize matrix A ; A[i, j] = j
     scf.for %i = %c0 to %c1024 step %c1 {
       scf.for %j = %c0 to %c1024 step %c1 {
@@ -115,6 +128,13 @@ module @gemm attributes {gpu.container_module} {
         memref.store %c0_f32, %C_ref[%i, %j] : memref<1024x1024xf32>
       }
     }
+    // intialize matrix Bias ; Bias[i, j] = 1
+    %c1_f32 = arith.constant 1.0 : f32
+    scf.for %i = %c0 to %c1024 step %c1 {
+      scf.for %j = %c0 to %c1024 step %c1 {
+        memref.store %c1_f32, %Bias[%i, %j] : memref<1024x1024xf32>
+      }
+    }
     // compute C for reference
     scf.for %i = %c0 to %c1024 step %c1 {
       scf.for %j = %c0 to %c1024 step %c1 {
@@ -122,15 +142,19 @@ module @gemm attributes {gpu.container_module} {
         %c_val = scf.for %k = %c0 to %c1024 step %c1 iter_args(%c_partial = %c_curr) -> f32 {
           %a_val = memref.load %A[%i, %k] : memref<1024x1024xbf16>
           %b_val = memref.load %B[%k, %j] : memref<1024x1024xbf16>
-          %t = arith.mulf %a_val, %b_val : bf16
+          %a_val_preop = arith.addf %a_val, %a_val : bf16
+          %b_val_preop = arith.addf %b_val, %b_val : bf16
+          %t = arith.mulf %a_val_preop, %b_val_preop : bf16
           %t_cast = arith.extf %t : bf16 to f32
           %c_sum = arith.addf %t_cast, %c_partial : f32
           scf.yield %c_sum : f32
         }
-        memref.store %c_val , %C_ref[%i, %j] : memref<1024x1024xf32>
+        %bias_val = memref.load %Bias[%i, %j] : memref<1024x1024xf32>
+        %c_val_bias = arith.addf %c_val, %bias_val : f32
+        memref.store %c_val_bias, %C_ref[%i, %j] : memref<1024x1024xf32>
       }
     }
-    %2 = call @test(%A, %B, %C) : (memref<1024x1024xbf16>, memref<1024x1024xbf16>, memref<1024x1024xf32>) -> memref<1024x1024xf32>
+    %2 = call @test(%A, %B, %C, %Bias) : (memref<1024x1024xbf16>, memref<1024x1024xbf16>, memref<1024x1024xf32>, memref<1024x1024xf32>) -> memref<1024x1024xf32>
     // %cast = memref.cast %B : memref<1024x1024xbf16> to memref<*xbf16>
     // call @printMemrefbf16(%cast) : (memref<*xbf16>) -> ()
     %cast_C = memref.cast %2 : memref<1024x1024xf32> to memref<*xf32>


### PR DESCRIPTION
    Add bf16 conversion for vector operands.
    And handler for various unhandled cases for vector type with bf16 element type.
    Handle vc-intrinsic bf16 call args and declaration args update.
    bf16 to gpu: convert bf16 passthrough arg (caller args directly passed to gpu.func)
    to i16
    Add XeTile bf16 integration test with preop and postop.

Please review these guidelines to help with the review process:
- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [ ] Have you organized your commits logically and ensured each can be built by itself?
