### PR TITLE
XeGPU scattered tensor loads/stores

### DIFF
--- a/lib/Conversion/GPUToSPIRV/GPUToSPIRVPass.cpp
+++ b/lib/Conversion/GPUToSPIRV/GPUToSPIRVPass.cpp
@@ -349,6 +349,8 @@ void GPUXToSPIRVPass::runOnOperation() {
     //------- Upstream Conversion------------
     mlir::populateGPUToSPIRVPatterns(typeConverter, patterns);
     mlir::arith::populateArithToSPIRVPatterns(typeConverter, patterns);
+    mlir::populateBuiltinFuncToSPIRVPatterns(typeConverter, patterns);
+    mlir::populateVectorToSPIRVPatterns(typeConverter, patterns);
     mlir::populateMathToSPIRVPatterns(typeConverter, patterns);
     mlir::populateMemRefToSPIRVPatterns(typeConverter, patterns);
     mlir::populateFuncToSPIRVPatterns(typeConverter, patterns);

--- a/lib/Utils/XeCommon.cpp
+++ b/lib/Utils/XeCommon.cpp
@@ -76,6 +76,9 @@ encodeVectorType(mlir::ConversionPatternRewriter &rewriter,
   }
   std::string str;
   switch (size) {
+  case 4:
+    str += "v4";
+    break;
   case 8:
     str += "v8";
     break;
@@ -104,7 +107,7 @@ encodeVectorType(mlir::ConversionPatternRewriter &rewriter,
   if (use64bitData) {
     str += "i64";
     elemType = rewriter.getI64Type();
-  } else if (enforceInteger) {
+  } else if (enforceInteger || elemType == rewriter.getI32Type()) {
     str += "i32";
     elemType = rewriter.getI32Type();
   } else if (elemType == rewriter.getF32Type())

--- a/test/Conversion/XeGPUToVC/atomiclsc.mlir
+++ b/test/Conversion/XeGPUToVC/atomiclsc.mlir
@@ -2,37 +2,32 @@
 module @gemm attributes {gpu.container_module} {
 
   gpu.module @test_kernel {
-    // CHECK: func.func private @llvm.genx.lsc.xatomic.stateless.v16i32.v16i1.v16i64(vector<16xi1>, i8, i8, i8, i16, i32, i8, i8, i8, i8, vector<16xi64>, vector<16xi32>, vector<16xi32>, i32, vector<16xi32>) -> vector<16xi32> attributes {VectorComputeFunctionINTEL, linkage_attributes = #spirv.linkage_attributes<linkage_name = "llvm.genx.lsc.xatomic.stateless.v16i32.v16i1.v16i64", linkage_type = <Import>>}
+    // CHECK:    func.func private @llvm.genx.lsc.xatomic.stateless.v16i32.v16i1.v16i64(vector<16xi1>, i8, i8, i8, i16, i32, i8, i8, i8, vector<16xi1>, vector<16xindex>, vector<16xi32>, vector<16xi32>, i32, vector<16xi32>) -> vector<16xi32> attributes {VectorComputeFunctionINTEL, linkage_attributes = #spirv.linkage_attributes<linkage_name = "llvm.genx.lsc.xatomic.stateless.v16i32.v16i1.v16i64", linkage_type = <Import>>}
+
 
     gpu.func @test_atomiclsc(%arg0: memref<128xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
       // CHECK:  %[[cst:.*]] = arith.constant dense<true> : vector<16xi1>
       %mask = arith.constant dense<true> : vector<16xi1>
 
-      // CHECK: %[[cst_0:.*]] = arith.constant dense<[0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60]> : vector<16xindex>
-      // CHECK: %[[OFFSETS:.*]] = builtin.unrealized_conversion_cast %[[cst_0]] : vector<16xindex> to vector<16xi64>
+      // CHECK: %[[OFFSETS:.*]] = arith.constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]> : vector<16xindex>
+      %offsets = arith.constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]> : vector<16xindex>
 
-      %offsets = arith.constant dense<[0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60]> : vector<16xindex>
-
-      // CHECK: %[[cst_1:.*]] = arith.constant dense<5.000000e-01> : vector<16xf32>
+      // CHECK: %[[cst_0:.*]] = arith.constant dense<5.000000e-01> : vector<16xf32>
       %1 = arith.constant dense<0.5> : vector<16xf32>
 
-      // CHECK: %[[STRUCT:.*]] = arith.constant dense<0> : vector<4xi64>
+      // CHECK: %[[PAYLOAD:.*]] = arith.constant dense<0> : vector<16xindex>
       // CHECK: %[[BASEPTR:.*]] = memref.extract_aligned_pointer_as_index %{{.*}} : memref<128xf32> -> index
-      // CHECK: %[[BASEADDR:.*]] = arith.index_castui %[[BASEPTR]] : index to i64
-      // CHECK: %[[PAYLOAD_v4i64:.*]] = vector.insert %[[BASEADDR]], %[[STRUCT]] [0] : i64 into vector<4xi64>
-      // CHECK: %[[PAYLOAD_v8i32:.*]] = vector.bitcast %[[PAYLOAD_v4i64]] : vector<4xi64> to vector<8xi32>
+      // CHECK: %[[VEC_BASEPTR_INSERTED:.*]] = vector.insert %[[BASEPTR]], %[[PAYLOAD]] [0] : index into vector<16xindex>
+      // CHECK: %[[VEC_BASEPTR_SHUFFLED:.*]] = vector.shuffle %[[VEC_BASEPTR_INSERTED]], %[[VEC_BASEPTR_INSERTED]] [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] : vector<16xindex>, vector<16xindex>
+      // CHECK: %[[ELEMENT_BYTEWIDTH:.*]] = arith.constant dense<4> : vector<16xindex>
+      // CHECK: %[[OFFSETS_ADJUSTED:.*]] = arith.muli %[[ELEMENT_BYTEWIDTH]], %[[OFFSETS]] : vector<16xindex>
+      // CHECK: %[[VEC_OFFSETS_APPLIED:.*]] = arith.addi %[[VEC_BASEPTR_SHUFFLED]], %[[OFFSETS_ADJUSTED]] : vector<16xindex>
       %2 = xegpu.create_tdesc %arg0, %offsets {chunk_size = 1} : memref<128xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true>>
 
       // CHECK: %[[cst_3:.*]] = arith.constant dense<true> : vector<16xi1>
-      // CHECK: %[[TD_v4i64:.*]] = vector.bitcast %[[PAYLOAD_v8i32]] : vector<8xi32> to vector<4xi64>
-      // CHECK: %[[BASE:.*]] = vector.extract %[[TD_v4i64]][0] : i64 from vector<4xi64>
-      // CHECK: %[[PAYLOAD:.*]] = arith.constant dense<0> : vector<16xi64>
-      // CHECK: %[[PAYLOAD0:.*]] = vector.insert %[[BASE]], %[[PAYLOAD]] [0] : i64 into vector<16xi64>
-      // CHECK: %[[SHUFFLE:.*]] = vector.shuffle %[[PAYLOAD0]], %[[PAYLOAD0]] [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] : vector<16xi64>, vector<16xi64>
-      // CHECK: %[[ADDOFFSETS:.*]] = arith.addi %[[SHUFFLE]], %[[OFFSETS]] : vector<16xi64>
       // CHECK: %[[cst_8:.*]] = arith.constant dense<0> : vector<16xi32>
-      // CHECK: %[[SRC0:.*]] = vector.bitcast %[[cst_1]] : vector<16xf32> to vector<16xi32>
-      // CHECK: %[[ATOMIC_RES:.*]] = func.call @llvm.genx.lsc.xatomic.stateless.v16i32.v16i1.v16i64({{.*}}) : ({{vector<16xi1>, i8, i8, i8, i16, i32, i8, i8, i8, i8, vector<16xi64>, vector<16xi32>, vector<16xi32>, i32, vector<16xi32>}}) -> vector<16xi32>
+      // CHECK: %[[SRC0:.*]] = vector.bitcast %[[cst_0]] : vector<16xf32> to vector<16xi32>
+      // CHECK: %[[ATOMIC_RES:.*]] = func.call @llvm.genx.lsc.xatomic.stateless.v16i32.v16i1.v16i64({{.*}}, %[[VEC_OFFSETS_APPLIED]], %[[SRC0]], %[[cst_8]], {{.*}}, %[[cst_8]]) : ({{.*}}) -> vector<16xi32>
       // CHECK: %{{.*}} = vector.bitcast %[[ATOMIC_RES]] : vector<16xi32> to vector<16xf32>
       %3 = xegpu.atomic_rmw "addf" %2, %mask, %1 : !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true>>, vector<16xi1>, vector<16xf32> -> vector<16xf32>
       gpu.return

--- a/test/Conversion/XeGPUToVC/loadgather.mlir
+++ b/test/Conversion/XeGPUToVC/loadgather.mlir
@@ -3,79 +3,43 @@
 // RUN: imex-opt -convert-xegpu-to-vc='enable-vc-intrinsic=true useRawSend=false'  %s | FileCheck %s
 module @gemm attributes {gpu.container_module} {
    gpu.module @module0 {
-   // CHECK: func.func private @llvm.genx.raw.sends2.noresult.i1.v8i32.v128f32(i8, i8, i1, i8, i8, i8, i32, i32, vector<16xi64>, vector<128xf32>) attributes {VectorComputeFunctionINTEL, linkage_attributes = #spirv.linkage_attributes<linkage_name = "llvm.genx.raw.sends2.noresult.i1.v8i32.v128f32", linkage_type = <Import>>}
-   // CHECK: func.func private @llvm.genx.dpas.nosrc0.v128f32.v128i32.v64i32(vector<128xi32>, vector<64xi32>, i32) -> vector<128xf32> attributes {VectorComputeFunctionINTEL, linkage_attributes = #spirv.linkage_attributes<linkage_name = "llvm.genx.dpas.nosrc0.v128f32.v128i32.v64i32", linkage_type = <Import>>}
-   // CHECK: func.func private @llvm.genx.raw.send2.v64i32.i1.v16i64(i8, i8, i1, i8, i8, i8, i32, i32, vector<16xi64>, vector<64xi32>) -> vector<64xi32> attributes {VectorComputeFunctionINTEL, linkage_attributes = #spirv.linkage_attributes<linkage_name = "llvm.genx.raw.send2.v64i32.i1.v16i64", linkage_type = <Import>>}
-  gpu.func @test_loadgather(%arg0: memref<128xf16>, %arg1: memref<16x16xf16>, %arg2: memref<128xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>}{
-      // CHECK: %[[cst:.*]] = arith.constant dense<[0, 16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240]> : vector<16xindex>
-      %offsets = arith.constant dense<[0, 16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240]> : vector<16xindex>
+    // CHECK: func.func private @llvm.genx.raw.sends2.noresult.v16i1.v16i64.v16i32(i8, i8, vector<16xi1>, i8, i8, i8, i32, i32, vector<16xindex>, vector<16xi32>) attributes {VectorComputeFunctionINTEL, linkage_attributes = #spirv.linkage_attributes<linkage_name = "llvm.genx.raw.sends2.noresult.v16i1.v16i64.v16i32", linkage_type = <Import>>}
+    // CHECK: func.func private @llvm.genx.raw.send2.v16i32.v16i1.v16i64(i8, i8, vector<16xi1>, i8, i8, i8, i32, i32, vector<16xindex>, vector<16xi32>) -> vector<16xi32> attributes {VectorComputeFunctionINTEL, linkage_attributes = #spirv.linkage_attributes<linkage_name = "llvm.genx.raw.send2.v16i32.v16i1.v16i64", linkage_type = <Import>>}
+    gpu.func @test_loadgather(%in: memref<?xf16>, %out: memref<16x2xf16>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>}{
+      %out_flat = memref.reinterpret_cast %out to offset: [0], sizes: [32], strides: [1] : memref<16x2xf16> to memref<32xf16>
+      // CHECK: %[[OFFSET:.*]] = arith.constant dense<[0, 4, 8, 12, 16, 20, 24, 28, 32, 34, 38, 42, 46, 50, 54, 58]> : vector<16xindex>
+      %offsets = arith.constant dense<[0,4,8,12,16,20,24,28,32,34,38,42,46,50,54,58]> : vector<16xindex>
+      // CHECK: %[[MASK:.*]] = arith.constant dense<[true, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false]> : vector<16xi1>
+      %mask = arith.constant dense<[1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0]> : vector<16xi1>
 
-      // CHECK: %[[A_STRUCT:.*]] = arith.constant dense<0> : vector<4xi64>
-      // CHECK: %[[A_BASEPTR:.*]] = memref.extract_aligned_pointer_as_index {{.*}} : memref<128xf16> -> index
-      // CHECK: %[[A_BASEADDR:.*]] = arith.index_castui %[[A_BASEPTR]] : index to i64
-      // CHECK: %[[A_PAYLOAD_v4i64:.*]] = vector.insert %[[A_BASEADDR]], %[[A_STRUCT]] [0] : i64 into vector<4xi64>
-      // CHECK: %[[A_PAYLOAD_v8i32:.*]] = vector.bitcast %[[A_PAYLOAD_v4i64]] : vector<4xi64> to vector<8xi32>
-       %0 = xegpu.create_tdesc %arg0, %offsets {chunk_size = 8} : memref<128xf16>, vector<16xindex> -> !xegpu.tensor_desc<16x8xf16, #xegpu.tdesc_attr<scattered = true>>
+      // CHECK: %[[IN_EMPTY_PAYLOAD:.*]] = arith.constant dense<0> : vector<16xindex>
+      // CHECK: %[[IN_BASEPTR:.*]] = memref.extract_aligned_pointer_as_index {{.*}} : memref<?xf16> -> index
+      // CHECK: %[[IN_PAYLOAD_BASEPTR:.*]] = vector.insert %[[IN_BASEPTR]], %[[IN_EMPTY_PAYLOAD]] [0] : index into vector<16xindex>
+      // CHECK: %[[IN_PAYLOAD_BASEPTR_SHUFFLED:.*]] = vector.shuffle %[[IN_PAYLOAD_BASEPTR]], %[[IN_PAYLOAD_BASEPTR]] [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] : vector<16xindex>, vector<16xindex>
+      // CHECK: %[[IN_ELEMENT_BYTEWIDTH:.*]] = arith.constant dense<2> : vector<16xindex>
+      // CHECK: %[[IN_ELEMENTWISE_OFFSET:.*]] = arith.muli %[[IN_ELEMENT_BYTEWIDTH]], %[[OFFSET]] : vector<16xindex>
+      // CHECK: %[[IN_PAYLOAD:.*]] = arith.addi %[[IN_PAYLOAD_BASEPTR_SHUFFLED]], %[[IN_ELEMENTWISE_OFFSET]] : vector<16xindex>
+      %tdesc_in = xegpu.create_tdesc %in, %offsets {chunk_size = 2} : memref<?xf16>, vector<16xindex> -> !xegpu.tensor_desc<16x2xf16, #xegpu.tdesc_attr<scattered = true>>
 
-       // CHECK: %[[cst_1:.*]] = arith.constant dense<true> : vector<128xi1>
-       %cst = arith.constant dense<true> : vector<128xi1>
+      // CHECK: %[[OUT_EMPTY_PAYLOAD:.*]] = arith.constant dense<0> : vector<16xindex>
+      // CHECK: %[[OUT_BASEPTR:.*]] = memref.extract_aligned_pointer_as_index {{.*}} : memref<32xf16> -> index
+      // CHECK: %[[OUT_PAYLOAD_BASEPTR:.*]] = vector.insert %[[OUT_BASEPTR]], %[[OUT_EMPTY_PAYLOAD]] [0] : index into vector<16xindex>
+      // CHECK: %[[OUT_PAYLOAD_BASEPTR_SHUFFLED:.*]] = vector.shuffle %[[OUT_PAYLOAD_BASEPTR]], %[[OUT_PAYLOAD_BASEPTR]] [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] : vector<16xindex>, vector<16xindex>
+      // CHECK: %[[OUT_ELEMENT_BYTEWIDTH:.*]] = arith.constant dense<2> : vector<16xindex>
+      // CHECK: %[[OUT_ELEMENTWISE_OFFSET:.*]] = arith.muli %[[OUT_ELEMENT_BYTEWIDTH]], %[[OFFSET]] : vector<16xindex>
+      // CHECK: %[[OUT_PAYLOAD:.*]] = arith.addi %[[OUT_PAYLOAD_BASEPTR_SHUFFLED]], %[[OUT_ELEMENTWISE_OFFSET]] : vector<16xindex>
+      %tdesc_out = xegpu.create_tdesc %out_flat, %offsets {chunk_size = 2} : memref<32xf16>, vector<16xindex> -> !xegpu.tensor_desc<16x2xf16, #xegpu.tdesc_attr<scattered = true>>
 
-       %mask = vector.shape_cast %cst : vector<128xi1> to vector<16x8xi1>
+      // CHECK: %[[OLD:.*]] =  arith.constant dense<0> : vector<16xi32>
+      // CHECK: %[[LOAD_RES:.*]] = func.call @llvm.genx.raw.send2.v16i32.v16i1.v16i64({{.*}}, %[[MASK]], {{.*}}, %[[IN_PAYLOAD]], %[[OLD]]) : (i8, i8, vector<16xi1>, i8, i8, i8, i32, i32, vector<16xindex>, vector<16xi32>) -> vector<16xi32>
+      %loaded = xegpu.load %tdesc_in, %mask : !xegpu.tensor_desc<16x2xf16, #xegpu.tdesc_attr<scattered = true>>, vector<16xi1> -> vector<16x2xf16>
+      // CHECK: %[[POST_OP_ELEMENT_TYPE_CAST:.*]] = vector.bitcast %[[LOAD_RES]] : vector<16xi32> to vector<32xf16>
 
-       // CHECK: %[[LOADA_v128i32:.*]] = func.call @llvm.genx.raw.send2.v64i32.i1.v16i64(%c0_i8, %c4_i8, %true, %c2_i8, %c4_i8_2, %c15_i8, %c0_i32, %c71447936_i32, %8, %cst_4) : (i8, i8, i1, i8, i8, i8, i32, i32, vector<16xi64>, vector<64xi32>) -> vector<64xi32>
-       %3 = xegpu.load %0, %mask : !xegpu.tensor_desc<16x8xf16, #xegpu.tdesc_attr<scattered = true>>, vector<16x8xi1> -> vector<16x8xf16>
+      // CHECK: %[[PRE_OP_ELEMENT_TYPE_CAST:.*]] = vector.bitcast %[[POST_OP_ELEMENT_TYPE_CAST]] : vector<32xf16> to vector<16xi32>
+      // CHECK: func.call @llvm.genx.raw.sends2.noresult.v16i1.v16i64.v16i32({{.*}}, %[[MASK]], {{.*}}, %[[OUT_PAYLOAD]], %[[PRE_OP_ELEMENT_TYPE_CAST]]) : (i8, i8, vector<16xi1>, i8, i8, i8, i32, i32, vector<16xindex>, vector<16xi32>) -> ()
+      xegpu.store %loaded, %tdesc_out, %mask : vector<16x2xf16>, !xegpu.tensor_desc<16x2xf16, #xegpu.tdesc_attr<scattered = true>>, vector<16xi1>
 
-       // CHECK: %[[LOADA_v128f16:.*]] = vector.bitcast %[[LOADA_v128i32]] : vector<64xi32> to vector<128xf16>
-       %66 = vector.shape_cast %3: vector<16x8xf16> to vector<128xf16>
-
-       %6 = vector.shape_cast %66: vector<128xf16> to vector<8x16xf16>
-
-      // CHECK: %[[B_STRUCT:.*]]= arith.constant dense<0> : vector<4xi64>
-      // CHECK: %[[B_BASEPTR:.*]] = memref.extract_aligned_pointer_as_index {{.*}} : memref<16x16xf16> -> index
-      // CHECK: %[[B_BASEADDR:.*]] = arith.index_castui %[[B_BASEPTR]] : index to i64
-      // CHECK: %[[B_PAYLOAD_v4i64:.*]] = vector.insert %[[B_BASEADDR]], %[[B_STRUCT]][0] : i64 into vector<4xi64>
-      // CHECK: %[[B_PAYLOAD_v8i32:.*]] = vector.bitcast %[[B_PAYLOAD_v4i64]] : vector<4xi64> to vector<8xi32>
-      // CHECK: %[[p2:.*]] = vector.insert %{{.*}}, %[[B_PAYLOAD_v8i32]] [2] : i32 into vector<8xi32>
-      // CHECK: %[[p3:.*]] = vector.insert %{{.*}}, %[[p2]] [3] : i32 into vector<8xi32>
-      // CHECK: %[[p4:.*]] = vector.insert %{{.*}}, %[[p3]] [4] : i32 into vector<8xi32>
-      // CHECK: %[[p5:.*]] = vector.insert %{{.*}}, %[[p4]] [5] : i32 into vector<8xi32>
-      // CHECK: %[[p6:.*]] = vector.insert %{{.*}}, %[[p5]] [6] : i32 into vector<8xi32>
-      // CHECK: %[[B_PAYLOAD:.*]] = vector.insert %{{.*}}, %[[p6]] [7] : i32 into vector<8xi32>
-       %1 = xegpu.create_nd_tdesc %arg1[0, 0] {boundary_check = true} : memref<16x16xf16> -> !xegpu.tensor_desc<16x16xf16>
-
-       %4 = xegpu.load_nd %1 {packed} : !xegpu.tensor_desc<16x16xf16> -> vector<8x16x2xf16>
-
-       // CHECK: %[[LOADA_v64i32:.*]] = vector.bitcast %[[LOADA_v128f16]] : vector<128xf16> to vector<64xi32>
-       // CHECK: %[[C_ACC_v128f32:.*]] = func.call @llvm.genx.dpas.nosrc0.v128f32.v128i32.v64i32(%{{.*}}, %[[LOADA_v64i32]], %{{.*}}) : (vector<128xi32>, vector<64xi32>, i32) -> vector<128xf32>
-       %5 = xegpu.dpas %6, %4 : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-
-       // CHECK: %[[cst_17:.*]] = arith.constant dense<[0, 32, 64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 416, 448, 480]> : vector<16xindex>
-       // CHECK: %[[C_OFFSETS:.*]] = builtin.unrealized_conversion_cast %[[cst_17]] : vector<16xindex> to vector<16xi64>
-
-       %offsets2 = arith.constant dense<[0, 32, 64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 416, 448, 480]> : vector<16xindex>
-
-      // CHECK: %[[C_STRUCT:.*]] = arith.constant dense<0> : vector<4xi64>
-      // CHECK: %[[C_BASEPTR:.*]] = memref.extract_aligned_pointer_as_index {{.*}} : memref<128xf32> -> index
-      // CHECK: %[[C_BASE:.*]] = arith.index_castui %[[C_BASEPTR]] : index to i64
-      // CHECK: %[[C_PAYLOAD:.*]] = vector.insert %[[C_BASE]], %[[C_STRUCT]] [0] : i64 into vector<4xi64>
-      // CHECK: %[[C_PAYLOAD_v8i32:.*]] = vector.bitcast %[[C_PAYLOAD]] : vector<4xi64> to vector<8xi32>
-       %2 = xegpu.create_tdesc %arg2, %offsets2 {chunk_size = 8} : memref<128xf32>, vector<16xindex> -> !xegpu.tensor_desc<16x8xf32, #xegpu.tdesc_attr<scattered = true>>
-       %7 = vector.shape_cast %5: vector<8x16xf32> to vector<128xf32>
-       %8 = vector.shape_cast %7: vector<128xf32> to vector<16x8xf32>
-
-       // CHECK: %[[C_PAYLOAD_v4i64:.*]] = vector.bitcast %[[C_PAYLOAD_v8i32]] : vector<8xi32> to vector<4xi64>
-       // CHECK: %[[C_ADDR:.*]] = vector.extract %[[C_PAYLOAD_v4i64]][0] : i64 from vector<4xi64>
-       // CHECK: %[[PAYLOAD_v16i64:.*]] = arith.constant dense<0> : vector<16xi64>
-       // CHECK: %[[P0:.*]] = vector.insert %[[C_ADDR]], %[[PAYLOAD_v16i64]] [0] : i64 into vector<16xi64>
-       // CHECK: %[[OFFSETS:.*]] = vector.shuffle %[[P0]], %[[P0]] [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] : vector<16xi64>, vector<16xi64>
-       // CHECK: %[[STORE_OFFSETS:.*]] = arith.addi %[[OFFSETS]], %[[C_OFFSETS]] : vector<16xi64>
-
-
-       // CHECK: func.call @llvm.genx.raw.sends2.noresult.i1.v8i32.v128f32({{.*}}, %[[STORE_OFFSETS]], %[[C_ACC_v128f32]]) : (i8, i8, i1, i8, i8, i8, i32, i32, vector<16xi64>, vector<128xf32>) -> ()
-       xegpu.store %8, %2, %mask : vector<16x8xf32>, !xegpu.tensor_desc<16x8xf32, #xegpu.tdesc_attr<scattered = true>>, vector<16x8xi1>
-
-
-       gpu.return
+      gpu.return
     }
-     }
+  }
 }

--- a/test/Conversion/XeGPUToVC/loadgather_dpas.mlir
+++ b/test/Conversion/XeGPUToVC/loadgather_dpas.mlir
@@ -1,0 +1,71 @@
+
+// RUN: imex-opt -convert-xegpu-to-vc='enable-vc-intrinsic=true useRawSend=true'  %s | FileCheck %s
+// RUN: imex-opt -convert-xegpu-to-vc='enable-vc-intrinsic=true useRawSend=false'  %s | FileCheck %s
+module @gemm attributes {gpu.container_module} {
+   gpu.module @module0 {
+    // CHECK: func.func private @llvm.genx.raw.sends2.noresult.v16i1.v16i64.v128f32(i8, i8, vector<16xi1>, i8, i8, i8, i32, i32, vector<16xindex>, vector<128xf32>) attributes {VectorComputeFunctionINTEL, linkage_attributes = #spirv.linkage_attributes<linkage_name = "llvm.genx.raw.sends2.noresult.v16i1.v16i64.v128f32", linkage_type = <Import>>}
+    // CHECK: func.func private @llvm.genx.dpas.nosrc0.v128f32.v128i32.v64i32(vector<128xi32>, vector<64xi32>, i32) -> vector<128xf32> attributes {VectorComputeFunctionINTEL, linkage_attributes = #spirv.linkage_attributes<linkage_name = "llvm.genx.dpas.nosrc0.v128f32.v128i32.v64i32", linkage_type = <Import>>}
+    // CHECK: func.func private @llvm.genx.raw.send2.v64i32.v16i1.v16i64(i8, i8, vector<16xi1>, i8, i8, i8, i32, i32, vector<16xindex>, vector<64xi32>) -> vector<64xi32> attributes {VectorComputeFunctionINTEL, linkage_attributes = #spirv.linkage_attributes<linkage_name = "llvm.genx.raw.send2.v64i32.v16i1.v16i64", linkage_type = <Import>>}
+    gpu.func @test_loadgather(%arg0: memref<128xf16>, %arg1: memref<16x16xf16>, %arg2: memref<128xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>}{
+         // CHECK: %[[IN_OFFSET:.*]] = arith.constant dense<[0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120]> : vector<16xindex>
+         %offsets = arith.constant dense<[0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120]> : vector<16xindex>
+         // CHECK: %[[MASK:.*]] = arith.constant dense<true> : vector<16xi1>
+         %mask = arith.constant dense<true> : vector<16xi1>
+
+         // CHECK: %[[IN_EMPTY_PAYLOAD:.*]] = arith.constant dense<0> : vector<16xindex>
+         // CHECK: %[[IN_BASEPTR:.*]] = memref.extract_aligned_pointer_as_index {{.*}} : memref<128xf16> -> index
+         // CHECK: %[[IN_PAYLOAD_BASEPTR:.*]] = vector.insert %[[IN_BASEPTR]], %[[IN_EMPTY_PAYLOAD]] [0] : index into vector<16xindex>
+         // CHECK: %[[IN_PAYLOAD_BASEPTR_SHUFFLED:.*]] = vector.shuffle %[[IN_PAYLOAD_BASEPTR]], %[[IN_PAYLOAD_BASEPTR]] [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] : vector<16xindex>, vector<16xindex>
+         // CHECK: %[[IN_ELEMENT_BYTEWIDTH:.*]] = arith.constant dense<2> : vector<16xindex>
+         // CHECK: %[[IN_ELEMENTWISE_OFFSET:.*]] = arith.muli %[[IN_ELEMENT_BYTEWIDTH]], %[[IN_OFFSET]] : vector<16xindex>
+         // CHECK: %[[IN_PAYLOAD:.*]] = arith.addi %[[IN_PAYLOAD_BASEPTR_SHUFFLED]], %[[IN_ELEMENTWISE_OFFSET]] : vector<16xindex>
+         %0 = xegpu.create_tdesc %arg0, %offsets {chunk_size = 8} : memref<128xf16>, vector<16xindex> -> !xegpu.tensor_desc<16x8xf16, #xegpu.tdesc_attr<scattered = true>>
+
+         // CHECK: %[[OLD:.*]] =  arith.constant dense<0> : vector<64xi32>
+         // CHECK: %[[LOAD_RES:.*]] = func.call @llvm.genx.raw.send2.v64i32.v16i1.v16i64({{.*}}, %[[MASK]], {{.*}}, %[[IN_PAYLOAD]], %[[OLD]]) : (i8, i8, vector<16xi1>, i8, i8, i8, i32, i32, vector<16xindex>, vector<64xi32>) -> vector<64xi32>
+         %3 = xegpu.load %0, %mask : !xegpu.tensor_desc<16x8xf16, #xegpu.tdesc_attr<scattered = true>>, vector<16xi1> -> vector<16x8xf16>
+
+         // CHECK: %[[LOADA_v128f16:.*]] = vector.bitcast %[[LOAD_RES]] : vector<64xi32> to vector<128xf16>
+         %66 = vector.shape_cast %3: vector<16x8xf16> to vector<128xf16>
+         %6 = vector.shape_cast %66: vector<128xf16> to vector<8x16xf16>
+
+         // CHECK: %[[B_STRUCT:.*]]= arith.constant dense<0> : vector<4xi64>
+         // CHECK: %[[B_BASEPTR:.*]] = memref.extract_aligned_pointer_as_index {{.*}} : memref<16x16xf16> -> index
+         // CHECK: %[[B_BASEADDR:.*]] = arith.index_castui %[[B_BASEPTR]] : index to i64
+         // CHECK: %[[B_PAYLOAD_v4i64:.*]] = vector.insert %[[B_BASEADDR]], %[[B_STRUCT]][0] : i64 into vector<4xi64>
+         // CHECK: %[[B_PAYLOAD_v8i32:.*]] = vector.bitcast %[[B_PAYLOAD_v4i64]] : vector<4xi64> to vector<8xi32>
+         // CHECK: %[[p2:.*]] = vector.insert %{{.*}}, %[[B_PAYLOAD_v8i32]] [2] : i32 into vector<8xi32>
+         // CHECK: %[[p3:.*]] = vector.insert %{{.*}}, %[[p2]] [3] : i32 into vector<8xi32>
+         // CHECK: %[[p4:.*]] = vector.insert %{{.*}}, %[[p3]] [4] : i32 into vector<8xi32>
+         // CHECK: %[[p5:.*]] = vector.insert %{{.*}}, %[[p4]] [5] : i32 into vector<8xi32>
+         // CHECK: %[[p6:.*]] = vector.insert %{{.*}}, %[[p5]] [6] : i32 into vector<8xi32>
+         // CHECK: %[[B_PAYLOAD:.*]] = vector.insert %{{.*}}, %[[p6]] [7] : i32 into vector<8xi32>
+         %1 = xegpu.create_nd_tdesc %arg1[0, 0] {boundary_check = true} : memref<16x16xf16> -> !xegpu.tensor_desc<16x16xf16>
+
+         %4 = xegpu.load_nd %1 {packed} : !xegpu.tensor_desc<16x16xf16> -> vector<8x16x2xf16>
+
+         // CHECK: %[[LOADA_v64i32:.*]] = vector.bitcast %[[LOADA_v128f16]] : vector<128xf16> to vector<64xi32>
+         // CHECK: %[[C_ACC_v128f32:.*]] = func.call @llvm.genx.dpas.nosrc0.v128f32.v128i32.v64i32(%{{.*}}, %[[LOADA_v64i32]], %{{.*}}) : (vector<128xi32>, vector<64xi32>, i32) -> vector<128xf32>
+         %5 = xegpu.dpas %6, %4 : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
+
+         // CHECK: %[[OUT_OFFSET:.*]] = arith.constant dense<[0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120]> : vector<16xindex>
+         %offsets2 = arith.constant dense<[0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120]> : vector<16xindex>
+
+         // CHECK: %[[OUT_EMPTY_PAYLOAD:.*]] = arith.constant dense<0> : vector<16xindex>
+         // CHECK: %[[OUT_BASEPTR:.*]] = memref.extract_aligned_pointer_as_index {{.*}} : memref<128xf32> -> index
+         // CHECK: %[[OUT_PAYLOAD_BASEPTR:.*]] = vector.insert %[[OUT_BASEPTR]], %[[OUT_EMPTY_PAYLOAD]] [0] : index into vector<16xindex>
+         // CHECK: %[[OUT_PAYLOAD_BASEPTR_SHUFFLED:.*]] = vector.shuffle %[[OUT_PAYLOAD_BASEPTR]], %[[OUT_PAYLOAD_BASEPTR]] [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] : vector<16xindex>, vector<16xindex>
+         // CHECK: %[[OUT_ELEMENT_BYTEWIDTH:.*]] = arith.constant dense<4> : vector<16xindex>
+         // CHECK: %[[OUT_ELEMENTWISE_OFFSET:.*]] = arith.muli %[[OUT_ELEMENT_BYTEWIDTH]], %[[OUT_OFFSET]] : vector<16xindex>
+         // CHECK: %[[OUT_PAYLOAD:.*]] = arith.addi %[[OUT_PAYLOAD_BASEPTR_SHUFFLED]], %[[OUT_ELEMENTWISE_OFFSET]] : vector<16xindex>
+         %2 = xegpu.create_tdesc %arg2, %offsets2 {chunk_size = 8} : memref<128xf32>, vector<16xindex> -> !xegpu.tensor_desc<16x8xf32, #xegpu.tdesc_attr<scattered = true>>
+         %7 = vector.shape_cast %5: vector<8x16xf32> to vector<128xf32>
+         %8 = vector.shape_cast %7: vector<128xf32> to vector<16x8xf32>
+
+         // CHECK: func.call @llvm.genx.raw.sends2.noresult.v16i1.v16i64.v128f32({{.*}}, %[[MASK]], {{.*}}, %[[OUT_PAYLOAD]], %[[C_ACC_v128f32]]) : (i8, i8, vector<16xi1>, i8, i8, i8, i32, i32, vector<16xindex>, vector<128xf32>) -> ()
+         xegpu.store %8, %2, %mask : vector<16x8xf32>, !xegpu.tensor_desc<16x8xf32, #xegpu.tdesc_attr<scattered = true>>, vector<16xi1>
+
+         gpu.return
+      }
+   }
+}

--- a/test/Integration/Dialect/XeGPU/loadgather2d_masked_f32.mlir
+++ b/test/Integration/Dialect/XeGPU/loadgather2d_masked_f32.mlir
@@ -1,0 +1,83 @@
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                       --runner imex-cpu-runner -e main \
+// RUN:                                       --entry-point-result=void \
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
+// RUN: %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                        --runner imex-cpu-runner -e main \
+// RUN:                                        --entry-point-result=void \
+// RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck
+module @gemm attributes {gpu.container_module} {
+  memref.global "private" constant @__constant_1_3x16xf32 : memref<3x16xf32> = dense<1.0>
+  memref.global "private" constant @__constant_3_3x16xf32 : memref<3x16xf32> = dense<3.0>
+
+  func.func @test(%arg0: memref<3x16xf32>, %arg1: memref<3x16xf32>) -> memref<3x16xf32> attributes {llvm.emit_c_interface} {
+    %c1 = arith.constant 1 : index
+    %memref = gpu.alloc  host_shared () : memref<3x16xf32>
+    memref.copy %arg0, %memref : memref<3x16xf32> to memref<3x16xf32>
+    %memref1 = gpu.alloc  host_shared () : memref<3x16xf32>
+    memref.copy %arg1, %memref1 : memref<3x16xf32> to memref<3x16xf32>
+
+    // Spirv has no lowering for memref.subview
+    %in = memref.reinterpret_cast %memref to offset: [0], sizes: [48], strides: [1] : memref<3x16xf32> to memref<48xf32>
+    %out = memref.reinterpret_cast %memref1 to offset: [0], sizes: [48], strides: [1] : memref<3x16xf32> to memref<48xf32>
+
+    %memref_dyn = memref.cast %in : memref<48xf32> to memref<?xf32>
+    %memref1_dyn = memref.cast %out : memref<48xf32> to memref<?xf32>
+
+    gpu.launch_func  @test_kernel::@test_scattered blocks in (%c1, %c1, %c1) threads in (%c1, %c1, %c1) args(%memref_dyn : memref<?xf32>, %memref1_dyn : memref<?xf32>)
+    gpu.dealloc  %memref : memref<3x16xf32>
+    return %memref1 : memref<3x16xf32>
+  }
+
+  gpu.module @test_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
+    gpu.func @test_scattered(%arg0: memref<?xf32>, %arg1: memref<?xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      // This test emulates 2D load with user defined padding
+      // We load rows with %row_mask that has 0's to not cross the boundary.
+      // We pad the values that were not loaded (as per %row_mask) with %user_val.
+      // We store full (padded) rows with %store_mask.
+      %c0 = arith.constant 0 : index
+      %store_mask = arith.constant dense<[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]> : vector<16xi1>
+      %user_val = arith.constant dense<22.33> : vector<16xf32>
+      %row_mask = arith.constant dense<[1,1,1,1,1,1,1,1,1,1,1,1,1,0,0,0]> : vector<16xi1>
+      %offset_step = arith.constant dense<16>: vector<16xindex>
+
+      // Spirv has no lowering for memref.reinterpret_cast with different sizes (doesn't work: memref<3x16xf32> to memref<16xf32>)
+      // Each row has a tdesc with offsets that determine linearized memref's values to be loaded
+      %offsets_row1 = arith.constant dense<[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]> : vector<16xindex>
+      %row_1_in_td = xegpu.create_tdesc %arg0, %offsets_row1 : memref<?xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true>>
+      %row_1_out_td = xegpu.create_tdesc %arg1, %offsets_row1 : memref<?xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true>>
+      %row_1_loaded = xegpu.load %row_1_in_td, %row_mask : !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true>>, vector<16xi1> -> vector<16xf32>
+      %row_1_store = arith.select %row_mask, %row_1_loaded, %user_val : vector<16xi1>, vector<16xf32>
+      xegpu.store %row_1_store, %row_1_out_td, %store_mask : vector<16xf32>, !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true>>, vector<16xi1>
+
+      %row_2_in_td = xegpu.update_offset %row_1_in_td, %offset_step : !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true>>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true>>
+      %row_2_out_td = xegpu.update_offset %row_1_out_td, %offset_step : !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true>>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true>>
+      %row_2_loaded = xegpu.load %row_2_in_td, %row_mask : !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true>>, vector<16xi1> -> vector<16xf32>
+      %row_2_store = arith.select %row_mask, %row_2_loaded, %user_val : vector<16xi1>, vector<16xf32>
+      xegpu.store %row_2_store, %row_2_out_td, %store_mask : vector<16xf32>, !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true>>, vector<16xi1>
+
+      // The entire row is out of bounds
+      %row_3_out_td = xegpu.update_offset %row_2_out_td, %offset_step : !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true>>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true>>
+      xegpu.store %user_val, %row_3_out_td, %store_mask : vector<16xf32>, !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true>>, vector<16xi1>
+      gpu.return
+    }
+  }
+
+  func.func @main() attributes {llvm.emit_c_interface} {
+    %0 = memref.get_global @__constant_1_3x16xf32 : memref<3x16xf32>
+    %1 = memref.get_global @__constant_3_3x16xf32 : memref<3x16xf32>
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+
+    %2 = call @test(%0, %1) : (memref<3x16xf32>, memref<3x16xf32>) -> memref<3x16xf32>
+    %cast = memref.cast %2 : memref<3x16xf32> to memref<*xf32>
+    // CHECK: Unranked Memref base@ = 0x{{.*}} rank = 2 offset = 0 sizes = [3, 16] strides = [16, 1] data =
+    // CHECK-NEXT: [1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   22.33,   22.33,   22.33],
+    // CHECK-NEXT: [1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   22.33,   22.33,   22.33],
+    // CHECK-NEXT: [22.33,   22.33,   22.33,   22.33,   22.33,   22.33,   22.33,   22.33,   22.33,   22.33,   22.33,   22.33,   22.33,   22.33,   22.33,   22.33]
+    call @printMemrefF32(%cast) : (memref<*xf32>) -> ()
+    return
+  }
+  func.func private @printMemrefF32(memref<*xf32>) attributes {llvm.emit_c_interface}
+}

--- a/test/Integration/Dialect/XeGPU/loadgather2d_masked_slm_f32.mlir
+++ b/test/Integration/Dialect/XeGPU/loadgather2d_masked_slm_f32.mlir
@@ -1,0 +1,83 @@
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                       --runner imex-cpu-runner -e main \
+// RUN:                                       --entry-point-result=void \
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
+// RUN: %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                        --runner imex-cpu-runner -e main \
+// RUN:                                        --entry-point-result=void \
+// RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck
+module @gemm attributes {gpu.container_module} {
+  memref.global "private" constant @__constant_1_3x16xf32 : memref<3x16xf32> = dense<1.0>
+  memref.global "private" constant @__constant_3_3x16xf32 : memref<3x16xf32> = dense<3.0>
+
+  func.func @test(%arg0: memref<3x16xf32>, %arg1: memref<3x16xf32>) -> memref<3x16xf32> attributes {llvm.emit_c_interface} {
+    %c1 = arith.constant 1 : index
+    %memref = gpu.alloc  host_shared () : memref<3x16xf32>
+    memref.copy %arg0, %memref : memref<3x16xf32> to memref<3x16xf32>
+    %memref1 = gpu.alloc  host_shared () : memref<3x16xf32>
+    memref.copy %arg1, %memref1 : memref<3x16xf32> to memref<3x16xf32>
+
+    // Spirv has no lowering for memref.subview
+    %in = memref.reinterpret_cast %memref to offset: [0], sizes: [48], strides: [1] : memref<3x16xf32> to memref<48xf32>
+    %out = memref.reinterpret_cast %memref1 to offset: [0], sizes: [48], strides: [1] : memref<3x16xf32> to memref<48xf32>
+
+    %memref_dyn = memref.cast %in : memref<48xf32> to memref<?xf32>
+    %memref1_dyn = memref.cast %out : memref<48xf32> to memref<?xf32>
+
+    gpu.launch_func  @test_kernel::@test_scattered blocks in (%c1, %c1, %c1) threads in (%c1, %c1, %c1) args(%memref_dyn : memref<?xf32>, %memref1_dyn : memref<?xf32>)
+    gpu.dealloc  %memref : memref<3x16xf32>
+    return %memref1 : memref<3x16xf32>
+  }
+
+  gpu.module @test_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
+    gpu.func @test_scattered(%arg0: memref<?xf32>, %arg1: memref<?xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      // This test emulates 2D load with user defined padding
+      // We load rows with %row_mask that has 0's to not cross the boundary.
+      // We pad the values that were not loaded (as per %row_mask) with %user_val.
+      // We store full (padded) rows with %store_mask.
+      %c0 = arith.constant 0 : index
+      %store_mask = arith.constant dense<[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]> : vector<16xi1>
+      %user_val = arith.constant dense<22.33> : vector<16xf32>
+      %row_mask = arith.constant dense<[1,1,1,1,1,1,1,1,1,1,1,1,1,0,0,0]> : vector<16xi1>
+      %offset_step = arith.constant dense<16>: vector<16xindex>
+
+      // Spirv has no lowering for memref.reinterpret_cast with different sizes (doesn't work: memref<3x16xf32> to memref<16xf32>)
+      // Each row has a tdesc with offsets that determine linearized memref's values to be loaded
+      %offsets_row1 = arith.constant dense<[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]> : vector<16xindex>
+      %row_1_in_td = xegpu.create_tdesc %arg0, %offsets_row1 : memref<?xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true, memory_scope=slm>>
+      %row_1_out_td = xegpu.create_tdesc %arg1, %offsets_row1 : memref<?xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true, memory_scope=slm>>
+      %row_1_loaded = xegpu.load %row_1_in_td, %row_mask : !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true, memory_scope=slm>>, vector<16xi1> -> vector<16xf32>
+      %row_1_store = arith.select %row_mask, %row_1_loaded, %user_val : vector<16xi1>, vector<16xf32>
+      xegpu.store %row_1_store, %row_1_out_td, %store_mask : vector<16xf32>, !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true, memory_scope=slm>>, vector<16xi1>
+
+      %row_2_in_td = xegpu.update_offset %row_1_in_td, %offset_step : !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true, memory_scope=slm>>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true, memory_scope=slm>>
+      %row_2_out_td = xegpu.update_offset %row_1_out_td, %offset_step : !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true, memory_scope=slm>>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true, memory_scope=slm>>
+      %row_2_loaded = xegpu.load %row_2_in_td, %row_mask : !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true, memory_scope=slm>>, vector<16xi1> -> vector<16xf32>
+      %row_2_store = arith.select %row_mask, %row_2_loaded, %user_val : vector<16xi1>, vector<16xf32>
+      xegpu.store %row_2_store, %row_2_out_td, %store_mask : vector<16xf32>, !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true, memory_scope=slm>>, vector<16xi1>
+
+      // The entire row is out of bounds
+      %row_3_out_td = xegpu.update_offset %row_2_out_td, %offset_step : !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true, memory_scope=slm>>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true, memory_scope=slm>>
+      xegpu.store %user_val, %row_3_out_td, %store_mask : vector<16xf32>, !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true, memory_scope=slm>>, vector<16xi1>
+      gpu.return
+    }
+  }
+
+  func.func @main() attributes {llvm.emit_c_interface} {
+    %0 = memref.get_global @__constant_1_3x16xf32 : memref<3x16xf32>
+    %1 = memref.get_global @__constant_3_3x16xf32 : memref<3x16xf32>
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+
+    %2 = call @test(%0, %1) : (memref<3x16xf32>, memref<3x16xf32>) -> memref<3x16xf32>
+    %cast = memref.cast %2 : memref<3x16xf32> to memref<*xf32>
+    // CHECK: Unranked Memref base@ = 0x{{.*}} rank = 2 offset = 0 sizes = [3, 16] strides = [16, 1] data =
+    // CHECK-NEXT: [1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   22.33,   22.33,   22.33],
+    // CHECK-NEXT: [1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   22.33,   22.33,   22.33],
+    // CHECK-NEXT: [22.33,   22.33,   22.33,   22.33,   22.33,   22.33,   22.33,   22.33,   22.33,   22.33,   22.33,   22.33,   22.33,   22.33,   22.33,   22.33]
+    call @printMemrefF32(%cast) : (memref<*xf32>) -> ()
+    return
+  }
+  func.func private @printMemrefF32(memref<*xf32>) attributes {llvm.emit_c_interface}
+}

--- a/test/Integration/Dialect/XeGPU/loadgather_chunk_size_f32.mlir
+++ b/test/Integration/Dialect/XeGPU/loadgather_chunk_size_f32.mlir
@@ -1,0 +1,64 @@
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                       --runner imex-cpu-runner -e main \
+// RUN:                                       --entry-point-result=void \
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
+// RUN: %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                        --runner imex-cpu-runner -e main \
+// RUN:                                        --entry-point-result=void \
+// RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck
+module @gemm attributes {gpu.container_module} {
+  memref.global "private" constant @__constant_1_4x16xf32 : memref<4x16xf32> = dense<1.1>
+  memref.global "private" constant @__constant_3_4x16xf32 : memref<4x16xf32> = dense<3.0>
+
+  func.func @test(%arg0: memref<4x16xf32>, %arg1: memref<4x16xf32>) -> memref<4x16xf32> attributes {llvm.emit_c_interface} {
+    %c1 = arith.constant 1 : index
+    %memref = gpu.alloc  host_shared () : memref<4x16xf32>
+    memref.copy %arg0, %memref : memref<4x16xf32> to memref<4x16xf32>
+    %memref1 = gpu.alloc  host_shared () : memref<4x16xf32>
+    memref.copy %arg1, %memref1 : memref<4x16xf32> to memref<4x16xf32>
+
+    %in = memref.reinterpret_cast %memref to offset: [0], sizes: [64], strides: [1] : memref<4x16xf32> to memref<64xf32>
+    %out = memref.reinterpret_cast %memref1 to offset: [0], sizes: [64], strides: [1] : memref<4x16xf32> to memref<64xf32>
+
+    %memref_dyn = memref.cast %in : memref<64xf32> to memref<?xf32>
+    %memref1_dyn = memref.cast %out : memref<64xf32> to memref<?xf32>
+
+    gpu.launch_func  @test_kernel::@test_scattered blocks in (%c1, %c1, %c1) threads in (%c1, %c1, %c1) args(%memref_dyn : memref<?xf32>, %memref1_dyn : memref<?xf32>)
+    gpu.dealloc  %memref : memref<4x16xf32>
+    return %memref1 : memref<4x16xf32>
+  }
+
+  gpu.module @test_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
+    gpu.func @test_scattered(%in: memref<?xf32>, %out: memref<?xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      // We have 16 work items, each accesses 2 elements: {chunk_size = 2}, hence 16x2 tensor.
+      // Valid offsets (%offsets for which %mask is 1) should not exceed 16*2=32.
+      %offsets = arith.constant dense<[0,4,8,12,16,20,24,28,32,34,38,42,46,50,54,58]> : vector<16xindex>
+      %mask = arith.constant dense<[1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0]> : vector<16xi1>
+      %tdesc_in = xegpu.create_tdesc %in, %offsets {chunk_size = 2} : memref<?xf32>, vector<16xindex> -> !xegpu.tensor_desc<16x2xf32, #xegpu.tdesc_attr<scattered = true>>
+      %tdesc_out = xegpu.create_tdesc %out, %offsets {chunk_size = 2} : memref<?xf32>, vector<16xindex> -> !xegpu.tensor_desc<16x2xf32, #xegpu.tdesc_attr<scattered = true>>
+      %loaded = xegpu.load %tdesc_in, %mask : !xegpu.tensor_desc<16x2xf32, #xegpu.tdesc_attr<scattered = true>>, vector<16xi1> -> vector<16x2xf32>
+      xegpu.store %loaded, %tdesc_out, %mask : vector<16x2xf32>, !xegpu.tensor_desc<16x2xf32, #xegpu.tdesc_attr<scattered = true>>, vector<16xi1>
+      gpu.return
+    }
+  }
+
+  func.func @main() attributes {llvm.emit_c_interface} {
+    %0 = memref.get_global @__constant_1_4x16xf32 : memref<4x16xf32>
+    %1 = memref.get_global @__constant_3_4x16xf32 : memref<4x16xf32>
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+
+    %2 = call @test(%0, %1) : (memref<4x16xf32>, memref<4x16xf32>) -> memref<4x16xf32>
+    %cast = memref.cast %2 : memref<4x16xf32> to memref<*xf32>
+    // CHECK: Unranked Memref base@ = 0x{{.*}} rank = 2 offset = 0 sizes = [4, 16] strides = [16, 1] data =
+    // CHECK-NEXT: [1.1,   1.1,   3,   3,   1.1,   1.1,   3,   3,   1.1,   1.1,   3,   3,   1.1,   1.1,   3,   3],
+    // CHECK-NEXT: [1.1,   1.1,   3,   3,   1.1,   1.1,   3,   3,   1.1,   1.1,   3,   3,   1.1,   1.1,   3,   3],
+    // CHECK-NEXT: [3,   3,   3,   3,   3,   3,   3,   3,   3,   3,   3,   3,   3,   3,   3,   3],
+    // CHECK-NEXT: [3,   3,   3,   3,   3,   3,   3,   3,   3,   3,   3,   3,   3,   3,   3,   3]
+    call @printMemrefF32(%cast) : (memref<*xf32>) -> ()
+    return
+  }
+  func.func private @printMemrefF32(memref<*xf32>) attributes {llvm.emit_c_interface}
+}

--- a/test/Integration/Dialect/XeGPU/loadgather_chunk_size_i32.mlir
+++ b/test/Integration/Dialect/XeGPU/loadgather_chunk_size_i32.mlir
@@ -1,0 +1,64 @@
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                       --runner imex-cpu-runner -e main \
+// RUN:                                       --entry-point-result=void \
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
+// RUN: %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                        --runner imex-cpu-runner -e main \
+// RUN:                                        --entry-point-result=void \
+// RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck
+module @gemm attributes {gpu.container_module} {
+  memref.global "private" constant @__constant_1_4x16xi32 : memref<4x16xi32> = dense<[[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1], [2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2], [3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3], [4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4]]>
+  memref.global "private" constant @__constant_3_4x16xi32 : memref<4x16xi32> = dense<8>
+
+  func.func @test(%arg0: memref<4x16xi32>, %arg1: memref<4x16xi32>) -> memref<4x16xi32> attributes {llvm.emit_c_interface} {
+    %c1 = arith.constant 1 : index
+    %memref = gpu.alloc  host_shared () : memref<4x16xi32>
+    memref.copy %arg0, %memref : memref<4x16xi32> to memref<4x16xi32>
+    %memref1 = gpu.alloc  host_shared () : memref<4x16xi32>
+    memref.copy %arg1, %memref1 : memref<4x16xi32> to memref<4x16xi32>
+
+    %in = memref.reinterpret_cast %memref to offset: [0], sizes: [64], strides: [1] : memref<4x16xi32> to memref<64xi32>
+    %out = memref.reinterpret_cast %memref1 to offset: [0], sizes: [64], strides: [1] : memref<4x16xi32> to memref<64xi32>
+
+    %memref_dyn = memref.cast %in : memref<64xi32> to memref<?xi32>
+    %memref1_dyn = memref.cast %out : memref<64xi32> to memref<?xi32>
+
+    gpu.launch_func  @test_kernel::@test_scattered blocks in (%c1, %c1, %c1) threads in (%c1, %c1, %c1) args(%memref_dyn : memref<?xi32>, %memref1_dyn : memref<?xi32>)
+    gpu.dealloc  %memref : memref<4x16xi32>
+    return %memref1 : memref<4x16xi32>
+  }
+
+  gpu.module @test_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
+    gpu.func @test_scattered(%in: memref<?xi32>, %out: memref<?xi32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      // We have 16 work items, each accesses 2 elements: {chunk_size = 2}, hence 16x2 tensor.
+      // Valid offsets (%offsets for which %mask is 1) should not exceed 16*2=32.
+      %offsets = arith.constant dense<[0,4,8,12,16,20,24,28,32,34,38,42,46,50,54,58]> : vector<16xindex>
+      %mask = arith.constant dense<[1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0]> : vector<16xi1>
+      %tdesc_in = xegpu.create_tdesc %in, %offsets {chunk_size = 2} : memref<?xi32>, vector<16xindex> -> !xegpu.tensor_desc<16x2xi32, #xegpu.tdesc_attr<scattered = true>>
+      %tdesc_out = xegpu.create_tdesc %out, %offsets {chunk_size = 2} : memref<?xi32>, vector<16xindex> -> !xegpu.tensor_desc<16x2xi32, #xegpu.tdesc_attr<scattered = true>>
+      %loaded = xegpu.load %tdesc_in, %mask : !xegpu.tensor_desc<16x2xi32, #xegpu.tdesc_attr<scattered = true>>, vector<16xi1> -> vector<16x2xi32>
+      xegpu.store %loaded, %tdesc_out, %mask : vector<16x2xi32>, !xegpu.tensor_desc<16x2xi32, #xegpu.tdesc_attr<scattered = true>>, vector<16xi1>
+      gpu.return
+    }
+  }
+
+  func.func @main() attributes {llvm.emit_c_interface} {
+    %0 = memref.get_global @__constant_1_4x16xi32 : memref<4x16xi32>
+    %1 = memref.get_global @__constant_3_4x16xi32 : memref<4x16xi32>
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+
+    %2 = call @test(%0, %1) : (memref<4x16xi32>, memref<4x16xi32>) -> memref<4x16xi32>
+    %cast = memref.cast %2 : memref<4x16xi32> to memref<*xi32>
+    // CHECK: Unranked Memref base@ = 0x{{.*}} rank = 2 offset = 0 sizes = [4, 16] strides = [16, 1] data =
+    // CHECK-NEXT:  [1,   1,   8,   8,   1,   1,   8,   8,   1,   1,   8,   8,   1,   1,   8,   8],
+    // CHECK-NEXT:  [2,   2,   8,   8,   2,   2,   8,   8,   2,   2,   8,   8,   2,   2,   8,   8],
+    // CHECK-NEXT:  [8,   8,   8,   8,   8,   8,   8,   8,   8,   8,   8,   8,   8,   8,   8,   8],
+    // CHECK-NEXT:  [8,   8,   8,   8,   8,   8,   8,   8,   8,   8,   8,   8,   8,   8,   8,   8]
+    call @printMemrefI32(%cast) : (memref<*xi32>) -> ()
+    return
+  }
+  func.func private @printMemrefI32(memref<*xi32>) attributes {llvm.emit_c_interface}
+}

--- a/test/Integration/Dialect/XeGPU/loadgather_f32.mlir
+++ b/test/Integration/Dialect/XeGPU/loadgather_f32.mlir
@@ -1,0 +1,49 @@
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                       --runner imex-cpu-runner -e main \
+// RUN:                                       --entry-point-result=void \
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
+// RUN: %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                        --runner imex-cpu-runner -e main \
+// RUN:                                        --entry-point-result=void \
+// RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck
+module @gemm attributes {gpu.container_module} {
+  memref.global "private" constant @__constant_1x16xf32 : memref<1x16xf32> = dense<1.1>
+  memref.global "private" constant @__constant_3x16xf32 : memref<1x16xf32> = dense<3.0>
+
+  func.func @test(%arg0: memref<1x16xf32>, %arg1: memref<1x16xf32>) -> memref<1x16xf32> attributes {llvm.emit_c_interface} {
+    %c1 = arith.constant 1 : index
+    %memref = gpu.alloc  host_shared () : memref<1x16xf32>
+    memref.copy %arg0, %memref : memref<1x16xf32> to memref<1x16xf32>
+    %memref1 = gpu.alloc  host_shared () : memref<1x16xf32>
+    memref.copy %arg1, %memref1 : memref<1x16xf32> to memref<1x16xf32>
+    gpu.launch_func  @test_kernel::@test_scattered blocks in (%c1, %c1, %c1) threads in (%c1, %c1, %c1) args(%memref : memref<1x16xf32>, %memref1 : memref<1x16xf32>)
+    gpu.dealloc  %memref : memref<1x16xf32>
+    return %memref1 : memref<1x16xf32>
+  }
+
+  gpu.module @test_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
+    gpu.func @test_scattered(%arg0: memref<1x16xf32>, %arg1: memref<1x16xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %c0 = arith.constant 0 : index
+      %offsets = arith.constant dense<[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]> : vector<16xindex>
+      %mask = arith.constant dense<[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]> : vector<16xi1>
+      %1 = memref.reinterpret_cast %arg0 to offset: [0], sizes: [16], strides: [1] : memref<1x16xf32> to memref<16xf32>
+      %2 = memref.reinterpret_cast %arg1 to offset: [0], sizes: [16], strides: [1] : memref<1x16xf32> to memref<16xf32>
+      %tdesc1 = xegpu.create_tdesc %1, %offsets : memref<16xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true>>
+      %tdesc2 = xegpu.create_tdesc %2, %offsets : memref<16xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true>>
+      %loaded = xegpu.load %tdesc1, %mask : !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true>>, vector<16xi1> -> vector<16xf32>
+      xegpu.store %loaded, %tdesc2, %mask : vector<16xf32>, !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true>>, vector<16xi1>
+      gpu.return
+    }
+  }
+
+  func.func @main() attributes {llvm.emit_c_interface} {
+    %0 = memref.get_global @__constant_1x16xf32 : memref<1x16xf32>
+    %1 = memref.get_global @__constant_3x16xf32 : memref<1x16xf32>
+    %c0 = arith.constant 0 : index
+    %2 = call @test(%0, %1) : (memref<1x16xf32>, memref<1x16xf32>) -> memref<1x16xf32>
+    %vector_0 = vector.load %2[%c0,%c0] :memref<1x16xf32>, vector<16xf32>
+    // CHECK: ( 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1 )
+    vector.print %vector_0 : vector<16xf32>
+    return
+  }
+}

--- a/test/Integration/Dialect/XeGPU/loadgather_masked_f32.mlir
+++ b/test/Integration/Dialect/XeGPU/loadgather_masked_f32.mlir
@@ -1,0 +1,49 @@
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                       --runner imex-cpu-runner -e main \
+// RUN:                                       --entry-point-result=void \
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
+// RUN: %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                        --runner imex-cpu-runner -e main \
+// RUN:                                        --entry-point-result=void \
+// RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck
+module @gemm attributes {gpu.container_module} {
+  memref.global "private" constant @__constant_1x16xf32 : memref<1x16xf32> = dense<1.0>
+  memref.global "private" constant @__constant_3x16xf32 : memref<1x16xf32> = dense<3.3>
+
+  func.func @test(%arg0: memref<1x16xf32>, %arg1: memref<1x16xf32>) -> memref<1x16xf32> attributes {llvm.emit_c_interface} {
+    %c1 = arith.constant 1 : index
+    %memref = gpu.alloc  host_shared () : memref<1x16xf32>
+    memref.copy %arg0, %memref : memref<1x16xf32> to memref<1x16xf32>
+    %memref1 = gpu.alloc  host_shared () : memref<1x16xf32>
+    memref.copy %arg1, %memref1 : memref<1x16xf32> to memref<1x16xf32>
+    gpu.launch_func  @test_kernel::@test_scattered blocks in (%c1, %c1, %c1) threads in (%c1, %c1, %c1) args(%memref : memref<1x16xf32>, %memref1 : memref<1x16xf32>)
+    gpu.dealloc  %memref : memref<1x16xf32>
+    return %memref1 : memref<1x16xf32>
+  }
+
+  gpu.module @test_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
+    gpu.func @test_scattered(%arg0: memref<1x16xf32>, %arg1: memref<1x16xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %c0 = arith.constant 0 : index
+      %offsets = arith.constant dense<[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]> : vector<16xindex>
+      %mask = arith.constant dense<[1,1,1,0,1,1,1,1,0,1,1,1,1,0,1,1]> : vector<16xi1>
+      %1 = memref.reinterpret_cast %arg0 to offset: [0], sizes: [16], strides: [1] : memref<1x16xf32> to memref<16xf32>
+      %2 = memref.reinterpret_cast %arg1 to offset: [0], sizes: [16], strides: [1] : memref<1x16xf32> to memref<16xf32>
+      %tdesc1 = xegpu.create_tdesc %1, %offsets : memref<16xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true>>
+      %tdesc2 = xegpu.create_tdesc %2, %offsets : memref<16xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true>>
+      %loaded = xegpu.load %tdesc1, %mask : !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true>>, vector<16xi1> -> vector<16xf32>
+      xegpu.store %loaded, %tdesc2, %mask : vector<16xf32>, !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true>>, vector<16xi1>
+      gpu.return
+    }
+  }
+
+  func.func @main() attributes {llvm.emit_c_interface} {
+    %0 = memref.get_global @__constant_1x16xf32 : memref<1x16xf32>
+    %1 = memref.get_global @__constant_3x16xf32 : memref<1x16xf32>
+    %c0 = arith.constant 0 : index
+    %2 = call @test(%0, %1) : (memref<1x16xf32>, memref<1x16xf32>) -> memref<1x16xf32>
+    %vector_0 = vector.load %2[%c0,%c0] :memref<1x16xf32>, vector<16xf32>
+    // CHECK: ( 1, 1, 1, 3.3, 1, 1, 1, 1, 3.3, 1, 1, 1, 1, 3.3, 1, 1 )
+    vector.print %vector_0 : vector<16xf32>
+    return
+  }
+}

--- a/test/Integration/Dialect/XeGPU/loadgather_masked_slm_f32.mlir
+++ b/test/Integration/Dialect/XeGPU/loadgather_masked_slm_f32.mlir
@@ -1,0 +1,49 @@
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                       --runner imex-cpu-runner -e main \
+// RUN:                                       --entry-point-result=void \
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
+// RUN: %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                        --runner imex-cpu-runner -e main \
+// RUN:                                        --entry-point-result=void \
+// RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck
+module @gemm attributes {gpu.container_module} {
+  memref.global "private" constant @__constant_1x16xf32 : memref<1x16xf32> = dense<1.0>
+  memref.global "private" constant @__constant_3x16xf32 : memref<1x16xf32> = dense<3.3>
+
+  func.func @test(%arg0: memref<1x16xf32>, %arg1: memref<1x16xf32>) -> memref<1x16xf32> attributes {llvm.emit_c_interface} {
+    %c1 = arith.constant 1 : index
+    %memref = gpu.alloc  host_shared () : memref<1x16xf32>
+    memref.copy %arg0, %memref : memref<1x16xf32> to memref<1x16xf32>
+    %memref1 = gpu.alloc  host_shared () : memref<1x16xf32>
+    memref.copy %arg1, %memref1 : memref<1x16xf32> to memref<1x16xf32>
+    gpu.launch_func  @test_kernel::@test_scattered blocks in (%c1, %c1, %c1) threads in (%c1, %c1, %c1) args(%memref : memref<1x16xf32>, %memref1 : memref<1x16xf32>)
+    gpu.dealloc  %memref : memref<1x16xf32>
+    return %memref1 : memref<1x16xf32>
+  }
+
+  gpu.module @test_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
+    gpu.func @test_scattered(%arg0: memref<1x16xf32>, %arg1: memref<1x16xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %c0 = arith.constant 0 : index
+      %offsets = arith.constant dense<[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]> : vector<16xindex>
+      %mask = arith.constant dense<[1,1,1,0,1,1,1,1,0,1,1,1,1,0,1,1]> : vector<16xi1>
+      %1 = memref.reinterpret_cast %arg0 to offset: [0], sizes: [16], strides: [1] : memref<1x16xf32> to memref<16xf32>
+      %2 = memref.reinterpret_cast %arg1 to offset: [0], sizes: [16], strides: [1] : memref<1x16xf32> to memref<16xf32>
+      %tdesc1 = xegpu.create_tdesc %1, %offsets : memref<16xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true, memory_scope=slm>>
+      %tdesc2 = xegpu.create_tdesc %2, %offsets : memref<16xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true, memory_scope=slm>>
+      %loaded = xegpu.load %tdesc1, %mask : !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true, memory_scope=slm>>, vector<16xi1> -> vector<16xf32>
+      xegpu.store %loaded, %tdesc2, %mask : vector<16xf32>, !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true, memory_scope=slm>>, vector<16xi1>
+      gpu.return
+    }
+  }
+
+  func.func @main() attributes {llvm.emit_c_interface} {
+    %0 = memref.get_global @__constant_1x16xf32 : memref<1x16xf32>
+    %1 = memref.get_global @__constant_3x16xf32 : memref<1x16xf32>
+    %c0 = arith.constant 0 : index
+    %2 = call @test(%0, %1) : (memref<1x16xf32>, memref<1x16xf32>) -> memref<1x16xf32>
+    %vector_0 = vector.load %2[%c0,%c0] :memref<1x16xf32>, vector<16xf32>
+    // CHECK: ( 1, 1, 1, 3.3, 1, 1, 1, 1, 3.3, 1, 1, 1, 1, 3.3, 1, 1 )
+    vector.print %vector_0 : vector<16xf32>
+    return
+  }
+}

--- a/test/Integration/Dialect/XeGPU/loadgather_slm_f32.mlir
+++ b/test/Integration/Dialect/XeGPU/loadgather_slm_f32.mlir
@@ -1,0 +1,50 @@
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                       --runner imex-cpu-runner -e main \
+// RUN:                                       --entry-point-result=void \
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
+// RUN: %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                        --runner imex-cpu-runner -e main \
+// RUN:                                        --entry-point-result=void \
+// RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck
+module @gemm attributes {gpu.container_module} {
+  memref.global "private" constant @__constant_1x16xf32 : memref<1x16xf32> = dense<1.1>
+  memref.global "private" constant @__constant_3x16xf32 : memref<1x16xf32> = dense<3.0>
+
+  func.func @test(%arg0: memref<1x16xf32>, %arg1: memref<1x16xf32>) -> memref<1x16xf32> attributes {llvm.emit_c_interface} {
+    %c1 = arith.constant 1 : index
+    %memref = gpu.alloc  host_shared () : memref<1x16xf32>
+    memref.copy %arg0, %memref : memref<1x16xf32> to memref<1x16xf32>
+    %memref1 = gpu.alloc  host_shared () : memref<1x16xf32>
+    memref.copy %arg1, %memref1 : memref<1x16xf32> to memref<1x16xf32>
+    gpu.launch_func  @test_kernel::@test_scattered blocks in (%c1, %c1, %c1) threads in (%c1, %c1, %c1) args(%memref : memref<1x16xf32>, %memref1 : memref<1x16xf32>)
+    gpu.dealloc  %memref : memref<1x16xf32>
+    return %memref1 : memref<1x16xf32>
+  }
+
+  gpu.module @test_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
+    gpu.func @test_scattered(%arg0: memref<1x16xf32>, %arg1: memref<1x16xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %c0 = arith.constant 0 : index
+      // memory_scope=slm currently ignored (sfid is hardcoded 15 which is ugm, should be 14 for slm).
+      %offsets = arith.constant dense<[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]> : vector<16xindex>
+      %mask = arith.constant dense<[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]> : vector<16xi1>
+      %1 = memref.reinterpret_cast %arg0 to offset: [0], sizes: [16], strides: [1] : memref<1x16xf32> to memref<16xf32>
+      %2 = memref.reinterpret_cast %arg1 to offset: [0], sizes: [16], strides: [1] : memref<1x16xf32> to memref<16xf32>
+      %tdesc1 = xegpu.create_tdesc %1, %offsets : memref<16xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true, memory_scope=slm>>
+      %tdesc2 = xegpu.create_tdesc %2, %offsets : memref<16xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true, memory_scope=slm>>
+      %loaded = xegpu.load %tdesc1, %mask : !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true, memory_scope=slm>>, vector<16xi1> -> vector<16xf32>
+      xegpu.store %loaded, %tdesc2, %mask : vector<16xf32>, !xegpu.tensor_desc<16xf32, #xegpu.tdesc_attr<scattered = true, memory_scope=slm>>, vector<16xi1>
+      gpu.return
+    }
+  }
+
+  func.func @main() attributes {llvm.emit_c_interface} {
+    %0 = memref.get_global @__constant_1x16xf32 : memref<1x16xf32>
+    %1 = memref.get_global @__constant_3x16xf32 : memref<1x16xf32>
+    %c0 = arith.constant 0 : index
+    %2 = call @test(%0, %1) : (memref<1x16xf32>, memref<1x16xf32>) -> memref<1x16xf32>
+    %vector_0 = vector.load %2[%c0,%c0] :memref<1x16xf32>, vector<16xf32>
+    // CHECK: ( 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1 )
+    vector.print %vector_0 : vector<16xf32>
+    return
+  }
+}

--- a/test/Integration/Dialect/XeGPU/xegpu-to-func-vc.pp
+++ b/test/Integration/Dialect/XeGPU/xegpu-to-func-vc.pp
@@ -7,8 +7,6 @@ builtin.module(
     gpu.module(convert-xegpu-to-vc)
     reconcile-unrealized-casts
     bf16-to-gpu
-    gpu.module(convert-func-to-spirv)
-    gpu.module(convert-vector-to-spirv)
     imex-convert-gpu-to-spirv
     spirv.module(spirv-lower-abi-attrs
              spirv-update-vce)


### PR DESCRIPTION
This PR addresses XeGPU scattered operations. More specifically:
- adds `xegpu.update_offset`.
- improves consistency with the official documentation for `xegpu.create_tdesc`, `xegpu.load`, `xegpu.store`
- above mentioned modifications also affected `xegpu.atomic_rmw`
- adds integration tests for scattered ops and their parameters (e.g., `chunk_size`, masks, datatypes).