### PR TITLE
Update blocking pass to support slm

### DIFF
--- a/include/imex/Conversion/XeTileToXeGPU/XeTileToXeGPUConversion.h
+++ b/include/imex/Conversion/XeTileToXeGPU/XeTileToXeGPUConversion.h
@@ -159,12 +159,14 @@ public:
     // (convertedTypes.size() == 1) we will reuse the current value. Otherwise,
     // it has one-to-n mapping, and the new value should be an
     // UnrealizedConversionCastOp.
-    for (auto &value : remappedValues) {
+    for (size_t i = 0; i < remappedValues.size(); i++) {
+      auto value = remappedValues[i];
       auto castOp = value.getDefiningOp<mlir::UnrealizedConversionCastOp>();
-      if (castOp && castOp.getInputs().size() > 1)
+      auto valueTy = value.getType();
+      if (castOp && valueTy == op->getOperand(i).getType())
         convertedValues.push_back(castOp.getInputs());
       else
-        convertedValues.push_back(value);
+        convertedValues.push_back(remappedValues[i]);
     }
 
     auto sourceOp = llvm::dyn_cast<SourceOp>(op);

--- a/include/imex/Dialect/XeTile/IR/XeTileOps.h
+++ b/include/imex/Dialect/XeTile/IR/XeTileOps.h
@@ -14,7 +14,6 @@
 
 #ifndef _XETILE_OPS_H_INCLUDED_
 #define _XETILE_OPS_H_INCLUDED_
-
 #include <mlir/Dialect/Vector/IR/VectorOps.h>
 #include <mlir/IR/BuiltinTypeInterfaces.h>
 #include <mlir/IR/BuiltinTypes.h>

--- a/include/imex/Dialect/XeTile/IR/XeTileTypes.td
+++ b/include/imex/Dialect/XeTile/IR/XeTileTypes.td
@@ -146,7 +146,7 @@ def XeTile : XeTile_Type<"Tile", "tile", [ShapedTypeInterface],
 def XeTile_IntType : AnyTypeOf<[I1, I8, I16, I32, I64, SI1, SI8, SI16, SI32, SI64, UI1, UI8, UI16, UI32, UI64]>;
 
 // Float types allowed in XeTile
-def XeTile_FloatType : AnyTypeOf<[F16, F32, F64, BF16, TF32]>;
+def XeTile_FloatType : AnyTypeOf<[F8E5M2, F16, F32, F64, BF16, TF32]>;
 
 // Define the scalar type for XeTile
 def XeTile_ScalarType : AnyTypeOf<[XeTile_IntType, XeTile_FloatType]>;

--- a/include/imex/Utils/XeCommon.h
+++ b/include/imex/Utils/XeCommon.h
@@ -268,8 +268,9 @@ private:
 
       auto *op = getDefineOrParentOp(value);
 
-      // stop when meet a function.
-      if (!op || llvm::isa<mlir::FunctionOpInterface>(op))
+      // stop when meet a function or ops, e.g., arith.truncf.
+      if (!op || llvm::isa<mlir::FunctionOpInterface>(op) ||
+          llvm::isa<mlir::CastOpInterface>(op))
         continue;
 
       OpAttrMap[value] = attr;

--- a/lib/Conversion/XeTileToXeGPU/XeTileOpConversion.cpp
+++ b/lib/Conversion/XeTileToXeGPU/XeTileOpConversion.cpp
@@ -637,7 +637,7 @@ struct SgLoadTileOpPattern : public XeOneToNConversion<xetile::LoadTileOp> {
       bool isPowerOf2 = (width & (width - 1)) == 0;
       return isPowerOf2 & (width < 32) & (width > 1);
     };
-    if (isForDPASB(op) && factor > 1)
+    if (isForDPASB(op) && factor > 1 && blockSZ[0] >= factor)
       vnniAttr = mlir::UnitAttr::get(ctx);
 
     mlir::DenseI64ArrayAttr transposeAttr;
@@ -659,6 +659,12 @@ struct SgLoadTileOpPattern : public XeOneToNConversion<xetile::LoadTileOp> {
     } else {
       return ((mlir::PatternRewriter &)rewriter)
           .notifyMatchFailure(op, "Unsupported order");
+    }
+
+    // vnni and transpose are not available for SLM memory scope.
+    if (tileTy.getMemoryScopeAsInt() == 3) {
+      vnniAttr = nullptr;
+      transposeBitWidthAttr = nullptr;
     }
 
     rewriter.setInsertionPoint(op);

--- a/lib/Utils/XeArch.cpp
+++ b/lib/Utils/XeArch.cpp
@@ -303,6 +303,10 @@ mlir::LogicalResult XeuArchInterface::isLegalLoad2dOp(mlir::Operation *op) {
   if (auto loadOp = llvm::dyn_cast<mlir::xegpu::LoadNdOp>(op)) {
     auto tdescTy = loadOp.getTensorDescType();
 
+    // TODO: need more thinking on SLM
+    if (tdescTy.getMemoryScope() == mlir::xegpu::MemoryScope::SLM)
+      return mlir::success();
+
     int elementSize = loadOp.getTensorDescType().getElementTypeBitWidth();
 
     LoadStore2DConfig loadParams;
@@ -341,6 +345,10 @@ mlir::LogicalResult XeuArchInterface::isLegalStore2dOp(mlir::Operation *op) {
   if (auto storeOp = llvm::dyn_cast<mlir::xegpu::StoreNdOp>(op)) {
     auto tdescTy = storeOp.getTensorDescType();
     int elementSize = tdescTy.getElementTypeBitWidth();
+
+    // TODO: need more thinking on SLM
+    if (tdescTy.getMemoryScope() == mlir::xegpu::MemoryScope::SLM)
+      return mlir::success();
 
     LoadStore2DConfig storeParams;
     bool vnni = false;

--- a/test/Conversion/XeTileToXeGPU/sg_gemm_1k_1k_1k_f16_f32_slm.mlir
+++ b/test/Conversion/XeTileToXeGPU/sg_gemm_1k_1k_1k_f16_f32_slm.mlir
@@ -1,0 +1,119 @@
+// RUN: imex-opt --split-input-file --xetile-init-duplicate --xetile-blocking --canonicalize \
+// RUN: --cse --convert-xetile-to-xegpu --cse %s -o -| FileCheck %s
+
+
+#tile_attr = #xetile.tile_attr<memory_scope = 3>
+
+// CHECK-LABEL: gpu.module @test_kernel {
+gpu.module @test_kernel {
+
+  //CHECK: gpu.func @test_gemm(%[[arg0:.*]]: memref<128x128xf16, 3>, %[[arg1:.*]]: memref<128x128xf16, 3>, %[[arg2:.*]]: memref<128x128xf32>)
+  gpu.func @test_gemm(%arg0: memref<128x128xf16, 3>, %arg1: memref<128x128xf16, 3>, %arg2: memref<128x128xf32>) {
+    //CHECK: %[[c0:.*]] = arith.constant 0 : index
+    //CHECK: %[[c16:.*]] = arith.constant 16 : index
+    //CHECK: %[[c128:.*]] = arith.constant 128 : index
+    //CHECK: %[[block_id_x:.*]] = gpu.block_id  x
+    //CHECK: %[[block_id_y:.*]] = gpu.block_id  y
+    //CHECK: %[[r0:.*]] = arith.muli %[[block_id_x]], %[[c16]] : index
+    //CHECK: %[[r1:.*]] = arith.muli %[[block_id_y]], %[[c16]] : index
+    //CHECK: %[[r2:.*]] = arith.addi %[[r0]], %[[c0]] : index
+    //CHECK: %[[r3:.*]] = arith.addi %[[r1]], %[[c0]] : index
+    %c0 = arith.constant 0 : index
+    %c16 = arith.constant 16 : index
+    %c128 = arith.constant 128 : index
+    %block_id_x = gpu.block_id  x
+    %block_id_y = gpu.block_id  y
+    %0 = arith.muli %block_id_x, %c16 : index
+    %1 = arith.muli %block_id_y, %c16 : index
+
+    //CHECK: %[[r4:.*]] = xegpu.create_nd_tdesc %[[arg2]][%[[r2]], %[[r3]]] : memref<128x128xf32> -> !xegpu.tensor_desc<8x16xf32, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 1 : i64, boundary_check = true>>
+    //CHECK: %[[r5:.*]] = xegpu.load_nd %[[r4]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>}> : !xegpu.tensor_desc<8x16xf32, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 1 : i64, boundary_check = true>> -> vector<8x16xf32>
+    %2 = xetile.init_tile %arg2[%0, %1] : memref<128x128xf32> -> !xetile.tile<8x16xf32>
+    %3 = xetile.load_tile %2 { padding = 0.000000e+00 : f32 }  : !xetile.tile<8x16xf32> -> vector<8x16xf32>
+
+    //CHECK: %[[r6:.*]] = xegpu.create_nd_tdesc %[[arg0]][%[[r2]], %[[c0]]] : memref<128x128xf16, 3> -> !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+    //CHECK: %[[c1:.*]] = arith.constant 1 : index
+    //CHECK: %[[r7:.*]] = arith.addi %[[r0]], %[[c1]] : index
+    //CHECK: %[[r8:.*]] = xegpu.create_nd_tdesc %[[arg0]][%[[r7]], %[[c0]]] : memref<128x128xf16, 3> -> !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+    //CHECK: %[[c2:.*]] = arith.constant 2 : index
+    //CHECK: %[[r9:.*]] = arith.addi %[[r0]], %[[c2]] : index
+    //CHECK: %[[r10:.*]] = xegpu.create_nd_tdesc %[[arg0]][%[[r9]], %[[c0]]] : memref<128x128xf16, 3> -> !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+    //CHECK: %[[c3:.*]] = arith.constant 3 : index
+    //CHECK: %[[r11:.*]] = arith.addi %[[r0]], %[[c3]] : index
+    //CHECK: %[[r12:.*]] = xegpu.create_nd_tdesc %[[arg0]][%[[r11]], %[[c0]]] : memref<128x128xf16, 3> -> !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+    //CHECK: %[[c4:.*]] = arith.constant 4 : index
+    //CHECK: %[[r13:.*]] = arith.addi %[[r0]], %[[c4]] : index
+    //CHECK: %[[r14:.*]] = xegpu.create_nd_tdesc %[[arg0]][%[[r13]], %[[c0]]] : memref<128x128xf16, 3> -> !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+    //CHECK: %[[c5:.*]] = arith.constant 5 : index
+    //CHECK: %[[r15:.*]] = arith.addi %[[r0]], %[[c5]] : index
+    //CHECK: %[[r16:.*]] = xegpu.create_nd_tdesc %[[arg0]][%[[r15]], %[[c0]]] : memref<128x128xf16, 3> -> !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+    //CHECK: %[[c6:.*]] = arith.constant 6 : index
+    //CHECK: %[[r17:.*]] = arith.addi %[[r0]], %[[c6]] : index
+    //CHECK: %[[r18:.*]] = xegpu.create_nd_tdesc %[[arg0]][%[[r17]], %[[c0]]] : memref<128x128xf16, 3> -> !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+    //CHECK: %[[c7:.*]] = arith.constant 7 : index
+    //CHECK: %[[r19:.*]] = arith.addi %[[r0]], %[[c7]] : index
+    //CHECK: %[[r20:.*]] = xegpu.create_nd_tdesc %[[arg0]][%[[r19]], %[[c0]]] : memref<128x128xf16, 3> -> !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+    %4 = xetile.init_tile %arg0[%0, %c0] : memref<128x128xf16, 3> -> !xetile.tile<8x16xf16, #tile_attr>
+
+
+    //CHECK: %[[r21:.*]] = xegpu.create_nd_tdesc %[[arg1]][%[[c0]], %[[r3]]] : memref<128x128xf16, 3> -> !xegpu.tensor_desc<16x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+    %5 = xetile.init_tile %arg1[%c0, %1] : memref<128x128xf16, 3> -> !xetile.tile<16x16xf16, #tile_attr>
+
+    //CHECK: %[[r37:.*]]:10 = scf.for %[[arg3:.*]] = %[[c0]] to %[[c128]] step %[[c16]]
+    //CHECK-SAME: iter_args(%[[arg4:.*]] = %[[r6]], %[[arg5:.*]] = %[[r8]], %[[arg6:.*]] = %[[r10]],
+    //CHECK-SAME: %[[arg7:.*]] = %[[r12]], %[[arg8:.*]] = %[[r14]], %[[arg9:.*]] = %[[r16]],
+    //CHECK-SAME: %[[arg10:.*]] = %[[r18]], %[[arg11:.*]] = %[[r20]], %[[arg12:.*]] = %[[r21]],
+    //CHECK-SAME: %[[arg28:.*]] = %[[r5]])
+    //CHECK-SAME: !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>,
+    //CHECK-SAME: !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>,
+    //CHECK-SAME: !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>,
+    //CHECK-SAME: !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>,
+    //CHECK-SAME: !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>,
+    //CHECK-SAME: !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>,
+    //CHECK-SAME: !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>,
+    //CHECK-SAME: !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>,
+    //CHECK-SAME: !xegpu.tensor_desc<16x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>, vector<8x16xf32>
+    %6:3 = scf.for %arg3 = %c0 to %c128 step %c16 iter_args(%arg4 = %4, %arg5 = %5, %arg6 = %3)
+          -> (!xetile.tile<8x16xf16, #tile_attr>, !xetile.tile<16x16xf16, #tile_attr>, vector<8x16xf32>) {
+      //CHECK: %[[r38:.*]] = xegpu.load_nd %[[arg4]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>}> : !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>> -> vector<1x16xf16>
+      //CHECK: %[[r39:.*]] = xegpu.load_nd %[[arg5]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>}> : !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>> -> vector<1x16xf16>
+      //CHECK: %[[r40:.*]] = xegpu.load_nd %[[arg6]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>}> : !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>> -> vector<1x16xf16>
+      //CHECK: %[[r41:.*]] = xegpu.load_nd %[[arg7]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>}> : !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>> -> vector<1x16xf16>
+      //CHECK: %[[r42:.*]] = xegpu.load_nd %[[arg8]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>}> : !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>> -> vector<1x16xf16>
+      //CHECK: %[[r43:.*]] = xegpu.load_nd %[[arg9]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>}> : !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>> -> vector<1x16xf16>
+      //CHECK: %[[r44:.*]] = xegpu.load_nd %[[arg10]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>}> : !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>> -> vector<1x16xf16>
+      //CHECK: %[[r45:.*]] = xegpu.load_nd %[[arg11]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>}> : !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>> -> vector<1x16xf16>
+      //CHECK: %[[r46:.*]] = vector.shuffle %[[r38]], %[[r39]] [0, 1] : vector<1x16xf16>, vector<1x16xf16>
+      //CHECK: %[[r47:.*]] = vector.shuffle %[[r40]], %[[r41]] [0, 1] : vector<1x16xf16>, vector<1x16xf16>
+      //CHECK: %[[r48:.*]] = vector.shuffle %[[r42]], %[[r43]] [0, 1] : vector<1x16xf16>, vector<1x16xf16>
+      //CHECK: %[[r49:.*]] = vector.shuffle %[[r44]], %[[r45]] [0, 1] : vector<1x16xf16>, vector<1x16xf16>
+      //CHECK: %[[r50:.*]] = vector.shuffle %[[r46]], %[[r47]] [0, 1, 2, 3] : vector<2x16xf16>, vector<2x16xf16>
+      //CHECK: %[[r51:.*]] = vector.shuffle %[[r48]], %[[r49]] [0, 1, 2, 3] : vector<2x16xf16>, vector<2x16xf16>
+      //CHECK: %[[r52:.*]] = vector.shuffle %[[r50]], %[[r51]] [0, 1, 2, 3, 4, 5, 6, 7] : vector<4x16xf16>, vector<4x16xf16>
+      %7 = xetile.load_tile %arg4 { padding = 0.000000e+00 : f32 }  : !xetile.tile<8x16xf16, #tile_attr> -> vector<8x16xf16>
+
+      //CHECK: %[[r53:.*]] = xegpu.load_nd %[[arg12]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>}> : !xegpu.tensor_desc<16x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>> -> vector<16x16xf16>
+      %8 = xetile.load_tile %arg5 { padding = 0.000000e+00 : f32 }  : !xetile.tile<16x16xf16, #tile_attr> -> vector<16x16xf16>
+
+
+      //CHECK: %[[r84:.*]] = xegpu.dpas %[[r52]], %[[r53]], %[[arg28]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      %9 = xetile.tile_mma %7, %8, %arg6 : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+
+      //CHECK: %[[r85:.*]] = xegpu.update_nd_offset %[[arg4]], [%[[c0]], %[[c16]]] : !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+      //CHECK: %[[r86:.*]] = xegpu.update_nd_offset %[[arg5]], [%[[c0]], %[[c16]]] : !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+      //CHECK: %[[r87:.*]] = xegpu.update_nd_offset %[[arg6]], [%[[c0]], %[[c16]]] : !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+      //CHECK: %[[r88:.*]] = xegpu.update_nd_offset %[[arg7]], [%[[c0]], %[[c16]]] : !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+      //CHECK: %[[r89:.*]] = xegpu.update_nd_offset %[[arg8]], [%[[c0]], %[[c16]]] : !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+      //CHECK: %[[r90:.*]] = xegpu.update_nd_offset %[[arg9]], [%[[c0]], %[[c16]]] : !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+      //CHECK: %[[r91:.*]] = xegpu.update_nd_offset %[[arg10]], [%[[c0]], %[[c16]]] : !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+      //CHECK: %[[r92:.*]] = xegpu.update_nd_offset %[[arg11]], [%[[c0]], %[[c16]]] : !xegpu.tensor_desc<1x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+      %10 = xetile.update_tile_offset %arg4, [%c0,  %c16] : !xetile.tile<8x16xf16, #tile_attr>, index, index -> !xetile.tile<8x16xf16, #tile_attr>
+      //CHECK: %[[r108:.*]] = xegpu.update_nd_offset %[[arg12]], [%[[c16]], %[[c0]]] : !xegpu.tensor_desc<16x16xf16, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+      %11 = xetile.update_tile_offset %arg5, [%c16,  %c0] : !xetile.tile<16x16xf16, #tile_attr>, index, index -> !xetile.tile<16x16xf16, #tile_attr>
+      scf.yield %10, %11, %9 : !xetile.tile<8x16xf16, #tile_attr>, !xetile.tile<16x16xf16, #tile_attr>, vector<8x16xf32>
+    }
+    //CHECK: xegpu.store_nd %[[r37]]#9, %[[r4]] <{l1_hint = #xegpu.cache_hint<write_back>, l2_hint = #xegpu.cache_hint<write_back>, l3_hint = #xegpu.cache_hint<write_back>}> : vector<8x16xf32>, !xegpu.tensor_desc<8x16xf32, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 1 : i64, boundary_check = true>>
+    xetile.store_tile %6#2,  %2 : vector<8x16xf32>, !xetile.tile<8x16xf32>
+    gpu.return
+  }
+}

--- a/test/Conversion/XeTileToXeGPU/sg_mixed_scf.mlir
+++ b/test/Conversion/XeTileToXeGPU/sg_mixed_scf.mlir
@@ -101,18 +101,21 @@ gpu.module @postop_reduce_m attributes {spirv.target_env = #spirv.target_env<#sp
         %41 = vector.shape_cast %40 : vector<32xf32> to vector<1x32xf32>
         %alloc = memref.alloc() : memref<8x128xf32, 3>
 
-        //CHECK: %{{.*}} = xegpu.create_nd_tdesc %{{.*}} : memref<8x128xf32, 3> -> !xegpu.tensor_desc<1x16xf32, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
-        //CHECK: %{{.*}} = arith.addi %{{.*}}, %{{.*}} : index
-        //CHECK: %{{.*}} = xegpu.create_nd_tdesc %{{.*}} : memref<8x128xf32, 3> -> !xegpu.tensor_desc<1x16xf32, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+        //CHECK: %{{.*}} = xegpu.create_nd_tdesc %{{.*}} : memref<8x128xf32, 3> -> !xegpu.tensor_desc<1x32xf32, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
         %42 = xetile.init_tile %alloc[%17, %13] : memref<8x128xf32, 3> -> !xetile.tile<1x32xf32, #xetile.tile_attr<memory_scope = 3>>
 
-        //CHECK-COUNT-2: vector.extract_strided_slice %{{.*}} {offsets = {{.*}}, sizes = [1, 16], strides = [1, 1]} : vector<1x32xf32> to vector<1x16xf32>
-        //CHECK-COUNT-2: xegpu.store_nd %{{.*}}, %{{.*}} <{l1_hint = #xegpu.cache_hint<write_back>, l2_hint = #xegpu.cache_hint<write_back>, l3_hint = #xegpu.cache_hint<write_back>}> : vector<1x16xf32>, !xegpu.tensor_desc<1x16xf32, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+        //CHECK: xegpu.store_nd %{{.*}}, %{{.*}} <{l1_hint = #xegpu.cache_hint<write_back>, l2_hint = #xegpu.cache_hint<write_back>, l3_hint = #xegpu.cache_hint<write_back>}> : vector<1x32xf32>, !xegpu.tensor_desc<1x32xf32, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
         xetile.store_tile %41,  %42 : vector<1x32xf32>, !xetile.tile<1x32xf32, #xetile.tile_attr<memory_scope = 3>>
 
-        //CHECK: xegpu.create_nd_tdesc %{{.*}} : memref<8x128xf32, 3> -> !xegpu.tensor_desc<8x4xf32, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
-        //CHECK: xegpu.load_nd {{.*}} <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>}> : !xegpu.tensor_desc<8x4xf32, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>> -> vector<8x4xf32>
-        //CHECK-COUNT-8: vector.extract_strided_slice %{{.*}} {offsets = {{.*}}, sizes = [1, 4], strides = [1, 1]} : vector<8x4xf32> to vector<1x4xf32>
+        //CHECK: xegpu.create_nd_tdesc %{{.*}} : memref<8x128xf32, 3> -> !xegpu.tensor_desc<1x4xf32, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+        //CHECK: xegpu.create_nd_tdesc %{{.*}} : memref<8x128xf32, 3> -> !xegpu.tensor_desc<1x4xf32, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+        //CHECK: xegpu.create_nd_tdesc %{{.*}} : memref<8x128xf32, 3> -> !xegpu.tensor_desc<1x4xf32, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+        //CHECK: xegpu.create_nd_tdesc %{{.*}} : memref<8x128xf32, 3> -> !xegpu.tensor_desc<1x4xf32, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+        //CHECK: xegpu.create_nd_tdesc %{{.*}} : memref<8x128xf32, 3> -> !xegpu.tensor_desc<1x4xf32, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+        //CHECK: xegpu.create_nd_tdesc %{{.*}} : memref<8x128xf32, 3> -> !xegpu.tensor_desc<1x4xf32, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+        //CHECK: xegpu.create_nd_tdesc %{{.*}} : memref<8x128xf32, 3> -> !xegpu.tensor_desc<1x4xf32, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+        //CHECK: xegpu.create_nd_tdesc %{{.*}} : memref<8x128xf32, 3> -> !xegpu.tensor_desc<1x4xf32, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>>
+        //CHECK-COUNT-8: xegpu.load_nd {{.*}} <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>}> : !xegpu.tensor_desc<1x4xf32, #xegpu.block_tdesc_attr<memory_scope =  slm, array_length = 1 : i64, boundary_check = true>> -> vector<1x4xf32>
         //CHECK-COUNT-8: arith.addf %{{.*}}, %{{.*}} : vector<1x4xf32>
         %43 = xetile.init_tile %alloc[%21, %23] : memref<8x128xf32, 3> -> !xetile.tile<8x4xf32, #xetile.tile_attr<memory_scope = 3>>
         %44 = xetile.load_tile %43 { padding = 0.000000e+00 : f32 }  : !xetile.tile<8x4xf32, #xetile.tile_attr<memory_scope = 3>> -> vector<8x4xf32>

--- a/test/Dialect/XeTile/Transforms/sg_gemm_1k_1k_1k_f16_f32_slm.mlir
+++ b/test/Dialect/XeTile/Transforms/sg_gemm_1k_1k_1k_f16_f32_slm.mlir
@@ -1,0 +1,45 @@
+// RUN: imex-opt --xetile-init-duplicate --xetile-blocking --canonicalize --cse %s | FileCheck %s
+
+#slm = #xetile.tile_attr<memory_scope = 3>
+
+// CHECK-LABEL: gpu.module @test_kernel {
+gpu.module @test_kernel {
+  //CHECK: gpu.func @test_gemm(%[[arg0:.*]]: memref<128x128xf16, 3>, %[[arg1:.*]]: memref<128x128xf16, 3>, %[[arg2:.*]]: memref<128x128xf32>) {
+  gpu.func @test_gemm(%arg0: memref<128x128xf16, 3>, %arg1: memref<128x128xf16, 3>, %arg2: memref<128x128xf32>) {
+    //CHECK: %[[c0:.*]] = arith.constant 0 : index
+    %c0 = arith.constant 0 : index
+    //CHECK: %[[c16:.*]] = arith.constant 16 : index
+    %c16 = arith.constant 16 : index
+    %c128 = arith.constant 128 : index
+
+    //CHECK: %[[block_id_x:.*]] = gpu.block_id  x
+    //CHECK: %[[block_id_y:.*]] = gpu.block_id  y
+    //CHECK: %[[r0:.*]] = arith.muli %block_id_x, %[[c16]] : index
+    //CHECK: %[[r1:.*]] = arith.muli %block_id_y, %[[c16]] : index
+    %block_id_x = gpu.block_id  x
+    %block_id_y = gpu.block_id  y
+    %0 = arith.muli %block_id_x, %c16 : index
+    %1 = arith.muli %block_id_y, %c16 : index
+
+    //CHECK: %[[r2:.*]] = xetile.init_tile %[[arg2]][%[[r0]], %[[r1]]] : memref<128x128xf32> -> !xetile.tile<8x16xf32, #xetile.tile_attr<inner_blocks = [8, 16]>>
+    //CHECK: %[[r3:.*]] = xetile.load_tile %[[r2]] { padding = 0.000000e+00 : f32 }  : !xetile.tile<8x16xf32, #xetile.tile_attr<inner_blocks = [8, 16]>> -> vector<1x1x8x16xf32>
+    %2 = xetile.init_tile %arg2[%0, %1] : memref<128x128xf32> -> !xetile.tile<8x16xf32>
+    %3 = xetile.load_tile %2 { padding = 0.000000e+00 : f32 }  : !xetile.tile<8x16xf32> -> vector<8x16xf32>
+
+    //CHECK: %[[r5:.*]] = xetile.init_tile %[[arg0]][%[[r0]], %[[c0]]] : memref<128x128xf16, 3> -> !xetile.tile<8x16xf16, #xetile.tile_attr<inner_blocks = [1, 16], memory_scope = 3 : i64>>
+    //CHECK: %[[r6:.*]] = xetile.init_tile %[[arg1]][%[[c0]], %[[r1]]] : memref<128x128xf16, 3> -> !xetile.tile<16x16xf16, #xetile.tile_attr<inner_blocks = [16, 16], memory_scope = 3 : i64>>
+    %4 = xetile.init_tile %arg0[%0, %c0] : memref<128x128xf16, 3> -> !xetile.tile<8x16xf16, #slm>
+    %5 = xetile.init_tile %arg1[%c0, %1] : memref<128x128xf16, 3> -> !xetile.tile<16x16xf16, #slm>
+    %6:3 = scf.for %arg3 = %c0 to %c128 step %c16 iter_args(%arg4 = %4, %arg5 = %5, %arg6 = %3)
+          -> (!xetile.tile<8x16xf16, #slm>, !xetile.tile<16x16xf16, #slm>, vector<8x16xf32>) {
+      %7 = xetile.load_tile %arg4 { padding = 0.000000e+00 : f32 }  : !xetile.tile<8x16xf16, #slm> -> vector<8x16xf16>
+      %8 = xetile.load_tile %arg5 { padding = 0.000000e+00 : f32 }  : !xetile.tile<16x16xf16, #slm> -> vector<16x16xf16>
+      %9 = xetile.tile_mma %7, %8, %arg6 : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      %10 = xetile.update_tile_offset %arg4, [%c0,  %c16] : !xetile.tile<8x16xf16, #slm>, index, index -> !xetile.tile<8x16xf16, #slm>
+      %11 = xetile.update_tile_offset %arg5, [%c16,  %c0] : !xetile.tile<16x16xf16, #slm>, index, index -> !xetile.tile<16x16xf16, #slm>
+      scf.yield %10, %11, %9 : !xetile.tile<8x16xf16, #slm>, !xetile.tile<16x16xf16, #slm>, vector<8x16xf32>
+    }
+    xetile.store_tile %6#2,  %2 : vector<8x16xf32>, !xetile.tile<8x16xf32>
+    gpu.return
+  }
+}


### PR DESCRIPTION
Updated the getInnerBlockSize logic to support SLM. Since accesses (load/store) to SLM need to use different instructions and has different constraints as compared to block load/store operations.
