### PR TITLE
ndarray lowering is compatible with one-shot-bufferize

### DIFF
--- a/test/Conversion/NDArrayToLinalg/NDArrayToLinalg.mlir
+++ b/test/Conversion/NDArrayToLinalg/NDArrayToLinalg.mlir
@@ -8,12 +8,12 @@ func.func @test_subview(%arg0: !ndarray.ndarray<?xi64>) -> !ndarray.ndarray<?xi6
     return %0 : !ndarray.ndarray<?xi64>
 }
 // CHECK-LABEL: @test_subview
-// CHECK-NEXT: [[V:%.*]] = bufferization.to_tensor %arg0 : memref<?xi64, strided<[?], offset: ?>>
+// CHECK-NEXT: [[V:%.*]] = bufferization.to_tensor %arg0 restrict : memref<?xi64, strided<[?], offset: ?>>
 // CHECK-NEXT: [[C0:%.*]] = arith.constant
 // CHECK-NEXT: [[C1:%.*]] = arith.constant
 // CHECK-NEXT: [[V0:%.*]] = bufferization.to_memref [[V]] : memref<?xi64, strided<[?], offset: ?>>
 // CHECK-NEXT: [[S0:%.*]] = memref.subview [[V0]][[[C0]]] [[[C1]]] [[[C1]]] : memref<?xi64, strided<[?], offset: ?>> to memref<?xi64, strided<[?], offset: ?>>
-// CHECK-NEXT: [[V1:%.*]] = bufferization.to_tensor [[S0]] writable : memref<?xi64, strided<[?], offset: ?>>
+// CHECK-NEXT: [[V1:%.*]] = bufferization.to_tensor [[S0]] restrict writable : memref<?xi64, strided<[?], offset: ?>>
 // CHECK-NEXT: [[V2:%.*]] = bufferization.to_memref
 // CHECK-NEXT: return [[V2]] : memref<?xi64, strided<[?], offset: ?>>
 
@@ -28,10 +28,10 @@ func.func @test_static_mr_2_tnsr_2_static_mr(%arg0: memref<55xi32, strided<[1], 
 // CHECK-LABEL: @test_static_mr_2_tnsr_2_static_mr
 // CHECK-NEXT: [[C0:%.*]] = arith.constant
 // CHECK-NEXT: [[C1:%.*]] = arith.constant
-// CHECK-NEXT: [[V:%.*]] = bufferization.to_tensor %arg0 : memref<55xi32, strided<[1], offset: 2>>
+// CHECK-NEXT: [[V:%.*]] = bufferization.to_tensor %arg0 restrict : memref<55xi32, strided<[1], offset: 2>>
 // CHECK-NEXT: [[V0:%.*]] = bufferization.to_memref [[V]] : memref<55xi32, strided<[1], offset: 2>>
 // CHECK-NEXT: [[S0:%.*]] = memref.subview [[V0]][[[C0]]] [[[C1]]] [[[C1]]] : memref<55xi32, strided<[1], offset: 2>> to memref<?xi32, strided<[?], offset: ?>>
-// CHECK-NEXT: [[V1:%.*]] = bufferization.to_tensor [[S0]] writable : memref<?xi32, strided<[?], offset: ?>>
+// CHECK-NEXT: [[V1:%.*]] = bufferization.to_tensor [[S0]] restrict writable : memref<?xi32, strided<[?], offset: ?>>
 // CHECK-NEXT: [[V2:%.*]] = bufferization.to_memref
 // CHECK-NEXT: [[V3:%.*]] = memref.cast [[V2]]
 // CHECK-NEXT: return [[V3]] : memref<3xi32, strided<[?], offset: ?>>
@@ -44,7 +44,7 @@ func.func @test_extract_slice(%arg0: !ndarray.ndarray<?xi64>) -> !ndarray.ndarra
     return %0 : !ndarray.ndarray<?xi64>
 }
 // CHECK-LABEL: @test_extract_slice
-// CHECK-NEXT: [[V:%.*]] = bufferization.to_tensor %arg0 : memref<?xi64, strided<[?], offset: ?>>
+// CHECK-NEXT: [[V:%.*]] = bufferization.to_tensor %arg0 restrict : memref<?xi64, strided<[?], offset: ?>>
 // CHECK-NEXT: [[C0:%.*]] = arith.constant
 // CHECK-NEXT: [[C1:%.*]] = arith.constant
 // CHECK-NEXT: [[V0:%.*]] = tensor.extract_slice [[V]][%c0] [%c3] [%c3] : tensor<?xi64> to tensor<?xi64>
@@ -105,9 +105,9 @@ func.func @test_reshape2(%arg0: index) -> !ndarray.ndarray<?x?xi64> {
 // CHECK-LABEL: @test_reshape2
 // CHECK: tensor.empty
 // CHECK: tensor.dim
-// CHECK: tensor.empty
+// CHECK: memref.alloc
 // CHECK: bufferization.to_memref
-// CHECK: bufferization.to_memref
+// CHECK: region.env_region "protect_copy_op"
 // CHECK: memref.copy
 // CHECK: tensor.from_elements
 // CHECK: tensor.reshape
@@ -193,8 +193,8 @@ func.func @test_insert_slice(%arg0: !ndarray.ndarray<?xi64>, %arg1: !ndarray.nda
     return
 }
 // CHECK-LABEL: @test_insert_slice
-// CHECK-NEXT: [[V:%.*]] = bufferization.to_tensor %arg0 : memref<?xi64, strided<[?], offset: ?>>
-// CHECK-NEXT: [[VV:%.*]] = bufferization.to_tensor %arg1 : memref<?xi64, strided<[?], offset: ?>>
+// CHECK-NEXT: [[V:%.*]] = bufferization.to_tensor %arg0 restrict : memref<?xi64, strided<[?], offset: ?>>
+// CHECK-NEXT: [[VV:%.*]] = bufferization.to_tensor %arg1 restrict : memref<?xi64, strided<[?], offset: ?>>
 // CHECK-NEXT: [[C0:%.*]] = arith.constant
 // CHECK-NEXT: [[C1:%.*]] = arith.constant
 // CHECK-NEXT: [[C3:%.*]] = arith.constant
@@ -212,8 +212,8 @@ func.func @test_insert_slice_scalar(%arg0: !ndarray.ndarray<?xi64>, %arg1: !ndar
     return
 }
 // CHECK-LABEL: @test_insert_slice_scalar
-// CHECK-NEXT: [[V:%.*]] = bufferization.to_tensor %arg0 : memref<?xi64, strided<[?], offset: ?>>
-// CHECK-NEXT: [[VV:%.*]] = bufferization.to_tensor %arg1 : memref<i64, strided<[], offset: ?>>
+// CHECK-NEXT: [[V:%.*]] = bufferization.to_tensor %arg0 restrict : memref<?xi64, strided<[?], offset: ?>>
+// CHECK-NEXT: [[VV:%.*]] = bufferization.to_tensor %arg1 restrict : memref<i64, strided<[], offset: ?>>
 // CHECK-NEXT: [[C0:%.*]] = arith.constant
 // CHECK-NEXT: [[C1:%.*]] = arith.constant
 // CHECK-NEXT: [[C3:%.*]] = arith.constant
@@ -231,8 +231,8 @@ func.func @test_immutable_insert_slice(%arg0: !ndarray.ndarray<?xi64>, %arg1: !n
     return %0 : !ndarray.ndarray<?xi64>
 }
 // CHECK-LABEL: @test_immutable_insert_slice
-// CHECK-NEXT: [[A0:%.*]] = bufferization.to_tensor %arg0 : memref<?xi64, strided<[?], offset: ?>>
-// CHECK-NEXT: [[A1:%.*]] = bufferization.to_tensor %arg1 : memref<?xi64, strided<[?], offset: ?>>
+// CHECK-NEXT: [[A0:%.*]] = bufferization.to_tensor %arg0 restrict : memref<?xi64, strided<[?], offset: ?>>
+// CHECK-NEXT: [[A1:%.*]] = bufferization.to_tensor %arg1 restrict : memref<?xi64, strided<[?], offset: ?>>
 // CHECK-NEXT: [[C0:%.*]] = arith.constant
 // CHECK-NEXT: [[C1:%.*]] = arith.constant
 // CHECK-NEXT: [[C3:%.*]] = arith.constant
@@ -256,7 +256,7 @@ func.func @test_load(%arg0: !ndarray.ndarray<?xi64>) -> i64 {
     return %1 : i64
 }
 // CHECK-LABEL: @test_load
-// CHECK-NEXT: [[V:%.*]] = bufferization.to_tensor %arg0 : memref<?xi64, strided<[?], offset: ?>>
+// CHECK-NEXT: [[V:%.*]] = bufferization.to_tensor %arg0 restrict : memref<?xi64, strided<[?], offset: ?>>
 // CHECK-NEXT: [[C0:%.*]] = arith.constant
 // CHECK-NEXT: [[V0:%.*]] = tensor.extract [[V]][[[C0]]] : tensor<?xi64>
 // CHECK-NEXT: return [[V0]] : i64
@@ -267,7 +267,7 @@ func.func @test_to_tensor(%arg0: !ndarray.ndarray<?xi64>) -> tensor<?xi64> {
     return %0 : tensor<?xi64>
 }
 // CHECK-LABEL: @test_to_tensor
-// CHECK-NEXT: [[V:%.*]] = bufferization.to_tensor %arg0 : memref<?xi64, strided<[?], offset: ?>>
+// CHECK-NEXT: [[V:%.*]] = bufferization.to_tensor %arg0 restrict : memref<?xi64, strided<[?], offset: ?>>
 // CHECK-NEXT: return [[V]] : tensor<?xi64>
 
 // -----

--- a/test/Gen/NDArray/ndarray-gpu.pp
+++ b/test/Gen/NDArray/ndarray-gpu.pp
@@ -9,26 +9,18 @@ builtin.module(
     linalg-fuse-elementwise-ops
     arith-expand
     memref-expand
-    arith-bufferize
-    func-bufferize
     func.func(empty-tensor-to-alloc-tensor)
-    func.func(scf-bufferize)
-    func.func(tensor-bufferize)
-    func.func(bufferization-bufferize)
-    func.func(linalg-bufferize)
-    func.func(linalg-detensorize)
-    func.func(tensor-bufferize)
-    func.func(finalizing-bufferize)
+    one-shot-bufferize{bufferize-function-boundaries}
     imex-remove-temporaries
     func.func(convert-linalg-to-parallel-loops)
     func.func(scf-parallel-loop-fusion)
-    drop-regions
 // GPU
     func.func(imex-add-outer-parallel-loop)
     func.func(gpu-map-parallel-loops)
     func.func(convert-parallel-loops-to-gpu)
 // insert-gpu-allocs pass can have client-api = opencl or vulkan args
     func.func(insert-gpu-allocs{client-api=opencl})
+    drop-regions
     canonicalize
     normalize-memrefs
 // Unstride memrefs does not seem to be needed.
@@ -45,7 +37,7 @@ builtin.module(
     imex-convert-gpu-to-spirv
     spirv.module(spirv-lower-abi-attrs
              spirv-update-vce)
-// func.func(llvm-request-c-wrappers)
+//  func.func(llvm-request-c-wrappers)
     serialize-spirv
     expand-strided-metadata
     lower-affine

--- a/test/Gen/NDArray/ndarray.pp
+++ b/test/Gen/NDArray/ndarray.pp
@@ -1,25 +1,18 @@
 builtin.module(
     convert-ndarray-to-linalg
-    func.func(
-        tosa-to-linalg
-        tosa-to-tensor
-    )
+    canonicalize
+    func.func(tosa-make-broadcastable)
+    func.func(tosa-to-linalg)
+    func.func(tosa-to-tensor)
     canonicalize
     linalg-fuse-elementwise-ops
-    convert-shape-to-std
     arith-expand
-    arith-bufferize
-    func-bufferize
-    func.func(
-        empty-tensor-to-alloc-tensor
-        scf-bufferize
-        tensor-bufferize
-        linalg-bufferize
-        bufferization-bufferize
-        linalg-detensorize
-        tensor-bufferize
-        finalizing-bufferize
-        convert-linalg-to-parallel-loops)
+    memref-expand
+    func.func(empty-tensor-to-alloc-tensor)
+    one-shot-bufferize{bufferize-function-boundaries}
+    imex-remove-temporaries
+    func.func(convert-linalg-to-parallel-loops)
+    func.func(scf-parallel-loop-fusion)
     drop-regions
     canonicalize
     fold-memref-alias-ops
@@ -31,4 +24,5 @@ builtin.module(
     convert-math-to-llvm
     convert-math-to-libm
     convert-func-to-llvm
-    reconcile-unrealized-casts)
+    reconcile-unrealized-casts
+)

--- a/test/imex-runner/ndarray-gpu.pp
+++ b/test/imex-runner/ndarray-gpu.pp
@@ -9,16 +9,8 @@ builtin.module(
     linalg-fuse-elementwise-ops
     arith-expand
     memref-expand
-    arith-bufferize
-    func-bufferize
     func.func(empty-tensor-to-alloc-tensor)
-    func.func(scf-bufferize)
-    func.func(tensor-bufferize)
-    func.func(bufferization-bufferize)
-    func.func(linalg-bufferize)
-    func.func(linalg-detensorize)
-    func.func(tensor-bufferize)
-    func.func(finalizing-bufferize)
+    one-shot-bufferize{bufferize-function-boundaries}
     imex-remove-temporaries
     func.func(convert-linalg-to-parallel-loops)
     func.func(scf-parallel-loop-fusion)
@@ -45,7 +37,7 @@ builtin.module(
     imex-convert-gpu-to-spirv
     spirv.module(spirv-lower-abi-attrs
              spirv-update-vce)
-//    func.func(llvm-request-c-wrappers)
+//  func.func(llvm-request-c-wrappers)
     serialize-spirv
     expand-strided-metadata
     lower-affine

--- a/test/imex-runner/ndarray.pp
+++ b/test/imex-runner/ndarray.pp
@@ -8,16 +8,8 @@ builtin.module(
     linalg-fuse-elementwise-ops
     arith-expand
     memref-expand
-    arith-bufferize
-    func-bufferize
     func.func(empty-tensor-to-alloc-tensor)
-    func.func(scf-bufferize)
-    func.func(tensor-bufferize)
-    func.func(bufferization-bufferize)
-    func.func(linalg-bufferize)
-    func.func(linalg-detensorize)
-    func.func(tensor-bufferize)
-    func.func(finalizing-bufferize)
+    one-shot-bufferize{bufferize-function-boundaries}
     imex-remove-temporaries
     func.func(convert-linalg-to-parallel-loops)
     func.func(scf-parallel-loop-fusion)


### PR DESCRIPTION
- ndarray-to-linalg pass: all to_tensor ops use `restrict=true` to comply with one-shot-bufferize
- region-bufferize pass: to_tensor ops use `restrict=true`
- ndarray-to-linalg pass: fix reshape op copy handling