### PR TITLE
[InsertGpuAllocs] Take `clientAPI` as an argument to `createInsertGPUAllocs()`

### DIFF
--- a/include/imex/Transforms/Passes.h
+++ b/include/imex/Transforms/Passes.h
@@ -22,7 +22,8 @@ namespace imex {
 // Passes
 //===----------------------------------------------------------------------===//
 std::unique_ptr<mlir::Pass> createSerializeSPIRVPass();
-std::unique_ptr<mlir::Pass> createInsertGPUAllocsPass();
+std::unique_ptr<mlir::Pass>
+createInsertGPUAllocsPass(const char *clientAPI = "vulkan");
 std::unique_ptr<mlir::Pass> createSetSPIRVCapabilitiesPass();
 std::unique_ptr<mlir::Pass> createSetSPIRVAbiAttributePass();
 std::unique_ptr<mlir::Pass> createAddOuterParallelLoopPass();

--- a/lib/Transforms/InsertGPUAllocs.cpp
+++ b/lib/Transforms/InsertGPUAllocs.cpp
@@ -503,7 +503,7 @@ private:
 } // namespace
 
 namespace imex {
-std::unique_ptr<mlir::Pass> createInsertGPUAllocsPass() {
-  return std::make_unique<InsertGPUAllocsPass>();
+std::unique_ptr<mlir::Pass> createInsertGPUAllocsPass(const char *clientAPI) {
+  return std::make_unique<InsertGPUAllocsPass>(clientAPI);
 }
 } // namespace imex


### PR DESCRIPTION
These changes allows users of IMEX to pass `clientAPI` to the `InsertGPUAllocs` using its public interface (via `createInsertGPUAllocs()` function).

Please review these guidelines to help with the review process:
- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [ ] Have you organized your commits logically and ensured each can be built by itself?
