### PR TITLE
[ExecutionEngine] Add Environment Variable to use IGC vector back end.

### DIFF
--- a/lib/ExecutionEngine/LEVELZERORUNTIME/LevelZeroRuntimeWrappers.cpp
+++ b/lib/ExecutionEngine/LEVELZERORUNTIME/LevelZeroRuntimeWrappers.cpp
@@ -393,11 +393,17 @@ static ze_module_handle_t loadModule(GPUL0QUEUE *queue, const void *data,
   }
   ze_module_desc_t desc = {};
 
-  const char *build_flags = nullptr;
+  std::string build_flags;
+  // IGC auto-detection of scalar/vector backend does not work for native BF16
+  // data type yet, hence we need to pass this flag explicitly for if native
+  // bf16 data type is used and we need to use vector compute.
+  if (getenv("IMEX_USE_IGC_VECTOR_BACK_END")) {
+    build_flags += " -vc-codegen ";
+  }
   // enable large register file if needed
   if (getenv("IMEX_ENABLE_LARGE_REG_FILE")) {
-    build_flags =
-        "-vc-codegen -doubleGRF -Xfinalizer -noLocalSplit -Xfinalizer "
+    build_flags +=
+        " -doubleGRF -Xfinalizer -noLocalSplit -Xfinalizer "
         "-DPASTokenReduction -Xfinalizer -SWSBDepReduction -Xfinalizer "
         "'-printregusage -enableBCR' ";
   }
@@ -405,7 +411,7 @@ static ze_module_handle_t loadModule(GPUL0QUEUE *queue, const void *data,
   desc.format = ZE_MODULE_FORMAT_IL_SPIRV;
   desc.pInputModule = static_cast<const uint8_t *>(data);
   desc.inputSize = dataSize;
-  desc.pBuildFlags = build_flags;
+  desc.pBuildFlags = build_flags.c_str();
   CHECK_ZE_RESULT(zeModuleCreate(gpuL0Queue->zeContext_, gpuL0Queue->zeDevice_,
                                  &desc, &zeModule, nullptr));
   std::lock_guard<std::mutex> entryLock(mutexLock);

--- a/lib/ExecutionEngine/SYCLRUNTIME/SyclRuntimeWrappers.cpp
+++ b/lib/ExecutionEngine/SYCLRUNTIME/SyclRuntimeWrappers.cpp
@@ -225,14 +225,21 @@ static ze_module_handle_t loadModule(GPUSYCLQUEUE *queue, const void *data,
                            nullptr,
                            nullptr};
 
+  std::string build_flags;
+  // IGC auto-detection of scalar/vector backend does not work for native BF16
+  // data type yet, hence we need to pass this flag explicitly for if native
+  // bf16 data type is used and we need to use vector compute.
+  if (getenv("IMEX_USE_IGC_VECTOR_BACK_END")) {
+    build_flags += " -vc-codegen ";
+  }
   // enable large register file if needed
   if (getenv("IMEX_ENABLE_LARGE_REG_FILE")) {
-    desc.pBuildFlags =
-        "-vc-codegen -doubleGRF -Xfinalizer -noLocalSplit -Xfinalizer "
+    build_flags +=
+        " -doubleGRF -Xfinalizer -noLocalSplit -Xfinalizer "
         "-DPASTokenReduction -Xfinalizer -SWSBDepReduction -Xfinalizer "
         "'-printregusage -enableBCR' ";
   }
-
+  desc.pBuildFlags = build_flags.c_str();
   auto zeDevice = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
       syclQueue.get_device());
   auto zeContext = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(

--- a/test/Integration/Dialect/Gpu/EltwiseAdd_BF16.mlir
+++ b/test/Integration/Dialect/Gpu/EltwiseAdd_BF16.mlir
@@ -1,8 +1,8 @@
-// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/gpu-to-llvm.pp \
+// RUN: IMEX_USE_IGC_VECTOR_BACK_END=1 %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/gpu-to-llvm.pp \
 // RUN:                                       --runner imex-cpu-runner  -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
-// RUN: %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/gpu-to-llvm.pp \
+// RUN: IMEX_USE_IGC_VECTOR_BACK_END=1 %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/gpu-to-llvm.pp \
 // RUN:                                        --runner imex-cpu-runner  -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck

--- a/test/Integration/Dialect/XeGPU/gemm_1024x1024xbf16.mlir
+++ b/test/Integration/Dialect/XeGPU/gemm_1024x1024xbf16.mlir
@@ -1,8 +1,8 @@
-// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN: IMEX_USE_IGC_VECTOR_BACK_END=1 %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
 // RUN:                                       --runner imex-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
-// RUN: %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN: IMEX_USE_IGC_VECTOR_BACK_END=1 %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
 // RUN:                                        --runner imex-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck

--- a/test/Integration/Dialect/XeGPU/gemm_256x256x256_bf16_bf16_f32.mlir
+++ b/test/Integration/Dialect/XeGPU/gemm_256x256x256_bf16_bf16_f32.mlir
@@ -1,8 +1,8 @@
-// RUN: IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN: IMEX_USE_IGC_VECTOR_BACK_END=1 IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
 // RUN:                                       --runner imex-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
-// RUN: IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN: IMEX_USE_IGC_VECTOR_BACK_END=1 IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
 // RUN:                                        --runner imex-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck

--- a/test/Integration/Dialect/XeGPU/gemm_4kx4kx4k_bf16_bf16_f32_xetla_like_load_store_prefetch.mlir
+++ b/test/Integration/Dialect/XeGPU/gemm_4kx4kx4k_bf16_bf16_f32_xetla_like_load_store_prefetch.mlir
@@ -1,8 +1,8 @@
-// RUN: IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN: IMEX_USE_IGC_VECTOR_BACK_END=1 IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
 // RUN:                                       --runner imex-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
-// RUN: IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN: IMEX_USE_IGC_VECTOR_BACK_END=1 IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
 // RUN:                                        --runner imex-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck

--- a/test/Integration/Dialect/XeTile/sg_gemm_1kx1kx1k_bf16_bf16_f32.mlir
+++ b/test/Integration/Dialect/XeTile/sg_gemm_1kx1kx1k_bf16_bf16_f32.mlir
@@ -1,8 +1,8 @@
-// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xetile-to-func-vc.pp \
+// RUN: IMEX_USE_IGC_VECTOR_BACK_END=1 %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xetile-to-func-vc.pp \
 // RUN:                                       --runner imex-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
-// RUN: %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xetile-to-func-vc.pp \
+// RUN: IMEX_USE_IGC_VECTOR_BACK_END=1 %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xetile-to-func-vc.pp \
 // RUN:                                        --runner imex-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck

--- a/test/Integration/Dialect/XeTile/sg_gemm_1kx1kx1k_preop_postop_bf16_bf16_f32.mlir
+++ b/test/Integration/Dialect/XeTile/sg_gemm_1kx1kx1k_preop_postop_bf16_bf16_f32.mlir
@@ -1,8 +1,8 @@
-// RUN: IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xetile-to-func-vc.pp \
+// RUN: IMEX_USE_IGC_VECTOR_BACK_END=1 IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xetile-to-func-vc.pp \
 // RUN:                                       --runner imex-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
-// RUN: IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xetile-to-func-vc.pp \
+// RUN: IMEX_USE_IGC_VECTOR_BACK_END=1 IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xetile-to-func-vc.pp \
 // RUN:                                        --runner imex-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck

--- a/test/Integration/Dialect/XeTile/sg_gemm_1kx1kx1k_transposed_b_preop_postop_bf16_bf16_f32.mlir
+++ b/test/Integration/Dialect/XeTile/sg_gemm_1kx1kx1k_transposed_b_preop_postop_bf16_bf16_f32.mlir
@@ -1,8 +1,8 @@
-// RUN: IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xetile-to-func-vc.pp \
+// RUN: IMEX_USE_IGC_VECTOR_BACK_END=1 IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xetile-to-func-vc.pp \
 // RUN:                                       --runner imex-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
 // RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
-// RUN: IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xetile-to-func-vc.pp \
+// RUN: IMEX_USE_IGC_VECTOR_BACK_END=1 IMEX_ENABLE_LARGE_REG_FILE=1 %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xetile-to-func-vc.pp \
 // RUN:                                        --runner imex-cpu-runner -e main \
 // RUN:                                        --entry-point-result=void \
 // RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck


### PR DESCRIPTION
IGC vecor backend auto-detection does not work for native bf16 data type, hence provide a way to pass '-vc-codgen' flag to such scenarios.

Update BF16 tests accordingly.

Please review these guidelines to help with the review process:
- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [x] Have you organized your commits logically and ensured each can be built by itself?
