### PR TITLE
XeGPU RFC Update: chunk_size_per_lane as tensor_desc's attribute  

### DIFF
--- a/docs/rfcs/XeGPU.md
+++ b/docs/rfcs/XeGPU.md
@@ -222,7 +222,7 @@ Attribute `chunk_size_per_lane` specifies the size being loaded per each work it
         	  tensor_desc<16xuint8, #Scattered>, vector<16xi1> into vector<16xuint8>
 ```
 
-When a tensor_desc with chunk_size_per_lane attribute is loaded, the output vector must be 2D vector, with the chunk being treated as a new dimension. The consecutive 1D tensor data being loaded can be viewed as a 2D tensor loaded with transposition, with the chunk dimension transposed to the outer dimension. User must use a chunk_size larger than 1. The transpose=[1,0] attribute must be present when chunk_size_per_lane is used. 
+When a tensor_desc with chunk_size_per_lane attribute is loaded, the output vector must be 2D vector, with the chunk being treated as a new dimension. The consecutive 1D tensor data being loaded can be viewed as a 2D tensor loaded with transposition, with the chunk dimension transposed to the outer dimension. User must use a chunk_size larger than 1. The transpose=[1,0] attribute must be present when chunk_size_per_lane is used.
 
 ```mlir
   #tdesc_attr = !xegpu.tdesc_attr< memory_scope=slm, scattered=true, chunk_size_per_lane=8>

--- a/docs/rfcs/XeGPU.md
+++ b/docs/rfcs/XeGPU.md
@@ -222,7 +222,7 @@ Attribute `chunk_size_per_lane` specifies the size being loaded per each work it
         	  tensor_desc<16xuint8, #Scattered>, vector<16xi1> into vector<16xuint8>
 ```
 
-When a tensor_desc with chunk_size_per_lane attribute is loaded, the output vector must be 2D vector, with the chunk being treated as a new dimension. The consecutive 1D tensor data being loaded can be viewed as a 2D tensor loaded with transposition, with the chunk dimension transposed to the outer dimension.
+When a tensor_desc with chunk_size_per_lane attribute is loaded, the output vector must be 2D vector, with the chunk being treated as a new dimension. The consecutive 1D tensor data being loaded can be viewed as a 2D tensor loaded with transposition, with the chunk dimension transposed to the outer dimension. The transpose=[1,0] attribute must be present when chunk_size_per_lane is larger than 1. 
 
 ```mlir
   #tdesc_attr = !xegpu.tdesc_attr< memory_scope=slm, scattered=true, chunk_size_per_lane=8>

--- a/docs/rfcs/XeGPU.md
+++ b/docs/rfcs/XeGPU.md
@@ -222,7 +222,7 @@ Attribute `chunk_size_per_lane` specifies the size being loaded per each work it
         	  tensor_desc<16xuint8, #Scattered>, vector<16xi1> into vector<16xuint8>
 ```
 
-When a tensor_desc with chunk_size_per_lane attribute is loaded, the output vector must be 2D vector, with the chunk being treated as a new dimension. The consecutive 1D tensor data being loaded can be viewed as a 2D tensor loaded with transposition, with the chunk dimension transposed to the outer dimension. The transpose=[1,0] attribute must be present when chunk_size_per_lane is larger than 1. 
+When a tensor_desc with chunk_size_per_lane attribute is loaded, the output vector must be 2D vector, with the chunk being treated as a new dimension. The consecutive 1D tensor data being loaded can be viewed as a 2D tensor loaded with transposition, with the chunk dimension transposed to the outer dimension. User must use a chunk_size larger than 1. The transpose=[1,0] attribute must be present when chunk_size_per_lane is used. 
 
 ```mlir
   #tdesc_attr = !xegpu.tdesc_attr< memory_scope=slm, scattered=true, chunk_size_per_lane=8>


### PR DESCRIPTION
Associate chunk_size_per_lane with the tensor_desc, to facilitate the lowering of load_gather and store_scatter.  

Currently the lowering of load_gather/store_scatter infer the chunk_size_per_lane by computing number of elements being load by 16, which is error-prone.  "chunk_size_per_lane" should be included as part of tensor_desc, since it helps describes how the linear 1D memory is viewed as 2D memory (16x8xuint16 in the example below). 

  #tdesc_attr = !xegpu.tdesc_attr< memory_scope=slm, scattered=true, chunk_size_per_lane=8>
  %scatter_tdesc_chunk = XeGPU.create_tdesc, %base_addr, %offsets { mode = vc} :
		uint64, vector<16xindex> into tensor_desc<16x8xuint16, #tdesc_attr>