### PR TITLE
Enable lowering support xetile.transpose op

### DIFF
--- a/include/imex/Dialect/XeTile/IR/XeTileOps.td
+++ b/include/imex/Dialect/XeTile/IR/XeTileOps.td
@@ -534,7 +534,7 @@ def XeTile_TransposeOp: XeTile_Op<"transpose", []> {
                          DenseI64ArrayAttr:$permutation);
     let results = (outs XeTile_2DOr4DVector: $result);
     let assemblyFormat = [{
-        $vector $permutation attr-dict `:` type($vector) `->` type($result)
+        $vector `,` $permutation attr-dict `:` type($vector) `->` type($result)
     }];
     let hasVerifier = 1;
 }

--- a/lib/Dialect/XeTile/Transforms/Blocking.cpp
+++ b/lib/Dialect/XeTile/Transforms/Blocking.cpp
@@ -182,7 +182,7 @@ getInnerBlockSizes(mlir::Operation *operation, mlir::Type elemTy, int height,
     // TODO: get from uArch?
     maxHeight = 16;
     minHeight = 1;
-    maxWidth = 16;
+    maxWidth = 8;
     minWidth = 1;
 
     return imex::getInnerBlockHeightWidth(maxHeight, maxWidth, minHeight,
@@ -437,8 +437,8 @@ struct TransposeOpPattern : public XeTileConversion<OpTy, TileUsageAnalysis> {
         mlir::DenseI64ArrayAttr::get(op.getContext(), inBlocks));
 
     int64_t newPermutation[4] = {1, 0, 3, 2};
-    mlir::Value transpose = rewriter.create<mlir::vector::TransposeOp>(
-        loc, newDstTy, pack, newPermutation);
+    mlir::Value transpose =
+        rewriter.create<OpTy>(loc, newDstTy, pack, newPermutation);
 
     mlir::Value unpack = rewriter.create<xetile::TileUnpackOp>(
         loc, resType, transpose,

--- a/test/Conversion/XeTileToXeGPU/test_blocking.mlir
+++ b/test/Conversion/XeTileToXeGPU/test_blocking.mlir
@@ -31,9 +31,9 @@ gpu.module @test_kernel {
 
 // CHECK-LABEL: test_blocking_transpose
 //  CHECK-SAME: (%[[SRC:.*]]: vector<64x32xf16>)
-//       CHECK: %[[PACK:.*]] = xetile.tile_pack %[[SRC]] { inner_blocks = [16, 16] } : vector<64x32xf16> -> vector<4x2x16x16xf16>
-//       CHECK: %[[T:.*]] = vector.transpose %[[PACK]], [1, 0, 3, 2] : vector<4x2x16x16xf16> to vector<2x4x16x16xf16>
-//       CHECK: %[[UNPACK:.*]] = xetile.tile_unpack %[[T]] { inner_blocks = [16, 16] } : vector<2x4x16x16xf16> -> vector<32x64xf16>
+//       CHECK: %[[PACK:.*]] = xetile.tile_pack %[[SRC]] { inner_blocks = [8, 16] } : vector<64x32xf16> -> vector<8x2x8x16xf16>
+//       CHECK: %[[T:.*]] = vector.transpose %[[PACK]], [1, 0, 3, 2] : vector<8x2x8x16xf16> to vector<2x8x16x8xf16>
+//       CHECK: %[[UNPACK:.*]] = xetile.tile_unpack %[[T]] { inner_blocks = [16, 8] } : vector<2x8x16x8xf16> -> vector<32x64xf16>
 //       CHECK: return %[[UNPACK]] : vector<32x64xf16>
 func.func @test_blocking_transpose(%a: vector<64x32xf16>) -> vector<32x64xf16> {
   %0 = vector.transpose %a, [1, 0]: vector<64x32xf16> to vector<32x64xf16>
@@ -48,9 +48,9 @@ gpu.module @test_kernel {
 
 // CHECK-LABEL: test_blocking_transpose_small
 //  CHECK-SAME: (%[[SRC:.*]]: vector<16x8xf16>)
-//       CHECK: %[[PACK:.*]] = xetile.tile_pack %[[SRC]] { inner_blocks = [16, 8] } : vector<16x8xf16> -> vector<1x1x16x8xf16>
-//       CHECK: %[[T:.*]] = vector.transpose %[[PACK]], [1, 0, 3, 2] : vector<1x1x16x8xf16> to vector<1x1x8x16xf16>
-//       CHECK: %[[UNPACK:.*]] = xetile.tile_unpack %[[T]] { inner_blocks = [8, 16] } : vector<1x1x8x16xf16> -> vector<8x16xf16>
+//       CHECK: %[[PACK:.*]] = xetile.tile_pack %[[SRC]] { inner_blocks = [8, 8] } : vector<16x8xf16> -> vector<2x1x8x8xf16>
+//       CHECK: %[[T:.*]] = vector.transpose %[[PACK]], [1, 0, 3, 2] : vector<2x1x8x8xf16> to vector<1x2x8x8xf16>
+//       CHECK: %[[UNPACK:.*]] = xetile.tile_unpack %[[T]] { inner_blocks = [8, 8] } : vector<1x2x8x8xf16> -> vector<8x16xf16>
 //       CHECK: return %[[UNPACK]] : vector<8x16xf16>
 func.func @test_blocking_transpose_small(%a: vector<16x8xf16>) -> vector<8x16xf16> {
   %0 = vector.transpose %a, [1, 0]: vector<16x8xf16> to vector<8x16xf16>

--- a/test/Dialect/XeTile/IR/invalid.mlir
+++ b/test/Dialect/XeTile/IR/invalid.mlir
@@ -233,7 +233,7 @@ func.func @tile_unpack_invalid_output_shape(%in : vector<4x4x16x16xf16>) {
 // -----
 func.func @test_transpose(%source: vector<8x16xf16>) {
   // expected-error@+1 {{Incorrect transpose permutation}}
-  %1 = xetile.transpose %source [0, 1] : vector<8x16xf16> -> vector<16x8xf16>
+  %1 = xetile.transpose %source, [0, 1] : vector<8x16xf16> -> vector<16x8xf16>
   return
 }
 

--- a/test/Dialect/XeTile/IR/ops.mlir
+++ b/test/Dialect/XeTile/IR/ops.mlir
@@ -312,7 +312,7 @@ func.func @test_atomic_rmw(%tile : !xetile.tile<8x16xf16>, %value : vector<8x16x
 
 func.func @test_transpose(%source: vector<8x16xf16>) {
   // CHECK: xetile.transpose {{.*}} [1, 0] : vector<8x16xf16> -> vector<16x8xf16>
-  %1 = xetile.transpose %source [1, 0] : vector<8x16xf16> -> vector<16x8xf16>
+  %1 = xetile.transpose %source, [1, 0] : vector<8x16xf16> -> vector<16x8xf16>
   return
 }
 

--- a/test/Dialect/XeTile/Transforms/blocking.mlir
+++ b/test/Dialect/XeTile/Transforms/blocking.mlir
@@ -365,10 +365,10 @@ gpu.module @test_kernel {
       //CHECK: %[[r8:.*]] = xetile.tile_unpack %[[r7]] { inner_blocks = [1, 16] }  : vector<32x4x1x16xf16> -> vector<32x64xf16>
       %6 = arith.divf %3, %5: vector<32x64xf16>
 
-      //CHECK: %[[r9:.*]] = xetile.tile_pack %[[r8]] { inner_blocks = [16, 16] }  : vector<32x64xf16> -> vector<2x4x16x16xf16>
-      //CHECK: %[[r10:.*]] = vector.transpose %[[r9]], [1, 0, 3, 2] : vector<2x4x16x16xf16> to vector<4x2x16x16xf16>
-      //CHECK: %[[r11:.*]] = xetile.tile_unpack %[[r10]] { inner_blocks = [16, 16] }  : vector<4x2x16x16xf16> -> vector<64x32xf16>
-      %7 = xetile.transpose %6 [1, 0]: vector<32x64xf16> -> vector<64x32xf16>
+      //CHECK: %[[r9:.*]] = xetile.tile_pack %[[r8]] { inner_blocks = [8, 16] }  : vector<32x64xf16> -> vector<4x4x8x16xf16>
+      //CHECK: %[[r10:.*]] = xetile.transpose %[[r9]], [1, 0, 3, 2] : vector<4x4x8x16xf16> -> vector<4x4x16x8xf16>
+      //CHECK: %[[r11:.*]] = xetile.tile_unpack %[[r10]] { inner_blocks = [16, 8] }  : vector<4x4x16x8xf16> -> vector<64x32xf16>
+      %7 = xetile.transpose %6, [1, 0]: vector<32x64xf16> -> vector<64x32xf16>
 
       //CHECK: %[[r12:.*]] = xetile.init_tile %[[arg0]][0, 0] : memref<1024x1024xf16> -> !xetile.tile<64x32xf16, #xetile.tile_attr<inner_blocks = [8, 32]>>
       %8 = xetile.init_tile %a[0, 0] : memref<1024x1024xf16> -> !xetile.tile<64x32xf16>

--- a/test/Integration/Dialect/XeGPU/transpose_8x16xf16.mlir
+++ b/test/Integration/Dialect/XeGPU/transpose_8x16xf16.mlir
@@ -1,0 +1,67 @@
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                       --runner imex-cpu-runner -e main \
+// RUN:                                       --entry-point-result=void \
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
+// RUN: %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                        --runner imex-cpu-runner -e main \
+// RUN:                                        --entry-point-result=void \
+// RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck
+module @transpose attributes {gpu.container_module} {
+  func.func @test(%arg0: memref<32x32xf16>) -> memref<32x32xf16> attributes {llvm.emit_c_interface} {
+    %c4 = arith.constant 4 : index
+    %c2 = arith.constant 2 : index
+    %c1 = arith.constant 1 : index
+    %memref = gpu.alloc  host_shared () : memref<32x32xf16>
+    memref.copy %arg0, %memref : memref<32x32xf16> to memref<32x32xf16>
+    %B = gpu.alloc  host_shared () : memref<32x32xf16>
+    gpu.launch_func  @test_kernel::@test_kernel blocks in (%c4, %c2, %c1) threads in (%c1, %c1, %c1) args(%memref : memref<32x32xf16>, %B : memref<32x32xf16>)
+    gpu.dealloc  %memref : memref<32x32xf16>
+    return %B : memref<32x32xf16>
+  }
+  gpu.module @test_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
+    gpu.func @test_kernel(%arg0: memref<32x32xf16>, %arg1: memref<32x32xf16>) kernel attributes {VectorComputeFunctionINTEL, gpu.known_block_size = array<i32: 1, 1, 1>, gpu.known_grid_size = array<i32: 4, 2, 1>, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %c0 = arith.constant 0 : index
+      %c8 = arith.constant 8 : index
+      %c16 = arith.constant 16 : index
+      %0 = gpu.block_id  x
+      %1 = gpu.block_id  y
+      %2 = arith.muli %0, %c8 : index
+      %3 = arith.muli %1, %c16 : index
+      %4 = xegpu.create_nd_tdesc %arg0[%2, %3] : memref<32x32xf16> -> !xegpu.tensor_desc<8x16xf16>
+      %5 = xegpu.load_nd %4 : !xegpu.tensor_desc<8x16xf16> -> vector<8x16xf16>
+      %6 = xegpu.create_nd_tdesc %arg1[%3, %2] : memref<32x32xf16> -> !xegpu.tensor_desc<16x8xf16>
+      %7 = vector.transpose %5, [1, 0]: vector<8x16xf16> to vector<16x8xf16>
+      xegpu.store_nd %7, %6 : vector<16x8xf16>, !xegpu.tensor_desc<16x8xf16>
+      gpu.return
+    }
+  }
+
+
+  func.func @main() attributes {llvm.emit_c_interface} {
+    %0 = memref.alloc() : memref<32x32xf16>
+    %ref = memref.alloc() : memref<32x32xf32>
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    // A matrix: row-major, start from 0.0, increase 0.01 per element
+    // B matrix: A matrix + 1.0
+    scf.for %i = %c0 to %c32 step %c1 {
+      scf.for %j = %c0 to %c32 step %c1 {
+        %int = arith.index_cast %j : index to i32
+        %fp = arith.uitofp %int : i32 to f16
+        memref.store %fp, %0[%i, %j] : memref<32x32xf16>
+        %fp_32 = arith.extf %fp : f16 to f32
+        memref.store %fp_32, %ref[%j, %i] : memref<32x32xf32>
+      }
+    }
+
+    %2 = call @test(%0) : (memref<32x32xf16>) -> memref<32x32xf16>
+    %res = memref.cast %2 : memref<32x32xf16> to memref<*xf16>
+    %cast_ref = memref.cast %ref : memref<32x32xf32> to memref<*xf32>
+    // CHECK:   [ALLCLOSE: TRUE]
+    call @printAllcloseF16(%res, %cast_ref) : (memref<*xf16>, memref<*xf32>) -> ()
+    return
+  }
+  func.func private @printAllcloseF16(memref<*xf16>, memref<*xf32>) attributes {llvm.emit_c_interface}
+}

--- a/test/Integration/Dialect/XeGPU/transpose_8x16xf32.mlir
+++ b/test/Integration/Dialect/XeGPU/transpose_8x16xf32.mlir
@@ -1,0 +1,67 @@
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                       --runner imex-cpu-runner -e main \
+// RUN:                                       --entry-point-result=void \
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
+// RUN: %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                        --runner imex-cpu-runner -e main \
+// RUN:                                        --entry-point-result=void \
+// RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck
+module @transpose attributes {gpu.container_module} {
+  func.func @test(%arg0: memref<32x32xf32>) -> memref<32x32xf32> attributes {llvm.emit_c_interface} {
+    %c4 = arith.constant 4 : index
+    %c2 = arith.constant 2 : index
+    %c1 = arith.constant 1 : index
+    %memref = gpu.alloc  host_shared () : memref<32x32xf32>
+    memref.copy %arg0, %memref : memref<32x32xf32> to memref<32x32xf32>
+    %B = gpu.alloc  host_shared () : memref<32x32xf32>
+    gpu.launch_func  @test_kernel::@test_kernel blocks in (%c4, %c2, %c1) threads in (%c1, %c1, %c1) args(%memref : memref<32x32xf32>, %B : memref<32x32xf32>)
+    gpu.dealloc  %memref : memref<32x32xf32>
+    return %B : memref<32x32xf32>
+  }
+  gpu.module @test_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
+    gpu.func @test_kernel(%arg0: memref<32x32xf32>, %arg1: memref<32x32xf32>) kernel attributes {VectorComputeFunctionINTEL, gpu.known_block_size = array<i32: 1, 1, 1>, gpu.known_grid_size = array<i32: 4, 2, 1>, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %c0 = arith.constant 0 : index
+      %c8 = arith.constant 8 : index
+      %c16 = arith.constant 16 : index
+      %0 = gpu.block_id  x
+      %1 = gpu.block_id  y
+      %2 = arith.muli %0, %c8 : index
+      %3 = arith.muli %1, %c16 : index
+      %4 = xegpu.create_nd_tdesc %arg0[%2, %3] : memref<32x32xf32> -> !xegpu.tensor_desc<8x16xf32>
+      %5 = xegpu.load_nd %4 : !xegpu.tensor_desc<8x16xf32> -> vector<8x16xf32>
+      %6 = xegpu.create_nd_tdesc %arg1[%3, %2] : memref<32x32xf32> -> !xegpu.tensor_desc<16x8xf32>
+      %7 = vector.transpose %5, [1, 0]: vector<8x16xf32> to vector<16x8xf32>
+      xegpu.store_nd %7, %6 : vector<16x8xf32>, !xegpu.tensor_desc<16x8xf32>
+      gpu.return
+    }
+  }
+
+
+  func.func @main() attributes {llvm.emit_c_interface} {
+    %0 = memref.alloc() : memref<32x32xf32>
+    %ref = memref.alloc() : memref<32x32xf32>
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    // A matrix: row-major, start from 0.0, increase 0.01 per element
+    // B matrix: A matrix + 1.0
+    scf.for %i = %c0 to %c32 step %c1 {
+      scf.for %j = %c0 to %c32 step %c1 {
+        %int = arith.index_cast %j : index to i32
+        %fp = arith.uitofp %int : i32 to f32
+        memref.store %fp, %0[%i, %j] : memref<32x32xf32>
+        memref.store %fp, %ref[%j, %i] : memref<32x32xf32>
+      }
+    }
+
+    %2 = call @test(%0) : (memref<32x32xf32>) -> memref<32x32xf32>
+    %res = memref.cast %2 : memref<32x32xf32> to memref<*xf32>
+    %cast_ref = memref.cast %ref : memref<32x32xf32> to memref<*xf32>
+    // CHECK:   [ALLCLOSE: TRUE]
+    call @printAllcloseF32(%res, %cast_ref) : (memref<*xf32>, memref<*xf32>) -> ()
+    return
+  }
+  // func.func private @printMemrefF32(memref<*xf32>) attributes {llvm.emit_c_interface}
+  func.func private @printAllcloseF32(memref<*xf32>, memref<*xf32>) attributes {llvm.emit_c_interface}
+}

--- a/test/Integration/Dialect/XeGPU/transpose_8x8xf16.mlir
+++ b/test/Integration/Dialect/XeGPU/transpose_8x8xf16.mlir
@@ -1,0 +1,67 @@
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                       --runner imex-cpu-runner -e main \
+// RUN:                                       --entry-point-result=void \
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
+// RUN: %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                        --runner imex-cpu-runner -e main \
+// RUN:                                        --entry-point-result=void \
+// RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck
+module @transpose attributes {gpu.container_module} {
+  func.func @test(%arg0: memref<32x32xf16>) -> memref<32x32xf16> attributes {llvm.emit_c_interface} {
+    %c4 = arith.constant 4 : index
+    %c1 = arith.constant 1 : index
+    %memref = gpu.alloc  host_shared () : memref<32x32xf16>
+    memref.copy %arg0, %memref : memref<32x32xf16> to memref<32x32xf16>
+    %B = gpu.alloc  host_shared () : memref<32x32xf16>
+    gpu.launch_func  @test_kernel::@test_kernel blocks in (%c4, %c4, %c1) threads in (%c1, %c1, %c1) args(%memref : memref<32x32xf16>, %B : memref<32x32xf16>)
+    gpu.dealloc  %memref : memref<32x32xf16>
+    return %B : memref<32x32xf16>
+  }
+  gpu.module @test_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
+    gpu.func @test_kernel(%arg0: memref<32x32xf16>, %arg1: memref<32x32xf16>) kernel attributes {VectorComputeFunctionINTEL, gpu.known_block_size = array<i32: 1, 1, 1>, gpu.known_grid_size = array<i32: 4, 4, 1>, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %c0 = arith.constant 0 : index
+      %c8 = arith.constant 8 : index
+      %0 = gpu.block_id  x
+      %1 = gpu.block_id  y
+      %2 = arith.muli %0, %c8 : index
+      %3 = arith.muli %1, %c8 : index
+      %4 = xegpu.create_nd_tdesc %arg0[%2, %3] : memref<32x32xf16> -> !xegpu.tensor_desc<8x8xf16>
+      %5 = xegpu.load_nd %4 : !xegpu.tensor_desc<8x8xf16> -> vector<8x8xf16>
+      %6 = xegpu.create_nd_tdesc %arg1[%3, %2] : memref<32x32xf16> -> !xegpu.tensor_desc<8x8xf16>
+      %7 = vector.transpose %5, [1, 0]: vector<8x8xf16> to vector<8x8xf16>
+      xegpu.store_nd %7, %6 : vector<8x8xf16>, !xegpu.tensor_desc<8x8xf16>
+      gpu.return
+    }
+  }
+
+
+  func.func @main() attributes {llvm.emit_c_interface} {
+    %0 = memref.alloc() : memref<32x32xf16>
+    %ref = memref.alloc() : memref<32x32xf32>
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    // A matrix: row-major, start from 0.0, increase 0.01 per element
+    // B matrix: A matrix + 1.0
+    scf.for %i = %c0 to %c32 step %c1 {
+      scf.for %j = %c0 to %c32 step %c1 {
+        %int = arith.index_cast %j : index to i32
+        %fp = arith.uitofp %int : i32 to f16
+        memref.store %fp, %0[%i, %j] : memref<32x32xf16>
+        %fp_32 = arith.extf %fp : f16 to f32
+        memref.store %fp_32, %ref[%j, %i] : memref<32x32xf32>
+      }
+    }
+
+    %2 = call @test(%0) : (memref<32x32xf16>) -> memref<32x32xf16>
+    %res = memref.cast %2 : memref<32x32xf16> to memref<*xf16>
+    %cast_ref = memref.cast %ref : memref<32x32xf32> to memref<*xf32>
+    // call @printMemreff16(%cast_ref) : (memref<*xf16>) -> ()
+    // CHECK:   [ALLCLOSE: TRUE]
+    call @printAllcloseF16(%res, %cast_ref) : (memref<*xf16>, memref<*xf32>) -> ()
+    return
+  }
+  func.func private @printMemrefF16(memref<*xf16>) attributes {llvm.emit_c_interface}
+  func.func private @printAllcloseF16(memref<*xf16>, memref<*xf32>) attributes {llvm.emit_c_interface}
+}

--- a/test/Integration/Dialect/XeGPU/transpose_8x8xf32.mlir
+++ b/test/Integration/Dialect/XeGPU/transpose_8x8xf32.mlir
@@ -1,0 +1,64 @@
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                       --runner imex-cpu-runner -e main \
+// RUN:                                       --entry-point-result=void \
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
+// RUN: %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                        --runner imex-cpu-runner -e main \
+// RUN:                                        --entry-point-result=void \
+// RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck
+module @transpose attributes {gpu.container_module} {
+  func.func @test(%arg0: memref<32x32xf32>) -> memref<32x32xf32> attributes {llvm.emit_c_interface} {
+    %c4 = arith.constant 4 : index
+    %c1 = arith.constant 1 : index
+    %memref = gpu.alloc  host_shared () : memref<32x32xf32>
+    memref.copy %arg0, %memref : memref<32x32xf32> to memref<32x32xf32>
+    %B = gpu.alloc  host_shared () : memref<32x32xf32>
+    gpu.launch_func  @test_kernel::@test_kernel blocks in (%c4, %c4, %c1) threads in (%c1, %c1, %c1) args(%memref : memref<32x32xf32>, %B : memref<32x32xf32>)
+    gpu.dealloc  %memref : memref<32x32xf32>
+    return %B : memref<32x32xf32>
+  }
+  gpu.module @test_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
+    gpu.func @test_kernel(%arg0: memref<32x32xf32>, %arg1: memref<32x32xf32>) kernel attributes {VectorComputeFunctionINTEL, gpu.known_block_size = array<i32: 1, 1, 1>, gpu.known_grid_size = array<i32: 4, 4, 1>, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %c0 = arith.constant 0 : index
+      %c8 = arith.constant 8 : index
+      %0 = gpu.block_id  x
+      %1 = gpu.block_id  y
+      %2 = arith.muli %0, %c8 : index
+      %3 = arith.muli %1, %c8 : index
+      %4 = xegpu.create_nd_tdesc %arg0[%2, %3] : memref<32x32xf32> -> !xegpu.tensor_desc<8x8xf32>
+      %5 = xegpu.load_nd %4 : !xegpu.tensor_desc<8x8xf32> -> vector<8x8xf32>
+      %6 = xegpu.create_nd_tdesc %arg1[%3, %2] : memref<32x32xf32> -> !xegpu.tensor_desc<8x8xf32>
+      %7 = vector.transpose %5, [1, 0]: vector<8x8xf32> to vector<8x8xf32>
+      xegpu.store_nd %7, %6 : vector<8x8xf32>, !xegpu.tensor_desc<8x8xf32>
+      gpu.return
+    }
+  }
+
+
+  func.func @main() attributes {llvm.emit_c_interface} {
+    %0 = memref.alloc() : memref<32x32xf32>
+    %ref = memref.alloc() : memref<32x32xf32>
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    // A matrix: row-major, start from 0.0, increase 0.01 per element
+    // B matrix: A matrix + 1.0
+    scf.for %i = %c0 to %c32 step %c1 {
+      scf.for %j = %c0 to %c32 step %c1 {
+        %int = arith.index_cast %j : index to i32
+        %fp = arith.uitofp %int : i32 to f32
+        memref.store %fp, %0[%i, %j] : memref<32x32xf32>
+        memref.store %fp, %ref[%j, %i] : memref<32x32xf32>
+      }
+    }
+
+    %2 = call @test(%0) : (memref<32x32xf32>) -> memref<32x32xf32>
+    %res = memref.cast %2 : memref<32x32xf32> to memref<*xf32>
+    %cast_ref = memref.cast %ref : memref<32x32xf32> to memref<*xf32>
+    // CHECK:   [ALLCLOSE: TRUE]
+    call @printAllcloseF32(%res, %cast_ref) : (memref<*xf32>, memref<*xf32>) -> ()
+    return
+  }
+  func.func private @printAllcloseF32(memref<*xf32>, memref<*xf32>) attributes {llvm.emit_c_interface}
+}

--- a/test/Integration/Dialect/XeTile/sg_gemm_1kx1kx1k_f16_f16_f32_transpose_a.mlir
+++ b/test/Integration/Dialect/XeTile/sg_gemm_1kx1kx1k_f16_f16_f32_transpose_a.mlir
@@ -1,0 +1,141 @@
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xetile-to-func-vc.pp \
+// RUN:                                       --runner imex-cpu-runner -e main \
+// RUN:                                       --entry-point-result=void \
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
+// RUN: %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xetile-to-func-vc.pp \
+// RUN:                                        --runner imex-cpu-runner -e main \
+// RUN:                                        --entry-point-result=void \
+// RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck
+
+// NOTES :
+// This example assumes one subgroup per one workgroup and the kernel specifies the computation
+// done by a single subgroup.
+
+module @gemm attributes {gpu.container_module} {
+  func.func @test(%A: memref<1024x1024xf16>, %B: memref<1024x1024xf16>, %C: memref<1024x1024xf32>) -> memref<1024x1024xf32> attributes {llvm.emit_c_interface} {
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %A_gpu = gpu.alloc  host_shared () : memref<1024x1024xf16>
+    memref.copy %A, %A_gpu : memref<1024x1024xf16> to memref<1024x1024xf16>
+    %B_gpu = gpu.alloc  host_shared () : memref<1024x1024xf16>
+    memref.copy %B, %B_gpu : memref<1024x1024xf16> to memref<1024x1024xf16>
+    %C_gpu = gpu.alloc  host_shared () : memref<1024x1024xf32>
+    memref.copy %C, %C_gpu : memref<1024x1024xf32> to memref<1024x1024xf32>
+    gpu.launch_func  @test_kernel::@test_kernel blocks in (%c32, %c32, %c1) threads in (%c1, %c1, %c1) args(%A_gpu : memref<1024x1024xf16>, %B_gpu : memref<1024x1024xf16>, %C_gpu : memref<1024x1024xf32>)
+    gpu.dealloc  %A_gpu : memref<1024x1024xf16>
+    gpu.dealloc  %B_gpu : memref<1024x1024xf16>
+    return %C_gpu : memref<1024x1024xf32>
+  }
+  gpu.module @test_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
+    gpu.func @test_kernel(%A: memref<1024x1024xf16>, %B: memref<1024x1024xf16>, %C: memref<1024x1024xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c8 = arith.constant 8 : index
+      %c32 = arith.constant 32 : index
+      %c1024 = arith.constant 1024 : index
+      %block_id_x = gpu.block_id x
+      %block_id_y = gpu.block_id y
+      %m = arith.muli %block_id_x, %c32 : index
+      %n = arith.muli %block_id_y, %c32 : index
+      // intialize C tile and load it
+      %c_init_tile = xetile.init_tile %C[%m, %n] : memref<1024x1024xf32> -> !xetile.tile<32x32xf32>
+      %c_init_value = xetile.load_tile %c_init_tile  : !xetile.tile<32x32xf32> -> vector<32x32xf32>
+      // initalize A and B tiles
+      %a_init_tile = xetile.init_tile %A[%c0, %m] : memref<1024x1024xf16> -> !xetile.tile<32x32xf16>
+      %b_init_tile = xetile.init_tile %B[%c0, %n] : memref<1024x1024xf16> -> !xetile.tile<32x32xf16>
+      // compute the value of C tile by iterating over tiles in k-dimension and doing dpas
+      %out:3 = scf.for %k = %c0 to %c1024 step %c32
+        iter_args(%a_tile = %a_init_tile, %b_tile = %b_init_tile, %c_value = %c_init_value)
+        -> (!xetile.tile<32x32xf16>, !xetile.tile<32x32xf16>, vector<32x32xf32>) {
+
+        // load A and B tiles
+        %a_value = xetile.load_tile %a_tile  : !xetile.tile<32x32xf16> -> vector<32x32xf16>
+        %b_value = xetile.load_tile %b_tile  : !xetile.tile<32x32xf16> -> vector<32x32xf16>
+        %a_trans = vector.transpose %a_value, [1, 0] : vector<32x32xf16> to vector<32x32xf16>
+        // perform dpas and accumulate
+        %c_new_value = xetile.tile_mma %a_trans, %b_value, %c_value
+          : vector<32x32xf16>, vector<32x32xf16>, vector<32x32xf32> -> vector<32x32xf32>
+        // update the offsets for A and B tiles
+        %a_next_tile = xetile.update_tile_offset %a_tile, [%c32, %c0]
+          : !xetile.tile<32x32xf16>, index, index -> !xetile.tile<32x32xf16>
+        %b_next_tile = xetile.update_tile_offset %b_tile, [%c32, %c0]
+          : !xetile.tile<32x32xf16>, index, index -> !xetile.tile<32x32xf16>
+        // partial C tile result
+        scf.yield %a_next_tile, %b_next_tile, %c_new_value
+          : !xetile.tile<32x32xf16>, !xetile.tile<32x32xf16>, vector<32x32xf32>
+      }
+      // store the final accumulated C tile result back to memory
+      xetile.store_tile %out#2, %c_init_tile: vector<32x32xf32>, !xetile.tile<32x32xf32>
+      gpu.return
+    }
+  }
+  func.func @main() attributes {llvm.emit_c_interface} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c1024 = arith.constant 1024 : index
+    %cf_0 = arith.constant 0.0 : f16
+    %cf_1 = arith.constant 1.0 : f16
+    %A = memref.alloc() : memref<1024x1024xf16>
+    %B = memref.alloc() : memref<1024x1024xf16>
+    %C = memref.alloc() : memref<1024x1024xf32>
+    %C_ref = memref.alloc() : memref<1024x1024xf32>
+    // intialize matrix A ; A[i, j] = j
+    scf.for %i = %c0 to %c1024 step %c1 {
+      scf.for %j = %c0 to %c1024 step %c1 {
+        %t = index.castu %j : index to i16
+        %val = arith.uitofp %t : i16 to f16
+        memref.store %val, %A[%i, %j] : memref<1024x1024xf16>
+      }
+    }
+    // make matrix B an identity matrix
+    scf.for %i = %c0 to %c1024 step %c1 {
+      scf.for %j = %c0 to %c1024 step %c1 {
+        %i_i32 = index.castu %i : index to i32
+        %j_i32 = index.castu %j : index to i32
+        %i_j_same = arith.cmpi eq, %i_i32, %j_i32 : i32
+
+        scf.if %i_j_same {
+          memref.store %cf_1, %B[%i, %j] : memref<1024x1024xf16>
+        } else {
+          memref.store %cf_0, %B[%i, %j] : memref<1024x1024xf16>
+        }
+      }
+    }
+    // intialize matrix C and C_ref ; C[i, j] = 0
+    %c0_f32 = arith.constant 0.0 : f32
+    scf.for %i = %c0 to %c1024 step %c1 {
+      scf.for %j = %c0 to %c1024 step %c1 {
+        memref.store %c0_f32, %C[%i, %j] : memref<1024x1024xf32>
+        memref.store %c0_f32, %C_ref[%i, %j] : memref<1024x1024xf32>
+      }
+    }
+    // compute C for reference
+    scf.for %i = %c0 to %c1024 step %c1 {
+      scf.for %j = %c0 to %c1024 step %c1 {
+        %c_curr = memref.load %C_ref[%i, %j] : memref<1024x1024xf32>
+        %c_val = scf.for %k = %c0 to %c1024 step %c1 iter_args(%c_partial = %c_curr) -> f32 {
+          %a_val = memref.load %A[%k, %i] : memref<1024x1024xf16>
+          %b_val = memref.load %B[%k, %j] : memref<1024x1024xf16>
+          %t = arith.mulf %a_val, %b_val : f16
+          %t_cast = arith.extf %t : f16 to f32
+          %c_sum = arith.addf %t_cast, %c_partial : f32
+          scf.yield %c_sum : f32
+        }
+        memref.store %c_val , %C_ref[%i, %j] : memref<1024x1024xf32>
+      }
+    }
+    %2 = call @test(%A, %B, %C) : (memref<1024x1024xf16>, memref<1024x1024xf16>, memref<1024x1024xf32>) -> memref<1024x1024xf32>
+    %cast_C = memref.cast %2 : memref<1024x1024xf32> to memref<*xf32>
+    %cast_C_ref = memref.cast %C_ref : memref<1024x1024xf32> to memref<*xf32>
+    // CHECK: [ALLCLOSE: TRUE]
+    call @printAllcloseF32(%cast_C, %cast_C_ref) : (memref<*xf32>, memref<*xf32>) -> ()
+    memref.dealloc %A : memref<1024x1024xf16>
+    memref.dealloc %B : memref<1024x1024xf16>
+    memref.dealloc %C : memref<1024x1024xf32>
+    memref.dealloc %C_ref : memref<1024x1024xf32>
+    return
+  }
+  func.func private @printMemrefF32(memref<*xf32>) attributes {llvm.emit_c_interface}
+  func.func private @printMemrefF16(memref<*xf16>) attributes {llvm.emit_c_interface}
+  func.func private @printAllcloseF32(memref<*xf32>, memref<*xf32>) attributes {llvm.emit_c_interface}
+}

--- a/test/Integration/Dialect/XeTile/sg_gemm_1kx1kx1k_f16_f16_f32_transpose_b.mlir
+++ b/test/Integration/Dialect/XeTile/sg_gemm_1kx1kx1k_f16_f16_f32_transpose_b.mlir
@@ -1,0 +1,155 @@
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xetile-to-func-vc.pp \
+// RUN:                                       --runner imex-cpu-runner -e main \
+// RUN:                                       --entry-point-result=void \
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
+// RUN: %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xetile-to-func-vc.pp \
+// RUN:                                        --runner imex-cpu-runner -e main \
+// RUN:                                        --entry-point-result=void \
+// RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck
+
+// NOTES :
+// This example assumes one subgroup per one workgroup and the kernel specifies the computation
+// done by a single subgroup.
+
+module @gemm attributes {gpu.container_module} {
+  func.func @test(%A: memref<1024x1024xf16>, %B: memref<1024x1024xf16>, %C: memref<1024x1024xf32>) -> memref<1024x1024xf32> attributes {llvm.emit_c_interface} {
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %c8 = arith.constant 8 : index
+    %c16 = arith.constant 16 : index
+    %c32 = arith.constant 32 : index
+    %c64 = arith.constant 64 : index
+    %c128 = arith.constant 128 : index
+    %c512 = arith.constant 512 : index
+    %A_gpu = gpu.alloc  host_shared () : memref<1024x1024xf16>
+    memref.copy %A, %A_gpu : memref<1024x1024xf16> to memref<1024x1024xf16>
+    %B_gpu = gpu.alloc  host_shared () : memref<1024x1024xf16>
+    memref.copy %B, %B_gpu : memref<1024x1024xf16> to memref<1024x1024xf16>
+    %C_gpu = gpu.alloc  host_shared () : memref<1024x1024xf32>
+    memref.copy %C, %C_gpu : memref<1024x1024xf32> to memref<1024x1024xf32>
+    gpu.launch_func  @test_kernel::@test_kernel blocks in (%c64, %c32, %c1) threads in (%c1, %c1, %c1) args(%A_gpu : memref<1024x1024xf16>, %B_gpu : memref<1024x1024xf16>, %C_gpu : memref<1024x1024xf32>)
+    gpu.dealloc  %A_gpu : memref<1024x1024xf16>
+    gpu.dealloc  %B_gpu : memref<1024x1024xf16>
+    return %C_gpu : memref<1024x1024xf32>
+  }
+  gpu.module @test_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
+    gpu.func @test_kernel(%A: memref<1024x1024xf16>, %B: memref<1024x1024xf16>, %C: memref<1024x1024xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c8 = arith.constant 8 : index
+      %c16 = arith.constant 16 : index
+      %c32 = arith.constant 32 : index
+      %c1024 = arith.constant 1024 : index
+      %block_id_x = gpu.block_id x
+      %block_id_y = gpu.block_id y
+      %m = arith.muli %block_id_x, %c16 : index
+      %n = arith.muli %block_id_y, %c32 : index
+      // intialize C tile and load it
+      %c_init_tile = xetile.init_tile %C[%m, %n] : memref<1024x1024xf32> -> !xetile.tile<16x32xf32>
+      %c_init_value = xetile.load_tile %c_init_tile  : !xetile.tile<16x32xf32> -> vector<16x32xf32>
+      // initalize A and B tiles
+      %a_init_tile = xetile.init_tile %A[%m, %c0] : memref<1024x1024xf16> -> !xetile.tile<16x32xf16>
+      %b_init_tile = xetile.init_tile %B[%c0, %n] : memref<1024x1024xf16> -> !xetile.tile<32x32xf16>
+      // compute the value of C tile by iterating over tiles in k-dimension and doing dpas
+      %out:3 = scf.for %k = %c0 to %c1024 step %c32
+        iter_args(%a_tile = %a_init_tile, %b_tile = %b_init_tile, %c_value = %c_init_value)
+        -> (!xetile.tile<16x32xf16>, !xetile.tile<32x32xf16>, vector<16x32xf32>) {
+
+        // load A and B tiles
+        %a_value = xetile.load_tile %a_tile  : !xetile.tile<16x32xf16> -> vector<16x32xf16>
+        %b_value = xetile.load_tile %b_tile  : !xetile.tile<32x32xf16> -> vector<32x32xf16>
+        %b_trans = vector.transpose %b_value, [1, 0] : vector<32x32xf16> to vector<32x32xf16>
+        // perform dpas and accumulate
+        %c_new_value = xetile.tile_mma %a_value, %b_trans, %c_value
+          : vector<16x32xf16>, vector<32x32xf16>, vector<16x32xf32> -> vector<16x32xf32>
+        // update the offsets for A and B tiles
+        %a_next_tile = xetile.update_tile_offset %a_tile, [%c0, %c32]
+          : !xetile.tile<16x32xf16>, index, index -> !xetile.tile<16x32xf16>
+        %b_next_tile = xetile.update_tile_offset %b_tile, [%c32, %c0]
+          : !xetile.tile<32x32xf16>, index, index -> !xetile.tile<32x32xf16>
+        // partial C tile result
+        scf.yield %a_next_tile, %b_next_tile, %c_new_value
+          : !xetile.tile<16x32xf16>, !xetile.tile<32x32xf16>, vector<16x32xf32>
+      }
+      // store the final accumulated C tile result back to memory
+      xetile.store_tile %out#2, %c_init_tile: vector<16x32xf32>, !xetile.tile<16x32xf32>
+      gpu.return
+    }
+  }
+  func.func @main() attributes {llvm.emit_c_interface} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c1024 = arith.constant 1024 : index
+    %cf_0 = arith.constant 0.0 : f16
+    %cf_1 = arith.constant 1.0 : f16
+    %A = memref.alloc() : memref<1024x1024xf16>
+    %B = memref.alloc() : memref<1024x1024xf16>
+    %C = memref.alloc() : memref<1024x1024xf32>
+    %C_ref = memref.alloc() : memref<1024x1024xf32>
+    // intialize matrix A ; A[i, j] = j
+    scf.for %i = %c0 to %c1024 step %c1 {
+      scf.for %j = %c0 to %c1024 step %c1 {
+        %t = index.castu %j : index to i16
+        %val = arith.uitofp %t : i16 to f16
+        memref.store %val, %A[%i, %j] : memref<1024x1024xf16>
+      }
+    }
+    // make matrix B an identity matrix
+    scf.for %i = %c0 to %c1024 step %c1 {
+      scf.for %j = %c0 to %c1024 step %c1 {
+        %i_i32 = index.castu %i : index to i32
+        %j_i32 = index.castu %j : index to i32
+        %i_j_same = arith.cmpi eq, %i_i32, %j_i32 : i32
+
+        scf.if %i_j_same {
+          memref.store %cf_1, %B[%i, %j] : memref<1024x1024xf16>
+        } else {
+          memref.store %cf_0, %B[%i, %j] : memref<1024x1024xf16>
+        }
+      }
+    }
+    // intialize matrix C and C_ref ; C[i, j] = 0
+    %c0_f32 = arith.constant 0.0 : f32
+    scf.for %i = %c0 to %c1024 step %c1 {
+      scf.for %j = %c0 to %c1024 step %c1 {
+        memref.store %c0_f32, %C[%i, %j] : memref<1024x1024xf32>
+        memref.store %c0_f32, %C_ref[%i, %j] : memref<1024x1024xf32>
+      }
+    }
+    // compute C for reference
+    scf.for %i = %c0 to %c1024 step %c1 {
+      scf.for %j = %c0 to %c1024 step %c1 {
+        %c_curr = memref.load %C_ref[%i, %j] : memref<1024x1024xf32>
+        %c_val = scf.for %k = %c0 to %c1024 step %c1 iter_args(%c_partial = %c_curr) -> f32 {
+          %a_val = memref.load %A[%i, %k] : memref<1024x1024xf16>
+          %b_val = memref.load %B[%k, %j] : memref<1024x1024xf16>
+          %t = arith.mulf %a_val, %b_val : f16
+          %t_cast = arith.extf %t : f16 to f32
+          %c_sum = arith.addf %t_cast, %c_partial : f32
+          scf.yield %c_sum : f32
+        }
+        memref.store %c_val , %C_ref[%i, %j] : memref<1024x1024xf32>
+      }
+    }
+    %2 = call @test(%A, %B, %C) : (memref<1024x1024xf16>, memref<1024x1024xf16>, memref<1024x1024xf32>) -> memref<1024x1024xf32>
+    // %cast = memref.cast %B : memref<1024x1024xf16> to memref<*xf16>
+    // call @printMemrefF16(%cast) : (memref<*xf16>) -> ()
+    %cast_C = memref.cast %2 : memref<1024x1024xf32> to memref<*xf32>
+    %cast_C_ref = memref.cast %C_ref : memref<1024x1024xf32> to memref<*xf32>
+    // call @printMemrefF32(%cast_C) : (memref<*xf32>) -> ()
+    // call @printMemrefF32(%cast_C_ref) : (memref<*xf32>) -> ()
+    // %C_row_0 = memref.subview %2[0, 0][1, 1024][1, 1] : memref<1024x1024xf32> to memref<1x1024xf32>
+    // %C_row_0_cast = memref.cast %C_row_0 : memref<1x1024xf32> to memref<*xf32>
+    // call @printMemrefF32(%C_row_0_cast) : (memref<*xf32>) -> ()
+    // CHECK: [ALLCLOSE: TRUE]
+    call @printAllcloseF32(%cast_C, %cast_C_ref) : (memref<*xf32>, memref<*xf32>) -> ()
+    memref.dealloc %A : memref<1024x1024xf16>
+    memref.dealloc %B : memref<1024x1024xf16>
+    memref.dealloc %C : memref<1024x1024xf32>
+    memref.dealloc %C_ref : memref<1024x1024xf32>
+    return
+  }
+  func.func private @printMemrefF32(memref<*xf32>) attributes {llvm.emit_c_interface}
+  func.func private @printMemrefF16(memref<*xf16>) attributes {llvm.emit_c_interface}
+  func.func private @printAllcloseF32(memref<*xf32>, memref<*xf32>) attributes {llvm.emit_c_interface}
+}

--- a/test/Integration/Dialect/XeTile/transpose_1kx1kx1k_f16_f16_f16.mlir
+++ b/test/Integration/Dialect/XeTile/transpose_1kx1kx1k_f16_f16_f16.mlir
@@ -1,0 +1,84 @@
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xetile-to-func-vc.pp \
+// RUN:                                       --runner imex-cpu-runner -e main \
+// RUN:                                       --entry-point-result=void \
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
+// RUN: %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xetile-to-func-vc.pp \
+// RUN:                                        --runner imex-cpu-runner -e main \
+// RUN:                                        --entry-point-result=void \
+// RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck
+
+// NOTES :
+// This example assumes one subgroup per one workgroup and the kernel specifies the computation
+// done by a single subgroup.
+
+module @transpose attributes {gpu.container_module} {
+  func.func @transpose_test(%A: memref<1024x1024xf16>) -> memref<1024x1024xf16> attributes {llvm.emit_c_interface} {
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %c8 = arith.constant 8 : index
+    %c16 = arith.constant 16 : index
+    %c32 = arith.constant 32 : index
+    %c64 = arith.constant 64 : index
+    %c128 = arith.constant 128 : index
+    %c512 = arith.constant 512 : index
+    %A_gpu = gpu.alloc  host_shared () : memref<1024x1024xf16>
+    memref.copy %A, %A_gpu : memref<1024x1024xf16> to memref<1024x1024xf16>
+    %B_gpu = gpu.alloc  host_shared () : memref<1024x1024xf16>
+    gpu.launch_func  @transpose_kernel::@transpose_kernel blocks in (%c64, %c32, %c1) threads in (%c1, %c1, %c1) args(%A_gpu : memref<1024x1024xf16>, %B_gpu : memref<1024x1024xf16>)
+    gpu.dealloc  %A_gpu : memref<1024x1024xf16>
+    return %B_gpu : memref<1024x1024xf16>
+  }
+  gpu.module @transpose_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
+    gpu.func @transpose_kernel(%A: memref<1024x1024xf16>, %B: memref<1024x1024xf16>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c8 = arith.constant 8 : index
+      %c16 = arith.constant 16 : index
+      %c32 = arith.constant 32 : index
+      %c1024 = arith.constant 1024 : index
+      %block_id_x = gpu.block_id x
+      %block_id_y = gpu.block_id y
+      %m = arith.muli %block_id_x, %c16 : index
+      %n = arith.muli %block_id_y, %c32 : index
+      // initalize A and B tiles
+      %a_tile = xetile.init_tile %A[%m, %n] : memref<1024x1024xf16> -> !xetile.tile<16x32xf16>
+      %a_value = xetile.load_tile %a_tile  : !xetile.tile<16x32xf16> -> vector<16x32xf16>
+      %b_value = vector.transpose %a_value, [1, 0] : vector<16x32xf16> to vector<32x16xf16>
+
+      %b_tile = xetile.init_tile %B[%n, %m] : memref<1024x1024xf16> -> !xetile.tile<32x16xf16>
+      xetile.store_tile %b_value, %b_tile: vector<32x16xf16>, !xetile.tile<32x16xf16>
+      gpu.return
+    }
+  }
+  func.func @main() attributes {llvm.emit_c_interface} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c1024 = arith.constant 1024 : index
+    %cf_0 = arith.constant 0.0 : f16
+    %cf_1 = arith.constant 1.0 : f16
+    %A = memref.alloc() : memref<1024x1024xf16>
+    %B_ref = memref.alloc() : memref<1024x1024xf32>
+    // intialize matrix A; A[i, j] = j; B[i, j] = i
+    scf.for %i = %c0 to %c1024 step %c1 {
+      scf.for %j = %c0 to %c1024 step %c1 {
+        %t = index.castu %j : index to i16
+        %val = arith.uitofp %t : i16 to f16
+        memref.store %val, %A[%i, %j] : memref<1024x1024xf16>
+        %val_f32 = arith.extf %val : f16 to f32
+        memref.store %val_f32, %B_ref[%j, %i] : memref<1024x1024xf32>
+      }
+    }
+
+    %2 = call @transpose_test(%A) : (memref<1024x1024xf16>) -> memref<1024x1024xf16>
+    %cast_B = memref.cast %2 : memref<1024x1024xf16> to memref<*xf16>
+    %cast_B_ref = memref.cast %B_ref : memref<1024x1024xf32> to memref<*xf32>
+    // CHECK: [ALLCLOSE: TRUE]
+    call @printAllcloseF16(%cast_B, %cast_B_ref) : (memref<*xf16>, memref<*xf32>) -> ()
+    memref.dealloc %A : memref<1024x1024xf16>
+    memref.dealloc %B_ref : memref<1024x1024xf32>
+    return
+  }
+  func.func private @printMemrefF32(memref<*xf32>) attributes {llvm.emit_c_interface}
+  func.func private @printMemrefF16(memref<*xf16>) attributes {llvm.emit_c_interface}
+  func.func private @printAllcloseF16(memref<*xf16>, memref<*xf32>) attributes {llvm.emit_c_interface}
+}


### PR DESCRIPTION
- reused the existing code for vector.transpose for xetile.transpose.
- added end-to-end test case for transpose ops. 
