### PR TITLE
Remove vnni and transpose logic from XeTileToXeGPU

### DIFF
--- a/test/Conversion/XeTileToXeGPU/gemm_preop.mlir
+++ b/test/Conversion/XeTileToXeGPU/gemm_preop.mlir
@@ -71,7 +71,7 @@ module attributes {gpu.container_module} {
         %31 = xetile.update_tile_offset %arg6, [%c0,  %c32] : !xetile.tile<32x32xf16>, index, index -> !xetile.tile<32x32xf16>
         xegpu.compile_hint
 
-        // CHECK-COUNT-16: {{.*}} = xegpu.dpas {{.*}}, {{.*}}, {{.*}} : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+        // CHECK-COUNT-16: {{.*}} = xegpu.dpas {{.*}}, {{.*}}, {{.*}} : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
         %32 = xetile.tile_mma %29, %28, %arg7 : vector<32x32xf16>, vector<32x32xf16>, vector<32x32xf32> -> vector<32x32xf32>
         xegpu.compile_hint
         scf.yield %30, %31, %32 : !xetile.tile<32x32xf16>, !xetile.tile<32x32xf16>, vector<32x32xf32>

--- a/test/Conversion/XeTileToXeGPU/sg_gemm_1k_1k_1k_f16_f32.mlir
+++ b/test/Conversion/XeTileToXeGPU/sg_gemm_1k_1k_1k_f16_f32.mlir
@@ -198,165 +198,165 @@ gpu.module @test_kernel {
       //CHECK: %[[r148:.*]] = vector.extract_strided_slice %[[r116]] {offsets = [24, 0], sizes = [8, 16], strides = [1, 1]} : vector<32x16xf16> to vector<8x16xf16>
       %a_value = xetile.load_tile %a_tile : !xetile.tile<64x64xf16> -> vector<64x64xf16>
 
-      //CHECK: %[[r149:.*]] = xegpu.load_nd %[[arg8]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>, packed}> : !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 2 : i64, boundary_check = true>> -> vector<2x16x16x2xf16>
-      //CHECK: %[[r150:.*]] = vector.extract %[[r149]][0] : vector<16x16x2xf16> from vector<2x16x16x2xf16>
-      //CHECK: %[[r151:.*]] = vector.extract %[[r149]][1] : vector<16x16x2xf16> from vector<2x16x16x2xf16>
-      //CHECK: %[[r152:.*]] = xegpu.load_nd %[[arg9]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>, packed}> : !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 2 : i64, boundary_check = true>> -> vector<2x16x16x2xf16>
-      //CHECK: %[[r153:.*]] = vector.extract %[[r152]][0] : vector<16x16x2xf16> from vector<2x16x16x2xf16>
-      //CHECK: %[[r154:.*]] = vector.extract %[[r152]][1] : vector<16x16x2xf16> from vector<2x16x16x2xf16>
-      //CHECK: %[[r155:.*]] = xegpu.load_nd %[[arg10]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>, packed}> : !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 2 : i64, boundary_check = true>> -> vector<2x16x16x2xf16>
-      //CHECK: %[[r156:.*]] = vector.extract %[[r155]][0] : vector<16x16x2xf16> from vector<2x16x16x2xf16>
-      //CHECK: %[[r157:.*]] = vector.extract %[[r155]][1] : vector<16x16x2xf16> from vector<2x16x16x2xf16>
-      //CHECK: %[[r158:.*]] = xegpu.load_nd %[[arg11]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>, packed}> : !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 2 : i64, boundary_check = true>> -> vector<2x16x16x2xf16>
-      //CHECK: %[[r159:.*]] = vector.extract %[[r158]][0] : vector<16x16x2xf16> from vector<2x16x16x2xf16>
-      //CHECK: %[[r160:.*]] = vector.extract %[[r158]][1] : vector<16x16x2xf16> from vector<2x16x16x2xf16>
-      //CHECK: %[[r161:.*]] = vector.extract_strided_slice %[[r150]] {offsets = [0, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-      //CHECK: %[[r162:.*]] = vector.extract_strided_slice %[[r150]] {offsets = [8, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-      //CHECK: %[[r163:.*]] = vector.extract_strided_slice %[[r151]] {offsets = [0, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-      //CHECK: %[[r164:.*]] = vector.extract_strided_slice %[[r151]] {offsets = [8, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-      //CHECK: %[[r165:.*]] = vector.extract_strided_slice %[[r153]] {offsets = [0, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-      //CHECK: %[[r166:.*]] = vector.extract_strided_slice %[[r153]] {offsets = [8, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-      //CHECK: %[[r167:.*]] = vector.extract_strided_slice %[[r154]] {offsets = [0, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-      //CHECK: %[[r168:.*]] = vector.extract_strided_slice %[[r154]] {offsets = [8, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-      //CHECK: %[[r169:.*]] = vector.extract_strided_slice %[[r156]] {offsets = [0, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-      //CHECK: %[[r170:.*]] = vector.extract_strided_slice %[[r156]] {offsets = [8, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-      //CHECK: %[[r171:.*]] = vector.extract_strided_slice %[[r157]] {offsets = [0, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-      //CHECK: %[[r172:.*]] = vector.extract_strided_slice %[[r157]] {offsets = [8, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-      //CHECK: %[[r173:.*]] = vector.extract_strided_slice %[[r159]] {offsets = [0, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-      //CHECK: %[[r174:.*]] = vector.extract_strided_slice %[[r159]] {offsets = [8, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-      //CHECK: %[[r175:.*]] = vector.extract_strided_slice %[[r160]] {offsets = [0, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-      //CHECK: %[[r176:.*]] = vector.extract_strided_slice %[[r160]] {offsets = [8, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
+      //CHECK: %[[r149:.*]] = xegpu.load_nd %[[arg8]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>}> : !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 2 : i64, boundary_check = true>> -> vector<2x32x16xf16>
+      //CHECK: %[[r150:.*]] = vector.extract %[[r149]][0] : vector<32x16xf16> from vector<2x32x16xf16>
+      //CHECK: %[[r151:.*]] = vector.extract %[[r149]][1] : vector<32x16xf16> from vector<2x32x16xf16>
+      //CHECK: %[[r152:.*]] = xegpu.load_nd %[[arg9]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>}> : !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 2 : i64, boundary_check = true>> -> vector<2x32x16xf16>
+      //CHECK: %[[r153:.*]] = vector.extract %[[r152]][0] : vector<32x16xf16> from vector<2x32x16xf16>
+      //CHECK: %[[r154:.*]] = vector.extract %[[r152]][1] : vector<32x16xf16> from vector<2x32x16xf16>
+      //CHECK: %[[r155:.*]] = xegpu.load_nd %[[arg10]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>}> : !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 2 : i64, boundary_check = true>> -> vector<2x32x16xf16>
+      //CHECK: %[[r156:.*]] = vector.extract %[[r155]][0] : vector<32x16xf16> from vector<2x32x16xf16>
+      //CHECK: %[[r157:.*]] = vector.extract %[[r155]][1] : vector<32x16xf16> from vector<2x32x16xf16>
+      //CHECK: %[[r158:.*]] = xegpu.load_nd %[[arg11]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>}> : !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 2 : i64, boundary_check = true>> -> vector<2x32x16xf16>
+      //CHECK: %[[r159:.*]] = vector.extract %[[r158]][0] : vector<32x16xf16> from vector<2x32x16xf16>
+      //CHECK: %[[r160:.*]] = vector.extract %[[r158]][1] : vector<32x16xf16> from vector<2x32x16xf16>
+      //CHECK: %[[r161:.*]] = vector.extract_strided_slice %[[r150]] {offsets = [0, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+      //CHECK: %[[r162:.*]] = vector.extract_strided_slice %[[r150]] {offsets = [16, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+      //CHECK: %[[r163:.*]] = vector.extract_strided_slice %[[r151]] {offsets = [0, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+      //CHECK: %[[r164:.*]] = vector.extract_strided_slice %[[r151]] {offsets = [16, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+      //CHECK: %[[r165:.*]] = vector.extract_strided_slice %[[r153]] {offsets = [0, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+      //CHECK: %[[r166:.*]] = vector.extract_strided_slice %[[r153]] {offsets = [16, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+      //CHECK: %[[r167:.*]] = vector.extract_strided_slice %[[r154]] {offsets = [0, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+      //CHECK: %[[r168:.*]] = vector.extract_strided_slice %[[r154]] {offsets = [16, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+      //CHECK: %[[r169:.*]] = vector.extract_strided_slice %[[r156]] {offsets = [0, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+      //CHECK: %[[r170:.*]] = vector.extract_strided_slice %[[r156]] {offsets = [16, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+      //CHECK: %[[r171:.*]] = vector.extract_strided_slice %[[r157]] {offsets = [0, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+      //CHECK: %[[r172:.*]] = vector.extract_strided_slice %[[r157]] {offsets = [16, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+      //CHECK: %[[r173:.*]] = vector.extract_strided_slice %[[r159]] {offsets = [0, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+      //CHECK: %[[r174:.*]] = vector.extract_strided_slice %[[r159]] {offsets = [16, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+      //CHECK: %[[r175:.*]] = vector.extract_strided_slice %[[r160]] {offsets = [0, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+      //CHECK: %[[r176:.*]] = vector.extract_strided_slice %[[r160]] {offsets = [16, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
       %b_value = xetile.load_tile %b_tile : !xetile.tile<64x64xf16> -> vector<64x64xf16>
 
 
-      //CHECK: %[[r209:.*]] = xegpu.dpas %[[r117]], %[[r161]], %[[r177]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r210:.*]] = xegpu.dpas %[[r121]], %[[r162]], %[[r209]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r211:.*]] = xegpu.dpas %[[r125]], %[[r169]], %[[r210]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r212:.*]] = xegpu.dpas %[[r129]], %[[r170]], %[[r211]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r213:.*]] = xegpu.dpas %[[r117]], %[[r163]], %[[r181]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r214:.*]] = xegpu.dpas %[[r121]], %[[r164]], %[[r213]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r215:.*]] = xegpu.dpas %[[r125]], %[[r171]], %[[r214]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r216:.*]] = xegpu.dpas %[[r129]], %[[r172]], %[[r215]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r217:.*]] = xegpu.dpas %[[r117]], %[[r165]], %[[r185]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r218:.*]] = xegpu.dpas %[[r121]], %[[r166]], %[[r217]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r219:.*]] = xegpu.dpas %[[r125]], %[[r173]], %[[r218]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r220:.*]] = xegpu.dpas %[[r129]], %[[r174]], %[[r219]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r221:.*]] = xegpu.dpas %[[r117]], %[[r167]], %[[r189]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r222:.*]] = xegpu.dpas %[[r121]], %[[r168]], %[[r221]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r223:.*]] = xegpu.dpas %[[r125]], %[[r175]], %[[r222]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r224:.*]] = xegpu.dpas %[[r129]], %[[r176]], %[[r223]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r225:.*]] = xegpu.dpas %[[r118]], %[[r161]], %[[r178]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r226:.*]] = xegpu.dpas %[[r122]], %[[r162]], %[[r225]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r227:.*]] = xegpu.dpas %[[r126]], %[[r169]], %[[r226]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r228:.*]] = xegpu.dpas %[[r130]], %[[r170]], %[[r227]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r229:.*]] = xegpu.dpas %[[r118]], %[[r163]], %[[r182]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r230:.*]] = xegpu.dpas %[[r122]], %[[r164]], %[[r229]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r231:.*]] = xegpu.dpas %[[r126]], %[[r171]], %[[r230]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r232:.*]] = xegpu.dpas %[[r130]], %[[r172]], %[[r231]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r233:.*]] = xegpu.dpas %[[r118]], %[[r165]], %[[r186]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r234:.*]] = xegpu.dpas %[[r122]], %[[r166]], %[[r233]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r235:.*]] = xegpu.dpas %[[r126]], %[[r173]], %[[r234]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r236:.*]] = xegpu.dpas %[[r130]], %[[r174]], %[[r235]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r237:.*]] = xegpu.dpas %[[r118]], %[[r167]], %[[r190]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r238:.*]] = xegpu.dpas %[[r122]], %[[r168]], %[[r237]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r239:.*]] = xegpu.dpas %[[r126]], %[[r175]], %[[r238]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r240:.*]] = xegpu.dpas %[[r130]], %[[r176]], %[[r239]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r241:.*]] = xegpu.dpas %[[r119]], %[[r161]], %[[r179]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r242:.*]] = xegpu.dpas %[[r123]], %[[r162]], %[[r241]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r243:.*]] = xegpu.dpas %[[r127]], %[[r169]], %[[r242]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r244:.*]] = xegpu.dpas %[[r131]], %[[r170]], %[[r243]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r245:.*]] = xegpu.dpas %[[r119]], %[[r163]], %[[r183]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r246:.*]] = xegpu.dpas %[[r123]], %[[r164]], %[[r245]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r247:.*]] = xegpu.dpas %[[r127]], %[[r171]], %[[r246]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r248:.*]] = xegpu.dpas %[[r131]], %[[r172]], %[[r247]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r249:.*]] = xegpu.dpas %[[r119]], %[[r165]], %[[r187]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r250:.*]] = xegpu.dpas %[[r123]], %[[r166]], %[[r249]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r251:.*]] = xegpu.dpas %[[r127]], %[[r173]], %[[r250]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r252:.*]] = xegpu.dpas %[[r131]], %[[r174]], %[[r251]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r253:.*]] = xegpu.dpas %[[r119]], %[[r167]], %[[r191]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r254:.*]] = xegpu.dpas %[[r123]], %[[r168]], %[[r253]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r255:.*]] = xegpu.dpas %[[r127]], %[[r175]], %[[r254]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r256:.*]] = xegpu.dpas %[[r131]], %[[r176]], %[[r255]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r257:.*]] = xegpu.dpas %[[r120]], %[[r161]], %[[r180]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r258:.*]] = xegpu.dpas %[[r124]], %[[r162]], %[[r257]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r259:.*]] = xegpu.dpas %[[r128]], %[[r169]], %[[r258]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r260:.*]] = xegpu.dpas %[[r132]], %[[r170]], %[[r259]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r261:.*]] = xegpu.dpas %[[r120]], %[[r163]], %[[r184]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r262:.*]] = xegpu.dpas %[[r124]], %[[r164]], %[[r261]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r263:.*]] = xegpu.dpas %[[r128]], %[[r171]], %[[r262]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r264:.*]] = xegpu.dpas %[[r132]], %[[r172]], %[[r263]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r265:.*]] = xegpu.dpas %[[r120]], %[[r165]], %[[r188]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r266:.*]] = xegpu.dpas %[[r124]], %[[r166]], %[[r265]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r267:.*]] = xegpu.dpas %[[r128]], %[[r173]], %[[r266]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r268:.*]] = xegpu.dpas %[[r132]], %[[r174]], %[[r267]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r269:.*]] = xegpu.dpas %[[r120]], %[[r167]], %[[r192]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r270:.*]] = xegpu.dpas %[[r124]], %[[r168]], %[[r269]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r271:.*]] = xegpu.dpas %[[r128]], %[[r175]], %[[r270]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r272:.*]] = xegpu.dpas %[[r132]], %[[r176]], %[[r271]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r273:.*]] = xegpu.dpas %[[r133]], %[[r161]], %[[r193]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r274:.*]] = xegpu.dpas %[[r137]], %[[r162]], %[[r273]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r275:.*]] = xegpu.dpas %[[r141]], %[[r169]], %[[r274]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r276:.*]] = xegpu.dpas %[[r145]], %[[r170]], %[[r275]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r277:.*]] = xegpu.dpas %[[r133]], %[[r163]], %[[r197]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r278:.*]] = xegpu.dpas %[[r137]], %[[r164]], %[[r277]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r279:.*]] = xegpu.dpas %[[r141]], %[[r171]], %[[r278]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r280:.*]] = xegpu.dpas %[[r145]], %[[r172]], %[[r279]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r281:.*]] = xegpu.dpas %[[r133]], %[[r165]], %[[r201]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r282:.*]] = xegpu.dpas %[[r137]], %[[r166]], %[[r281]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r283:.*]] = xegpu.dpas %[[r141]], %[[r173]], %[[r282]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r284:.*]] = xegpu.dpas %[[r145]], %[[r174]], %[[r283]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r285:.*]] = xegpu.dpas %[[r133]], %[[r167]], %[[r205]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r286:.*]] = xegpu.dpas %[[r137]], %[[r168]], %[[r285]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r287:.*]] = xegpu.dpas %[[r141]], %[[r175]], %[[r286]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r288:.*]] = xegpu.dpas %[[r145]], %[[r176]], %[[r287]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r289:.*]] = xegpu.dpas %[[r134]], %[[r161]], %[[r194]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r290:.*]] = xegpu.dpas %[[r138]], %[[r162]], %[[r289]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r291:.*]] = xegpu.dpas %[[r142]], %[[r169]], %[[r290]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r292:.*]] = xegpu.dpas %[[r146]], %[[r170]], %[[r291]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r293:.*]] = xegpu.dpas %[[r134]], %[[r163]], %[[r198]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r294:.*]] = xegpu.dpas %[[r138]], %[[r164]], %[[r293]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r295:.*]] = xegpu.dpas %[[r142]], %[[r171]], %[[r294]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r296:.*]] = xegpu.dpas %[[r146]], %[[r172]], %[[r295]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r297:.*]] = xegpu.dpas %[[r134]], %[[r165]], %[[r202]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r298:.*]] = xegpu.dpas %[[r138]], %[[r166]], %[[r297]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r299:.*]] = xegpu.dpas %[[r142]], %[[r173]], %[[r298]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r300:.*]] = xegpu.dpas %[[r146]], %[[r174]], %[[r299]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r301:.*]] = xegpu.dpas %[[r134]], %[[r167]], %[[r206]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r302:.*]] = xegpu.dpas %[[r138]], %[[r168]], %[[r301]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r303:.*]] = xegpu.dpas %[[r142]], %[[r175]], %[[r302]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r304:.*]] = xegpu.dpas %[[r146]], %[[r176]], %[[r303]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r305:.*]] = xegpu.dpas %[[r135]], %[[r161]], %[[r195]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r306:.*]] = xegpu.dpas %[[r139]], %[[r162]], %[[r305]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r307:.*]] = xegpu.dpas %[[r143]], %[[r169]], %[[r306]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r308:.*]] = xegpu.dpas %[[r147]], %[[r170]], %[[r307]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r309:.*]] = xegpu.dpas %[[r135]], %[[r163]], %[[r199]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r310:.*]] = xegpu.dpas %[[r139]], %[[r164]], %[[r309]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r311:.*]] = xegpu.dpas %[[r143]], %[[r171]], %[[r310]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r312:.*]] = xegpu.dpas %[[r147]], %[[r172]], %[[r311]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r313:.*]] = xegpu.dpas %[[r135]], %[[r165]], %[[r203]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r314:.*]] = xegpu.dpas %[[r139]], %[[r166]], %[[r313]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r315:.*]] = xegpu.dpas %[[r143]], %[[r173]], %[[r314]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r316:.*]] = xegpu.dpas %[[r147]], %[[r174]], %[[r315]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r317:.*]] = xegpu.dpas %[[r135]], %[[r167]], %[[r207]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r318:.*]] = xegpu.dpas %[[r139]], %[[r168]], %[[r317]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r319:.*]] = xegpu.dpas %[[r143]], %[[r175]], %[[r318]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r320:.*]] = xegpu.dpas %[[r147]], %[[r176]], %[[r319]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r321:.*]] = xegpu.dpas %[[r136]], %[[r161]], %[[r196]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r322:.*]] = xegpu.dpas %[[r140]], %[[r162]], %[[r321]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r323:.*]] = xegpu.dpas %[[r144]], %[[r169]], %[[r322]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r324:.*]] = xegpu.dpas %[[r148]], %[[r170]], %[[r323]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r325:.*]] = xegpu.dpas %[[r136]], %[[r163]], %[[r200]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r326:.*]] = xegpu.dpas %[[r140]], %[[r164]], %[[r325]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r327:.*]] = xegpu.dpas %[[r144]], %[[r171]], %[[r326]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r328:.*]] = xegpu.dpas %[[r148]], %[[r172]], %[[r327]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r329:.*]] = xegpu.dpas %[[r136]], %[[r165]], %[[r204]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r330:.*]] = xegpu.dpas %[[r140]], %[[r166]], %[[r329]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r331:.*]] = xegpu.dpas %[[r144]], %[[r173]], %[[r330]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r332:.*]] = xegpu.dpas %[[r148]], %[[r174]], %[[r331]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r333:.*]] = xegpu.dpas %[[r136]], %[[r167]], %[[r208]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r334:.*]] = xegpu.dpas %[[r140]], %[[r168]], %[[r333]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r335:.*]] = xegpu.dpas %[[r144]], %[[r175]], %[[r334]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-      //CHECK: %[[r336:.*]] = xegpu.dpas %[[r148]], %[[r176]], %[[r335]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r209:.*]] = xegpu.dpas %[[r117]], %[[r161]], %[[r177]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r210:.*]] = xegpu.dpas %[[r121]], %[[r162]], %[[r209]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r211:.*]] = xegpu.dpas %[[r125]], %[[r169]], %[[r210]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r212:.*]] = xegpu.dpas %[[r129]], %[[r170]], %[[r211]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r213:.*]] = xegpu.dpas %[[r117]], %[[r163]], %[[r181]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r214:.*]] = xegpu.dpas %[[r121]], %[[r164]], %[[r213]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r215:.*]] = xegpu.dpas %[[r125]], %[[r171]], %[[r214]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r216:.*]] = xegpu.dpas %[[r129]], %[[r172]], %[[r215]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r217:.*]] = xegpu.dpas %[[r117]], %[[r165]], %[[r185]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r218:.*]] = xegpu.dpas %[[r121]], %[[r166]], %[[r217]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r219:.*]] = xegpu.dpas %[[r125]], %[[r173]], %[[r218]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r220:.*]] = xegpu.dpas %[[r129]], %[[r174]], %[[r219]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r221:.*]] = xegpu.dpas %[[r117]], %[[r167]], %[[r189]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r222:.*]] = xegpu.dpas %[[r121]], %[[r168]], %[[r221]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r223:.*]] = xegpu.dpas %[[r125]], %[[r175]], %[[r222]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r224:.*]] = xegpu.dpas %[[r129]], %[[r176]], %[[r223]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r225:.*]] = xegpu.dpas %[[r118]], %[[r161]], %[[r178]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r226:.*]] = xegpu.dpas %[[r122]], %[[r162]], %[[r225]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r227:.*]] = xegpu.dpas %[[r126]], %[[r169]], %[[r226]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r228:.*]] = xegpu.dpas %[[r130]], %[[r170]], %[[r227]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r229:.*]] = xegpu.dpas %[[r118]], %[[r163]], %[[r182]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r230:.*]] = xegpu.dpas %[[r122]], %[[r164]], %[[r229]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r231:.*]] = xegpu.dpas %[[r126]], %[[r171]], %[[r230]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r232:.*]] = xegpu.dpas %[[r130]], %[[r172]], %[[r231]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r233:.*]] = xegpu.dpas %[[r118]], %[[r165]], %[[r186]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r234:.*]] = xegpu.dpas %[[r122]], %[[r166]], %[[r233]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r235:.*]] = xegpu.dpas %[[r126]], %[[r173]], %[[r234]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r236:.*]] = xegpu.dpas %[[r130]], %[[r174]], %[[r235]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r237:.*]] = xegpu.dpas %[[r118]], %[[r167]], %[[r190]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r238:.*]] = xegpu.dpas %[[r122]], %[[r168]], %[[r237]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r239:.*]] = xegpu.dpas %[[r126]], %[[r175]], %[[r238]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r240:.*]] = xegpu.dpas %[[r130]], %[[r176]], %[[r239]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r241:.*]] = xegpu.dpas %[[r119]], %[[r161]], %[[r179]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r242:.*]] = xegpu.dpas %[[r123]], %[[r162]], %[[r241]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r243:.*]] = xegpu.dpas %[[r127]], %[[r169]], %[[r242]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r244:.*]] = xegpu.dpas %[[r131]], %[[r170]], %[[r243]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r245:.*]] = xegpu.dpas %[[r119]], %[[r163]], %[[r183]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r246:.*]] = xegpu.dpas %[[r123]], %[[r164]], %[[r245]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r247:.*]] = xegpu.dpas %[[r127]], %[[r171]], %[[r246]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r248:.*]] = xegpu.dpas %[[r131]], %[[r172]], %[[r247]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r249:.*]] = xegpu.dpas %[[r119]], %[[r165]], %[[r187]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r250:.*]] = xegpu.dpas %[[r123]], %[[r166]], %[[r249]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r251:.*]] = xegpu.dpas %[[r127]], %[[r173]], %[[r250]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r252:.*]] = xegpu.dpas %[[r131]], %[[r174]], %[[r251]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r253:.*]] = xegpu.dpas %[[r119]], %[[r167]], %[[r191]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r254:.*]] = xegpu.dpas %[[r123]], %[[r168]], %[[r253]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r255:.*]] = xegpu.dpas %[[r127]], %[[r175]], %[[r254]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r256:.*]] = xegpu.dpas %[[r131]], %[[r176]], %[[r255]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r257:.*]] = xegpu.dpas %[[r120]], %[[r161]], %[[r180]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r258:.*]] = xegpu.dpas %[[r124]], %[[r162]], %[[r257]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r259:.*]] = xegpu.dpas %[[r128]], %[[r169]], %[[r258]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r260:.*]] = xegpu.dpas %[[r132]], %[[r170]], %[[r259]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r261:.*]] = xegpu.dpas %[[r120]], %[[r163]], %[[r184]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r262:.*]] = xegpu.dpas %[[r124]], %[[r164]], %[[r261]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r263:.*]] = xegpu.dpas %[[r128]], %[[r171]], %[[r262]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r264:.*]] = xegpu.dpas %[[r132]], %[[r172]], %[[r263]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r265:.*]] = xegpu.dpas %[[r120]], %[[r165]], %[[r188]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r266:.*]] = xegpu.dpas %[[r124]], %[[r166]], %[[r265]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r267:.*]] = xegpu.dpas %[[r128]], %[[r173]], %[[r266]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r268:.*]] = xegpu.dpas %[[r132]], %[[r174]], %[[r267]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r269:.*]] = xegpu.dpas %[[r120]], %[[r167]], %[[r192]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r270:.*]] = xegpu.dpas %[[r124]], %[[r168]], %[[r269]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r271:.*]] = xegpu.dpas %[[r128]], %[[r175]], %[[r270]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r272:.*]] = xegpu.dpas %[[r132]], %[[r176]], %[[r271]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r273:.*]] = xegpu.dpas %[[r133]], %[[r161]], %[[r193]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r274:.*]] = xegpu.dpas %[[r137]], %[[r162]], %[[r273]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r275:.*]] = xegpu.dpas %[[r141]], %[[r169]], %[[r274]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r276:.*]] = xegpu.dpas %[[r145]], %[[r170]], %[[r275]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r277:.*]] = xegpu.dpas %[[r133]], %[[r163]], %[[r197]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r278:.*]] = xegpu.dpas %[[r137]], %[[r164]], %[[r277]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r279:.*]] = xegpu.dpas %[[r141]], %[[r171]], %[[r278]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r280:.*]] = xegpu.dpas %[[r145]], %[[r172]], %[[r279]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r281:.*]] = xegpu.dpas %[[r133]], %[[r165]], %[[r201]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r282:.*]] = xegpu.dpas %[[r137]], %[[r166]], %[[r281]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r283:.*]] = xegpu.dpas %[[r141]], %[[r173]], %[[r282]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r284:.*]] = xegpu.dpas %[[r145]], %[[r174]], %[[r283]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r285:.*]] = xegpu.dpas %[[r133]], %[[r167]], %[[r205]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r286:.*]] = xegpu.dpas %[[r137]], %[[r168]], %[[r285]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r287:.*]] = xegpu.dpas %[[r141]], %[[r175]], %[[r286]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r288:.*]] = xegpu.dpas %[[r145]], %[[r176]], %[[r287]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r289:.*]] = xegpu.dpas %[[r134]], %[[r161]], %[[r194]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r290:.*]] = xegpu.dpas %[[r138]], %[[r162]], %[[r289]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r291:.*]] = xegpu.dpas %[[r142]], %[[r169]], %[[r290]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r292:.*]] = xegpu.dpas %[[r146]], %[[r170]], %[[r291]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r293:.*]] = xegpu.dpas %[[r134]], %[[r163]], %[[r198]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r294:.*]] = xegpu.dpas %[[r138]], %[[r164]], %[[r293]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r295:.*]] = xegpu.dpas %[[r142]], %[[r171]], %[[r294]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r296:.*]] = xegpu.dpas %[[r146]], %[[r172]], %[[r295]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r297:.*]] = xegpu.dpas %[[r134]], %[[r165]], %[[r202]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r298:.*]] = xegpu.dpas %[[r138]], %[[r166]], %[[r297]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r299:.*]] = xegpu.dpas %[[r142]], %[[r173]], %[[r298]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r300:.*]] = xegpu.dpas %[[r146]], %[[r174]], %[[r299]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r301:.*]] = xegpu.dpas %[[r134]], %[[r167]], %[[r206]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r302:.*]] = xegpu.dpas %[[r138]], %[[r168]], %[[r301]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r303:.*]] = xegpu.dpas %[[r142]], %[[r175]], %[[r302]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r304:.*]] = xegpu.dpas %[[r146]], %[[r176]], %[[r303]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r305:.*]] = xegpu.dpas %[[r135]], %[[r161]], %[[r195]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r306:.*]] = xegpu.dpas %[[r139]], %[[r162]], %[[r305]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r307:.*]] = xegpu.dpas %[[r143]], %[[r169]], %[[r306]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r308:.*]] = xegpu.dpas %[[r147]], %[[r170]], %[[r307]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r309:.*]] = xegpu.dpas %[[r135]], %[[r163]], %[[r199]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r310:.*]] = xegpu.dpas %[[r139]], %[[r164]], %[[r309]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r311:.*]] = xegpu.dpas %[[r143]], %[[r171]], %[[r310]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r312:.*]] = xegpu.dpas %[[r147]], %[[r172]], %[[r311]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r313:.*]] = xegpu.dpas %[[r135]], %[[r165]], %[[r203]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r314:.*]] = xegpu.dpas %[[r139]], %[[r166]], %[[r313]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r315:.*]] = xegpu.dpas %[[r143]], %[[r173]], %[[r314]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r316:.*]] = xegpu.dpas %[[r147]], %[[r174]], %[[r315]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r317:.*]] = xegpu.dpas %[[r135]], %[[r167]], %[[r207]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r318:.*]] = xegpu.dpas %[[r139]], %[[r168]], %[[r317]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r319:.*]] = xegpu.dpas %[[r143]], %[[r175]], %[[r318]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r320:.*]] = xegpu.dpas %[[r147]], %[[r176]], %[[r319]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r321:.*]] = xegpu.dpas %[[r136]], %[[r161]], %[[r196]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r322:.*]] = xegpu.dpas %[[r140]], %[[r162]], %[[r321]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r323:.*]] = xegpu.dpas %[[r144]], %[[r169]], %[[r322]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r324:.*]] = xegpu.dpas %[[r148]], %[[r170]], %[[r323]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r325:.*]] = xegpu.dpas %[[r136]], %[[r163]], %[[r200]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r326:.*]] = xegpu.dpas %[[r140]], %[[r164]], %[[r325]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r327:.*]] = xegpu.dpas %[[r144]], %[[r171]], %[[r326]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r328:.*]] = xegpu.dpas %[[r148]], %[[r172]], %[[r327]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r329:.*]] = xegpu.dpas %[[r136]], %[[r165]], %[[r204]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r330:.*]] = xegpu.dpas %[[r140]], %[[r166]], %[[r329]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r331:.*]] = xegpu.dpas %[[r144]], %[[r173]], %[[r330]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r332:.*]] = xegpu.dpas %[[r148]], %[[r174]], %[[r331]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r333:.*]] = xegpu.dpas %[[r136]], %[[r167]], %[[r208]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r334:.*]] = xegpu.dpas %[[r140]], %[[r168]], %[[r333]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r335:.*]] = xegpu.dpas %[[r144]], %[[r175]], %[[r334]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+      //CHECK: %[[r336:.*]] = xegpu.dpas %[[r148]], %[[r176]], %[[r335]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
 
       %c_new_value = xetile.tile_mma %a_value, %b_value, %c_value : vector<64x64xf16>, vector<64x64xf16>, vector<64x64xf32> -> vector<64x64xf32>
 

--- a/test/Conversion/XeTileToXeGPU/sg_gemm_1k_1k_1k_i8_i32.mlir
+++ b/test/Conversion/XeTileToXeGPU/sg_gemm_1k_1k_1k_i8_i32.mlir
@@ -61,12 +61,12 @@ gpu.module @test_kernel {
       //CHECK: %[[r43:.*]] = vector.extract_strided_slice %[[r39]] {offsets = [24, 0], sizes = [8, 32], strides = [1, 1]} : vector<32x32xi8> to vector<8x32xi8>
       %a_value = xetile.load_tile %a_tile : !xetile.tile<32x32xi8> -> vector<32x32xi8>
 
-      //CHECK: %[[r44:.*]] = xegpu.load_nd %{{.*}} <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>, packed}> : !xegpu.tensor_desc<32x16xi8, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 2 : i64, boundary_check = true>> -> vector<2x8x16x4xi8>
-      //CHECK: %[[r45:.*]] = vector.extract %[[r44]][0] : vector<8x16x4xi8> from vector<2x8x16x4xi8>
-      //CHECK: %[[r46:.*]] = vector.extract %[[r44]][1] : vector<8x16x4xi8> from vector<2x8x16x4xi8>
+      //CHECK: %[[r44:.*]] = xegpu.load_nd %{{.*}} <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>}> : !xegpu.tensor_desc<32x16xi8, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 2 : i64, boundary_check = true>> -> vector<2x32x16xi8>
+      //CHECK: %[[r45:.*]] = vector.extract %[[r44]][0] : vector<32x16xi8> from vector<2x32x16xi8>
+      //CHECK: %[[r46:.*]] = vector.extract %[[r44]][1] : vector<32x16xi8> from vector<2x32x16xi8>
       %b_value = xetile.load_tile %b_tile : !xetile.tile<32x32xi8> -> vector<32x32xi8>
 
-      //CHECK-COUNT-8: xegpu.dpas {{.*}} : vector<8x32xi8>, vector<8x16x4xi8>, vector<8x16xi32> -> vector<8x16xi32>
+      //CHECK-COUNT-8: xegpu.dpas {{.*}} : vector<8x32xi8>, vector<32x16xi8>, vector<8x16xi32> -> vector<8x16xi32>
       %c_new_value = xetile.tile_mma %a_value, %b_value, %c_value : vector<32x32xi8>, vector<32x32xi8>, vector<32x32xi32> -> vector<32x32xi32>
 
       //CHECK: xegpu.update_nd_offset %{{.*}}, [%[[c0]], %[[c32]]] : !xegpu.tensor_desc<32x32xi8, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 1 : i64, boundary_check = true>>

--- a/test/Conversion/XeTileToXeGPU/sg_mixed_scf.mlir
+++ b/test/Conversion/XeTileToXeGPU/sg_mixed_scf.mlir
@@ -75,9 +75,9 @@ gpu.module @postop_reduce_m attributes {spirv.target_env = #spirv.target_env<#sp
           %48 = xetile.load_tile %arg7 { padding = 0.000000e+00 : f32 }  : !xetile.tile<32x32xbf16> -> vector<32x32xbf16>
 
 
-          //CHECK: %{{.*}} = xegpu.load_nd %{{.*}} <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>, packed}> : !xegpu.tensor_desc<32x16xbf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 2 : i64, boundary_check = true>> -> vector<2x16x16x2xbf16>
-          //CHECK-COUNT-2: %{{.*}} = vector.extract %{{.*}} : vector<16x16x2xbf16> from vector<2x16x16x2xbf16>
-          //CHECK-COUNT-4: %{{.*}} = vector.extract_strided_slice %{{.*}} {offsets = {{.*}}, sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xbf16> to vector<8x16x2xbf16>
+          //CHECK: %{{.*}} = xegpu.load_nd %{{.*}} <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>}> : !xegpu.tensor_desc<32x16xbf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 2 : i64, boundary_check = true>> -> vector<2x32x16xbf16>
+          //CHECK-COUNT-2: %{{.*}} = vector.extract %{{.*}} : vector<32x16xbf16> from vector<2x32x16xbf16>
+          //CHECK-COUNT-4: %{{.*}} = vector.extract_strided_slice %{{.*}} {offsets = {{.*}}, sizes = [16, 16], strides = [1, 1]} : vector<32x16xbf16> to vector<16x16xbf16>
           %49 = xetile.load_tile %arg8 { padding = 0.000000e+00 : f32 }  : !xetile.tile<32x32xbf16> -> vector<32x32xbf16>
 
           //CHECK: %{{.*}} = xegpu.update_nd_offset %{{.*}} : !xegpu.tensor_desc<32x16xbf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 2 : i64, boundary_check = true>>
@@ -85,7 +85,7 @@ gpu.module @postop_reduce_m attributes {spirv.target_env = #spirv.target_env<#sp
           %50 = xetile.update_tile_offset %arg7, [%c0,  %c32] : !xetile.tile<32x32xbf16>, index, index -> !xetile.tile<32x32xbf16>
           %51 = xetile.update_tile_offset %arg8, [%c0,  %c32] : !xetile.tile<32x32xbf16>, index, index -> !xetile.tile<32x32xbf16>
 
-          //CHECK-COUNT-16: %{{.*}} = xegpu.dpas %{{.*}}, %{{.*}}, %{{.*}} : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+          //CHECK-COUNT-16: %{{.*}} = xegpu.dpas %{{.*}}, %{{.*}}, %{{.*}} : vector<8x16xbf16>, vector<16x16xbf16>, vector<8x16xf32> -> vector<8x16xf32>
           %52 = xetile.tile_mma %48, %49, %arg9 : vector<32x32xbf16>, vector<32x32xbf16>, vector<32x32xf32> -> vector<32x32xf32>
           scf.yield %50, %51, %52 : !xetile.tile<32x32xbf16>, !xetile.tile<32x32xbf16>, vector<32x32xf32>
         } {lowerBoundMap = affine_map<() -> (0)>, operandSegmentSizes = array<i32: 0, 0, 3>, step = 32 : index, upperBoundMap = affine_map<() -> (12288)>}

--- a/test/Conversion/XeTileToXeGPU/sg_tile_mma.mlir
+++ b/test/Conversion/XeTileToXeGPU/sg_tile_mma.mlir
@@ -29,54 +29,54 @@ gpu.module @test_kernel {
     //CHECK: %[[r13:.*]] = xegpu.create_nd_tdesc %arg1[%[[c64]], %[[c32]]] : memref<1024x1024xf16> -> !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 2 : i64, boundary_check = true>>
   	%3 = xetile.init_tile %b[%c64, %c0] : memref<1024x1024xf16> -> !xetile.tile<32x64xf16>
 
-    //CHECK: %[[r14:.*]] = xegpu.load_nd %[[r12]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>, packed}> : !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 2 : i64, boundary_check = true>> -> vector<2x16x16x2xf16>
-    //CHECK: %[[r15:.*]] = vector.extract %[[r14]][0] : vector<16x16x2xf16> from vector<2x16x16x2xf16>
-    //CHECK: %[[r16:.*]] = vector.extract %[[r14]][1] : vector<16x16x2xf16> from vector<2x16x16x2xf16>
-    //CHECK: %[[r17:.*]] = xegpu.load_nd %[[r13]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>, packed}> : !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 2 : i64, boundary_check = true>> -> vector<2x16x16x2xf16>
-    //CHECK: %[[r18:.*]] = vector.extract %[[r17]][0] : vector<16x16x2xf16> from vector<2x16x16x2xf16>
-    //CHECK: %[[r19:.*]] = vector.extract %[[r17]][1] : vector<16x16x2xf16> from vector<2x16x16x2xf16>
-    //CHECK: %[[r20:.*]] = vector.extract_strided_slice %[[r15]] {offsets = [0, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-    //CHECK: %[[r21:.*]] = vector.extract_strided_slice %[[r15]] {offsets = [8, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-    //CHECK: %[[r22:.*]] = vector.extract_strided_slice %[[r16]] {offsets = [0, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-    //CHECK: %[[r23:.*]] = vector.extract_strided_slice %[[r16]] {offsets = [8, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-    //CHECK: %[[r24:.*]] = vector.extract_strided_slice %[[r18]] {offsets = [0, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-    //CHECK: %[[r25:.*]] = vector.extract_strided_slice %[[r18]] {offsets = [8, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-    //CHECK: %[[r26:.*]] = vector.extract_strided_slice %[[r19]] {offsets = [0, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-    //CHECK: %[[r27:.*]] = vector.extract_strided_slice %[[r19]] {offsets = [8, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
+    //CHECK: %[[r14:.*]] = xegpu.load_nd %[[r12]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>}> : !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 2 : i64, boundary_check = true>> -> vector<2x32x16xf16>
+    //CHECK: %[[r15:.*]] = vector.extract %[[r14]][0] : vector<32x16xf16> from vector<2x32x16xf16>
+    //CHECK: %[[r16:.*]] = vector.extract %[[r14]][1] : vector<32x16xf16> from vector<2x32x16xf16>
+    //CHECK: %[[r17:.*]] = xegpu.load_nd %[[r13]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>}> : !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 2 : i64, boundary_check = true>> -> vector<2x32x16xf16>
+    //CHECK: %[[r18:.*]] = vector.extract %[[r17]][0] : vector<32x16xf16> from vector<2x32x16xf16>
+    //CHECK: %[[r19:.*]] = vector.extract %[[r17]][1] : vector<32x16xf16> from vector<2x32x16xf16>
+    //CHECK: %[[r20:.*]] = vector.extract_strided_slice %[[r15]] {offsets = [0, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+    //CHECK: %[[r21:.*]] = vector.extract_strided_slice %[[r15]] {offsets = [16, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+    //CHECK: %[[r22:.*]] = vector.extract_strided_slice %[[r16]] {offsets = [0, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+    //CHECK: %[[r23:.*]] = vector.extract_strided_slice %[[r16]] {offsets = [16, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+    //CHECK: %[[r24:.*]] = vector.extract_strided_slice %[[r18]] {offsets = [0, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+    //CHECK: %[[r25:.*]] = vector.extract_strided_slice %[[r18]] {offsets = [16, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+    //CHECK: %[[r26:.*]] = vector.extract_strided_slice %[[r19]] {offsets = [0, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+    //CHECK: %[[r27:.*]] = vector.extract_strided_slice %[[r19]] {offsets = [16, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
     %4 = xetile.load_tile %3 : !xetile.tile<32x64xf16> -> vector<32x64xf16>
 
-    //CHECK: %[[r28:.*]] = xegpu.dpas %[[r4]], %[[r20]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    //CHECK: %[[r29:.*]] = xegpu.dpas %[[r8]], %[[r21]], %[[r28]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    //CHECK: %[[r30:.*]] = xegpu.dpas %[[r4]], %[[r22]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    //CHECK: %[[r31:.*]] = xegpu.dpas %[[r8]], %[[r23]], %[[r30]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    //CHECK: %[[r32:.*]] = xegpu.dpas %[[r4]], %[[r24]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    //CHECK: %[[r33:.*]] = xegpu.dpas %[[r8]], %[[r25]], %[[r32]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    //CHECK: %[[r34:.*]] = xegpu.dpas %[[r4]], %[[r26]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    //CHECK: %[[r35:.*]] = xegpu.dpas %[[r8]], %[[r27]], %[[r34]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    //CHECK: %[[r36:.*]] = xegpu.dpas %[[r5]], %[[r20]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    //CHECK: %[[r37:.*]] = xegpu.dpas %[[r9]], %[[r21]], %[[r36]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    //CHECK: %[[r38:.*]] = xegpu.dpas %[[r5]], %[[r22]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    //CHECK: %[[r39:.*]] = xegpu.dpas %[[r9]], %[[r23]], %[[r38]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    //CHECK: %[[r40:.*]] = xegpu.dpas %[[r5]], %[[r24]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    //CHECK: %[[r41:.*]] = xegpu.dpas %[[r9]], %[[r25]], %[[r40]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    //CHECK: %[[r42:.*]] = xegpu.dpas %[[r5]], %[[r26]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    //CHECK: %[[r43:.*]] = xegpu.dpas %[[r9]], %[[r27]], %[[r42]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    //CHECK: %[[r44:.*]] = xegpu.dpas %[[r6]], %[[r20]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    //CHECK: %[[r45:.*]] = xegpu.dpas %[[r10]], %[[r21]], %[[r44]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    //CHECK: %[[r46:.*]] = xegpu.dpas %[[r6]], %[[r22]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    //CHECK: %[[r47:.*]] = xegpu.dpas %[[r10]], %[[r23]], %[[r46]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    //CHECK: %[[r48:.*]] = xegpu.dpas %[[r6]], %[[r24]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    //CHECK: %[[r49:.*]] = xegpu.dpas %[[r10]], %[[r25]], %[[r48]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    //CHECK: %[[r50:.*]] = xegpu.dpas %[[r6]], %[[r26]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    //CHECK: %[[r51:.*]] = xegpu.dpas %[[r10]], %[[r27]], %[[r50]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    //CHECK: %[[r52:.*]] = xegpu.dpas %[[r7]], %[[r20]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    //CHECK: %[[r53:.*]] = xegpu.dpas %[[r11]], %[[r21]], %[[r52]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    //CHECK: %[[r54:.*]] = xegpu.dpas %[[r7]], %[[r22]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    //CHECK: %[[r55:.*]] = xegpu.dpas %[[r11]], %[[r23]], %[[r54]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    //CHECK: %[[r56:.*]] = xegpu.dpas %[[r7]], %[[r24]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    //CHECK: %[[r57:.*]] = xegpu.dpas %[[r11]], %[[r25]], %[[r56]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    //CHECK: %[[r58:.*]] = xegpu.dpas %[[r7]], %[[r26]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    //CHECK: %[[r59:.*]] = xegpu.dpas %[[r11]], %[[r27]], %[[r58]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    //CHECK: %[[r28:.*]] = xegpu.dpas %[[r4]], %[[r20]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    //CHECK: %[[r29:.*]] = xegpu.dpas %[[r8]], %[[r21]], %[[r28]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    //CHECK: %[[r30:.*]] = xegpu.dpas %[[r4]], %[[r22]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    //CHECK: %[[r31:.*]] = xegpu.dpas %[[r8]], %[[r23]], %[[r30]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    //CHECK: %[[r32:.*]] = xegpu.dpas %[[r4]], %[[r24]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    //CHECK: %[[r33:.*]] = xegpu.dpas %[[r8]], %[[r25]], %[[r32]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    //CHECK: %[[r34:.*]] = xegpu.dpas %[[r4]], %[[r26]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    //CHECK: %[[r35:.*]] = xegpu.dpas %[[r8]], %[[r27]], %[[r34]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    //CHECK: %[[r36:.*]] = xegpu.dpas %[[r5]], %[[r20]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    //CHECK: %[[r37:.*]] = xegpu.dpas %[[r9]], %[[r21]], %[[r36]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    //CHECK: %[[r38:.*]] = xegpu.dpas %[[r5]], %[[r22]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    //CHECK: %[[r39:.*]] = xegpu.dpas %[[r9]], %[[r23]], %[[r38]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    //CHECK: %[[r40:.*]] = xegpu.dpas %[[r5]], %[[r24]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    //CHECK: %[[r41:.*]] = xegpu.dpas %[[r9]], %[[r25]], %[[r40]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    //CHECK: %[[r42:.*]] = xegpu.dpas %[[r5]], %[[r26]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    //CHECK: %[[r43:.*]] = xegpu.dpas %[[r9]], %[[r27]], %[[r42]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    //CHECK: %[[r44:.*]] = xegpu.dpas %[[r6]], %[[r20]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    //CHECK: %[[r45:.*]] = xegpu.dpas %[[r10]], %[[r21]], %[[r44]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    //CHECK: %[[r46:.*]] = xegpu.dpas %[[r6]], %[[r22]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    //CHECK: %[[r47:.*]] = xegpu.dpas %[[r10]], %[[r23]], %[[r46]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    //CHECK: %[[r48:.*]] = xegpu.dpas %[[r6]], %[[r24]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    //CHECK: %[[r49:.*]] = xegpu.dpas %[[r10]], %[[r25]], %[[r48]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    //CHECK: %[[r50:.*]] = xegpu.dpas %[[r6]], %[[r26]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    //CHECK: %[[r51:.*]] = xegpu.dpas %[[r10]], %[[r27]], %[[r50]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    //CHECK: %[[r52:.*]] = xegpu.dpas %[[r7]], %[[r20]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    //CHECK: %[[r53:.*]] = xegpu.dpas %[[r11]], %[[r21]], %[[r52]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    //CHECK: %[[r54:.*]] = xegpu.dpas %[[r7]], %[[r22]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    //CHECK: %[[r55:.*]] = xegpu.dpas %[[r11]], %[[r23]], %[[r54]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    //CHECK: %[[r56:.*]] = xegpu.dpas %[[r7]], %[[r24]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    //CHECK: %[[r57:.*]] = xegpu.dpas %[[r11]], %[[r25]], %[[r56]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    //CHECK: %[[r58:.*]] = xegpu.dpas %[[r7]], %[[r26]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    //CHECK: %[[r59:.*]] = xegpu.dpas %[[r11]], %[[r27]], %[[r58]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
     %6 = xetile.tile_mma %2, %4: vector<32x32xf16>, vector<32x64xf16> -> vector<32x64xf32>
   	gpu.return
   }

--- a/test/Conversion/XeTileToXeGPU/sg_tiled_tile_mma.mlir
+++ b/test/Conversion/XeTileToXeGPU/sg_tiled_tile_mma.mlir
@@ -22,12 +22,12 @@ gpu.module @test_kernel {
     // CHECK: %[[REG5:.*]] = xegpu.create_nd_tdesc %arg1[%[[C64]], %[[C32]]] : memref<1024x1024xf16> -> !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 2 : i64, boundary_check = true>>
     %2 = xetile.init_tile %arg1[%c64, %c0] : memref<1024x1024xf16> -> !xetile.tile<32x64xf16, #xetile.tile_attr<inner_blocks = [32, 16]>>
 
-    // CHECK: %[[REG6:.*]] = xegpu.load_nd %[[REG4]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>, packed}> : !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 2 : i64, boundary_check = true>> -> vector<2x16x16x2xf16>
-    // CHECK: %[[REG7:.*]] = vector.extract %[[REG6]][0] : vector<16x16x2xf16> from vector<2x16x16x2xf16>
-    // CHECK: %[[REG8:.*]] = vector.extract %[[REG6]][1] : vector<16x16x2xf16> from vector<2x16x16x2xf16>
-    // CHECK: %[[REG9:.*]] = xegpu.load_nd %[[REG5]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>, packed}> : !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 2 : i64, boundary_check = true>> -> vector<2x16x16x2xf16>
-    // CHECK: %[[REG10:.*]] = vector.extract %[[REG9]][0] : vector<16x16x2xf16> from vector<2x16x16x2xf16>
-    // CHECK: %[[REG11:.*]] = vector.extract %[[REG9]][1] : vector<16x16x2xf16> from vector<2x16x16x2xf16>
+    // CHECK: %[[REG6:.*]] = xegpu.load_nd %[[REG4]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>}> : !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 2 : i64, boundary_check = true>> -> vector<2x32x16xf16>
+    // CHECK: %[[REG7:.*]] = vector.extract %[[REG6]][0] : vector<32x16xf16> from vector<2x32x16xf16>
+    // CHECK: %[[REG8:.*]] = vector.extract %[[REG6]][1] : vector<32x16xf16> from vector<2x32x16xf16>
+    // CHECK: %[[REG9:.*]] = xegpu.load_nd %[[REG5]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>}> : !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 2 : i64, boundary_check = true>> -> vector<2x32x16xf16>
+    // CHECK: %[[REG10:.*]] = vector.extract %[[REG9]][0] : vector<32x16xf16> from vector<2x32x16xf16>
+    // CHECK: %[[REG11:.*]] = vector.extract %[[REG9]][1] : vector<32x16xf16> from vector<2x32x16xf16>
     %3 = xetile.load_tile %2 { padding = 0.000000e+00 : f32 }  : !xetile.tile<32x64xf16, #xetile.tile_attr<inner_blocks = [32, 16]>> -> vector<1x4x32x16xf16>
 
     //CHECK: %[[REG12:.*]] = vector.extract_strided_slice %[[REG2]] {offsets = [0, 0], sizes = [8, 16], strides = [1, 1]} : vector<32x16xf16> to vector<8x16xf16>
@@ -41,49 +41,49 @@ gpu.module @test_kernel {
     %4 = xetile.tile_unpack %1 { inner_blocks = [32, 16] }  : vector<1x2x32x16xf16> -> vector<32x32xf16>
     %5 = xetile.tile_pack %4 { inner_blocks = [8, 16] }  : vector<32x32xf16> -> vector<4x2x8x16xf16>
 
-    // CHECK: %[[REG20:.*]] = vector.extract_strided_slice %[[REG7]] {offsets = [0, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-    // CHECK: %[[REG21:.*]] = vector.extract_strided_slice %[[REG7]] {offsets = [8, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-    // CHECK: %[[REG22:.*]] = vector.extract_strided_slice %[[REG8]] {offsets = [0, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-    // CHECK: %[[REG23:.*]] = vector.extract_strided_slice %[[REG8]] {offsets = [8, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-    // CHECK: %[[REG24:.*]] = vector.extract_strided_slice %[[REG10]] {offsets = [0, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-    // CHECK: %[[REG25:.*]] = vector.extract_strided_slice %[[REG10]] {offsets = [8, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-    // CHECK: %[[REG26:.*]] = vector.extract_strided_slice %[[REG11]] {offsets = [0, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
-    // CHECK: %[[REG27:.*]] = vector.extract_strided_slice %[[REG11]] {offsets = [8, 0], sizes = [8, 16], strides = [1, 1]} : vector<16x16x2xf16> to vector<8x16x2xf16>
+    // CHECK: %[[REG20:.*]] = vector.extract_strided_slice %[[REG7]] {offsets = [0, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+    // CHECK: %[[REG21:.*]] = vector.extract_strided_slice %[[REG7]] {offsets = [16, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+    // CHECK: %[[REG22:.*]] = vector.extract_strided_slice %[[REG8]] {offsets = [0, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+    // CHECK: %[[REG23:.*]] = vector.extract_strided_slice %[[REG8]] {offsets = [16, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+    // CHECK: %[[REG24:.*]] = vector.extract_strided_slice %[[REG10]] {offsets = [0, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+    // CHECK: %[[REG25:.*]] = vector.extract_strided_slice %[[REG10]] {offsets = [16, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+    // CHECK: %[[REG26:.*]] = vector.extract_strided_slice %[[REG11]] {offsets = [0, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
+    // CHECK: %[[REG27:.*]] = vector.extract_strided_slice %[[REG11]] {offsets = [16, 0], sizes = [16, 16], strides = [1, 1]} : vector<32x16xf16> to vector<16x16xf16>
     %6 = xetile.tile_unpack %3 { inner_blocks = [32, 16] }  : vector<1x4x32x16xf16> -> vector<32x64xf16>
     %7 = xetile.tile_pack %6 { inner_blocks = [16, 16] }  : vector<32x64xf16> -> vector<2x4x16x16xf16>
 
-    // CHECK: %[[REG28:.*]] = xegpu.dpas %[[REG12]], %[[REG20]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    // CHECK: %[[REG29:.*]] = xegpu.dpas %[[REG16]], %[[REG21]], %[[REG28]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    // CHECK: %[[REG30:.*]] = xegpu.dpas %[[REG12]], %[[REG22]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    // CHECK: %[[REG31:.*]] = xegpu.dpas %[[REG16]], %[[REG23]], %[[REG30]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    // CHECK: %[[REG32:.*]] = xegpu.dpas %[[REG12]], %[[REG24]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    // CHECK: %[[REG33:.*]] = xegpu.dpas %[[REG16]], %[[REG25]], %[[REG32]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    // CHECK: %[[REG34:.*]] = xegpu.dpas %[[REG12]], %[[REG26]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    // CHECK: %[[REG35:.*]] = xegpu.dpas %[[REG16]], %[[REG27]], %[[REG34]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    // CHECK: %[[REG36:.*]] = xegpu.dpas %[[REG13]], %[[REG20]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    // CHECK: %[[REG37:.*]] = xegpu.dpas %[[REG17]], %[[REG21]], %[[REG36]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    // CHECK: %[[REG38:.*]] = xegpu.dpas %[[REG13]], %[[REG22]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    // CHECK: %[[REG39:.*]] = xegpu.dpas %[[REG17]], %[[REG23]], %[[REG38]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    // CHECK: %[[REG40:.*]] = xegpu.dpas %[[REG13]], %[[REG24]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    // CHECK: %[[REG41:.*]] = xegpu.dpas %[[REG17]], %[[REG25]], %[[REG40]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    // CHECK: %[[REG42:.*]] = xegpu.dpas %[[REG13]], %[[REG26]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    // CHECK: %[[REG43:.*]] = xegpu.dpas %[[REG17]], %[[REG27]], %[[REG42]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    // CHECK: %[[REG44:.*]] = xegpu.dpas %[[REG14]], %[[REG20]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    // CHECK: %[[REG45:.*]] = xegpu.dpas %[[REG18]], %[[REG21]], %[[REG44]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    // CHECK: %[[REG46:.*]] = xegpu.dpas %[[REG14]], %[[REG22]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    // CHECK: %[[REG47:.*]] = xegpu.dpas %[[REG18]], %[[REG23]], %[[REG46]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    // CHECK: %[[REG48:.*]] = xegpu.dpas %[[REG14]], %[[REG24]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    // CHECK: %[[REG49:.*]] = xegpu.dpas %[[REG18]], %[[REG25]], %[[REG48]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    // CHECK: %[[REG50:.*]] = xegpu.dpas %[[REG14]], %[[REG26]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    // CHECK: %[[REG51:.*]] = xegpu.dpas %[[REG18]], %[[REG27]], %[[REG50]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    // CHECK: %[[REG52:.*]] = xegpu.dpas %[[REG15]], %[[REG20]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    // CHECK: %[[REG53:.*]] = xegpu.dpas %[[REG19]], %[[REG21]], %[[REG52]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    // CHECK: %[[REG54:.*]] = xegpu.dpas %[[REG15]], %[[REG22]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    // CHECK: %[[REG55:.*]] = xegpu.dpas %[[REG19]], %[[REG23]], %[[REG54]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    // CHECK: %[[REG56:.*]] = xegpu.dpas %[[REG15]], %[[REG24]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    // CHECK: %[[REG57:.*]] = xegpu.dpas %[[REG19]], %[[REG25]], %[[REG56]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-    // CHECK: %[[REG58:.*]] = xegpu.dpas %[[REG15]], %[[REG26]] : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-    // CHECK: %[[REG59:.*]] = xegpu.dpas %[[REG19]], %[[REG27]], %[[REG58]] : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    // CHECK: %[[REG28:.*]] = xegpu.dpas %[[REG12]], %[[REG20]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    // CHECK: %[[REG29:.*]] = xegpu.dpas %[[REG16]], %[[REG21]], %[[REG28]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    // CHECK: %[[REG30:.*]] = xegpu.dpas %[[REG12]], %[[REG22]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    // CHECK: %[[REG31:.*]] = xegpu.dpas %[[REG16]], %[[REG23]], %[[REG30]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    // CHECK: %[[REG32:.*]] = xegpu.dpas %[[REG12]], %[[REG24]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    // CHECK: %[[REG33:.*]] = xegpu.dpas %[[REG16]], %[[REG25]], %[[REG32]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    // CHECK: %[[REG34:.*]] = xegpu.dpas %[[REG12]], %[[REG26]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    // CHECK: %[[REG35:.*]] = xegpu.dpas %[[REG16]], %[[REG27]], %[[REG34]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    // CHECK: %[[REG36:.*]] = xegpu.dpas %[[REG13]], %[[REG20]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    // CHECK: %[[REG37:.*]] = xegpu.dpas %[[REG17]], %[[REG21]], %[[REG36]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    // CHECK: %[[REG38:.*]] = xegpu.dpas %[[REG13]], %[[REG22]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    // CHECK: %[[REG39:.*]] = xegpu.dpas %[[REG17]], %[[REG23]], %[[REG38]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    // CHECK: %[[REG40:.*]] = xegpu.dpas %[[REG13]], %[[REG24]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    // CHECK: %[[REG41:.*]] = xegpu.dpas %[[REG17]], %[[REG25]], %[[REG40]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    // CHECK: %[[REG42:.*]] = xegpu.dpas %[[REG13]], %[[REG26]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    // CHECK: %[[REG43:.*]] = xegpu.dpas %[[REG17]], %[[REG27]], %[[REG42]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    // CHECK: %[[REG44:.*]] = xegpu.dpas %[[REG14]], %[[REG20]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    // CHECK: %[[REG45:.*]] = xegpu.dpas %[[REG18]], %[[REG21]], %[[REG44]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    // CHECK: %[[REG46:.*]] = xegpu.dpas %[[REG14]], %[[REG22]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    // CHECK: %[[REG47:.*]] = xegpu.dpas %[[REG18]], %[[REG23]], %[[REG46]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    // CHECK: %[[REG48:.*]] = xegpu.dpas %[[REG14]], %[[REG24]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    // CHECK: %[[REG49:.*]] = xegpu.dpas %[[REG18]], %[[REG25]], %[[REG48]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    // CHECK: %[[REG50:.*]] = xegpu.dpas %[[REG14]], %[[REG26]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    // CHECK: %[[REG51:.*]] = xegpu.dpas %[[REG18]], %[[REG27]], %[[REG50]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    // CHECK: %[[REG52:.*]] = xegpu.dpas %[[REG15]], %[[REG20]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    // CHECK: %[[REG53:.*]] = xegpu.dpas %[[REG19]], %[[REG21]], %[[REG52]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    // CHECK: %[[REG54:.*]] = xegpu.dpas %[[REG15]], %[[REG22]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    // CHECK: %[[REG55:.*]] = xegpu.dpas %[[REG19]], %[[REG23]], %[[REG54]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    // CHECK: %[[REG56:.*]] = xegpu.dpas %[[REG15]], %[[REG24]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    // CHECK: %[[REG57:.*]] = xegpu.dpas %[[REG19]], %[[REG25]], %[[REG56]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
+    // CHECK: %[[REG58:.*]] = xegpu.dpas %[[REG15]], %[[REG26]] : vector<8x16xf16>, vector<16x16xf16> -> vector<8x16xf32>
+    // CHECK: %[[REG59:.*]] = xegpu.dpas %[[REG19]], %[[REG27]], %[[REG58]] : vector<8x16xf16>, vector<16x16xf16>, vector<8x16xf32> -> vector<8x16xf32>
     %8 = xetile.tile_mma %5, %7 : vector<4x2x8x16xf16>, vector<2x4x16x16xf16> -> vector<4x4x8x16xf32>
 
     gpu.return

--- a/test/Conversion/XeTileToXeGPU/test_order.mlir
+++ b/test/Conversion/XeTileToXeGPU/test_order.mlir
@@ -1,18 +1,14 @@
-// RUN: imex-opt --split-input-file --xetile-blocking --convert-xetile-to-xegpu --cse %s -verify-diagnostics -o -| FileCheck %s
+// RUN: imex-opt --split-input-file --xetile-canonicalization --xetile-blocking --convert-xetile-to-xegpu --cse %s -verify-diagnostics -o -| FileCheck %s
 
 // CHECK-LABEL: @test_func
 // CHECK-SAME: (%[[ARG0:.*]]: memref<128x64xf16>, %[[ARG1:.*]]: memref<64x128xf16, strided<[1, 64]>>) {
 // CHECK: %[[C0:.*]] = arith.constant 0 : index
 // CHECK: %[[C16:.*]] = arith.constant 16 : index
-// CHECK: %[[R_CAST:.*]] = memref.reinterpret_cast %[[ARG1]] to offset: [0], sizes: [128, 64], strides: [64, 1] : memref<64x128xf16, strided<[1, 64]>> to memref<128x64xf16>
-// CHECK: %[[T1:.*]] = xegpu.create_nd_tdesc %[[R_CAST]][%[[C0]], %[[C0]]] : memref<128x64xf16> -> !xegpu.tensor_desc<16x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 1 : i64, boundary_check = true>>
-// CHECK: %[[T2:.*]] = xegpu.create_nd_tdesc %[[R_CAST]][%[[C16]], %[[C0]]] : memref<128x64xf16> -> !xegpu.tensor_desc<16x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 1 : i64, boundary_check = true>>
-// CHECK: %[[T8:.*]] = xegpu.load_nd %[[T1]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>, transpose = array<i64: 1, 0>, transpose_bit_width = 32 : i32}> : !xegpu.tensor_desc<16x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 1 : i64, boundary_check = true>> -> vector<8x16x2xf16>
-// CHECK: %[[T9:.*]] = xegpu.load_nd %[[T2]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>, transpose = array<i64: 1, 0>, transpose_bit_width = 32 : i32}> : !xegpu.tensor_desc<16x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 1 : i64, boundary_check = true>> -> vector<8x16x2xf16>
-// CHECK: %[[T19:.*]] = xegpu.update_nd_offset %[[T1]], [%[[C0]], %[[C16]]] : !xegpu.tensor_desc<16x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 1 : i64, boundary_check = true>>
-// CHECK: %[[T20:.*]] = xegpu.update_nd_offset %[[T2]], [%[[C0]], %[[C16]]] : !xegpu.tensor_desc<16x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 1 : i64, boundary_check = true>>
-// CHECK: %[[T26:.*]] = xegpu.load_nd %[[T19]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>, transpose = array<i64: 1, 0>, transpose_bit_width = 32 : i32}> : !xegpu.tensor_desc<16x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 1 : i64, boundary_check = true>> -> vector<8x16x2xf16>
-// CHECK: %[[T27:.*]] = xegpu.load_nd %[[T20]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>, transpose = array<i64: 1, 0>, transpose_bit_width = 32 : i32}> : !xegpu.tensor_desc<16x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 1 : i64, boundary_check = true>> -> vector<8x16x2xf16>
+// CHECK: %[[R_CAST:.*]] = memref.reinterpret_cast %[[ARG1]] to offset: [0], sizes: [128, 64], strides: [64, 1] : memref<64x128xf16, strided<[1, 64]>> to memref<128x64xf16, strided<[64, 1]>>
+// CHECK: %[[T1:.*]] = xegpu.create_nd_tdesc %[[R_CAST]][%[[C0]], %[[C0]]] : memref<128x64xf16, strided<[64, 1]>> -> !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 1 : i64, boundary_check = true>>
+// CHECK: %[[T8:.*]] = xegpu.load_nd %[[T1]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>}> : !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 1 : i64, boundary_check = true>> -> vector<32x16xf16>
+// CHECK: %[[T19:.*]] = xegpu.update_nd_offset %[[T1]], [%[[C0]], %[[C16]]] : !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 1 : i64, boundary_check = true>>
+// CHECK: %[[T26:.*]] = xegpu.load_nd %[[T19]] <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<cached>, l3_hint = #xegpu.cache_hint<cached>}> : !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<memory_scope =  global, array_length = 1 : i64, boundary_check = true>> -> vector<32x16xf16>
 gpu.module @test_kernel {
 func.func @test_func(%A : memref<128x64xf16>, %B : memref<64x128xf16, strided<[1, 64], offset: 0>>) {
   %c0 = arith.constant 0 : index

--- a/test/Integration/Dialect/XeTile/xetile-to-func-vc.pp
+++ b/test/Integration/Dialect/XeTile/xetile-to-func-vc.pp
@@ -1,10 +1,10 @@
 builtin.module(
     cse
     gpu.module(xetile-init-duplicate
-        xetile-optimize-transpose
+        xetile-canonicalization
         xetile-blocking
         convert-xetile-to-xegpu
-        imex-propagate-packed-layout)
+        imex-xegpu-apply-vnni-transformation)
     cse
     imex-vector-linearize
     cse


### PR DESCRIPTION
This PR removes the transpose and vnni logic from XeTileToXeGPU pass since we have independent passes for them now. The related testcases also get updated per changes, including the pipeline for XeTile Integration tests and unit conversion tests
