### PR TITLE
[XeGPU] Add support for strided memrefs.

### DIFF
--- a/test/Conversion/XeGPUToVC/create_nd_desc.mlir
+++ b/test/Conversion/XeGPUToVC/create_nd_desc.mlir
@@ -117,5 +117,43 @@ module @gemm attributes {gpu.container_module} {
       //CHECK: gpu.return
       gpu.return
     }
+
+    // CHECK: gpu.func @test_create_nd_tdesc_1d_strided_memref(%[[arg0:.*]]: memref<32x32xf16, strided<[64, 1]>>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+    gpu.func @test_create_nd_tdesc_1d_strided_memref(%arg0: memref<32x32xf16, strided<[64,1], offset: 0>>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>}{
+      //CHECK: %cst = arith.constant dense<0> : vector<4xi64>
+      //CHECK: %intptr = memref.extract_aligned_pointer_as_index %arg0 : memref<32x32xf16, strided<[64, 1]>> -> index
+      //CHECK: %c2 = arith.constant 2 : index
+      //CHECK: %c0 = arith.constant 0 : index
+      //CHECK: %0 = arith.muli %c0, %c2 : index
+      //CHECK: %1 = arith.addi %intptr, %0 : index
+      //CHECK: %c128 = arith.constant 128 : index
+      //CHECK: %2 = arith.muli %c0, %c128 : index
+      //CHECK: %3 = arith.addi %1, %2 : index
+      //CHECK: %4 = arith.index_castui %3 : index to i64
+      //CHECK: %5 = vector.insert %4, %cst [0] : i64 into vector<4xi64>
+      %tdesc_1d = xegpu.create_nd_tdesc %arg0[0, 0] : memref<32x32xf16, strided<[64,1], offset: 0>> -> !xegpu.tensor_desc<16xf16>
+      gpu.return
+    }
+
+    // CHECK: gpu.func @test_create_nd_tdesc_2d_strided_memref(%[[arg0:.*]]: memref<32x32xf16, strided<[64, 1]>>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+    gpu.func @test_create_nd_tdesc_2d_strided_memref(%arg0: memref<32x32xf16, strided<[64,1], offset: 0>>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>}{
+      //CHECK: %cst = arith.constant dense<0> : vector<4xi64>
+      //CHECK: %intptr = memref.extract_aligned_pointer_as_index %arg0 : memref<32x32xf16, strided<[64, 1]>> -> index
+      //CHECK: %0 = arith.index_castui %intptr : index to i64
+      //CHECK: %1 = vector.insert %0, %cst [0] : i64 into vector<4xi64>
+      //CHECK: %2 = vector.bitcast %1 : vector<4xi64> to vector<8xi32>
+      //CHECK: %c63_i32 = arith.constant 63 : i32
+      //CHECK: %c31_i32 = arith.constant 31 : i32
+      //CHECK: %c127_i32 = arith.constant 127 : i32
+      //CHECK: %3 = vector.insert %c63_i32, %2 [2] : i32 into vector<8xi32>
+      //CHECK: %4 = vector.insert %c31_i32, %3 [3] : i32 into vector<8xi32>
+      //CHECK: %5 = vector.insert %c127_i32, %4 [4] : i32 into vector<8xi32>
+      //CHECK: %c0_i32 = arith.constant 0 : i32
+      //CHECK: %6 = vector.insert %c0_i32, %5 [5] : i32 into vector<8xi32>
+      //CHECK: %7 = vector.insert %c0_i32, %6 [6] : i32 into vector<8xi32>
+      //CHECK: %c1807_i32 = arith.constant 1807 : i32
+      %tdesc_2d = xegpu.create_nd_tdesc %arg0[0, 0] : memref<32x32xf16, strided<[64,1], offset: 0>> -> !xegpu.tensor_desc<8x16xf16>
+      gpu.return
+    }
   }
 }

--- a/test/Conversion/XeGPUToVC/load_nd.mlir
+++ b/test/Conversion/XeGPUToVC/load_nd.mlir
@@ -140,6 +140,88 @@ module @gemm attributes {gpu.container_module} {
       gpu.return
     }
 
+    // CHECK: gpu.func @test_load_nd_1d_strided_memref(%[[arg0:.*]]: memref<32x32xf16, strided<[64, 1]>>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+    gpu.func @test_load_nd_1d_strided_memref(%arg0: memref<32x32xf16, strided<[64,1], offset: 0>>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>}{
+      //CHECK: %cst = arith.constant dense<0> : vector<4xi64>
+      //CHECK: %intptr = memref.extract_aligned_pointer_as_index %arg0 : memref<32x32xf16, strided<[64, 1]>> -> index
+      //CHECK: %c2 = arith.constant 2 : index
+      //CHECK: %c0 = arith.constant 0 : index
+      //CHECK: %0 = arith.muli %c0, %c2 : index
+      //CHECK: %1 = arith.addi %intptr, %0 : index
+      //CHECK: %c128 = arith.constant 128 : index
+      //CHECK: %2 = arith.muli %c0, %c128 : index
+      //CHECK: %3 = arith.addi %1, %2 : index
+      //CHECK: %4 = arith.index_castui %3 : index to i64
+      //CHECK: %5 = vector.insert %4, %cst [0] : i64 into vector<4xi64>
+      %tdesc_1d = xegpu.create_nd_tdesc %arg0[0, 0] : memref<32x32xf16, strided<[64,1], offset: 0>> -> !xegpu.tensor_desc<16xf16>
 
+      //RAW: %6 = vector.bitcast %5 : vector<4xi64> to vector<8xi32>
+      //RAW: %c0_i8 = arith.constant 0 : i8
+      //RAW: %true = arith.constant true
+      //RAW: %c1_i8 = arith.constant 1 : i8
+      //RAW: %c2_i8 = arith.constant 2 : i8
+      //RAW: %c15_i8 = arith.constant 15 : i8
+      //RAW: %c0_i32 = arith.constant 0 : i32
+      //RAW: %c37926784_i32 = arith.constant 37926784 : i32
+      //RAW: %7 = func.call @llvm.genx.raw.send2.v4i64.i1.v8i32(%c0_i8, %c0_i8, %true, %c1_i8, %c2_i8, %c15_i8, %c0_i32, %c37926784_i32, %6, %cst) : (i8, i8, i1, i8, i8, i8, i32, i32, vector<8xi32>, vector<4xi64>) -> vector<4xi64>
+
+      //LSC: %6 = vector.bitcast %5 : vector<4xi64> to vector<8xi32>
+      //LSC: %true = arith.constant true
+      //LSC: %c0_i8 = arith.constant 0 : i8
+      //LSC: %7 = vector.bitcast %6 : vector<8xi32> to vector<4xi64>
+      //LSC: %8 = vector.extract %7[0] : i64 from vector<4xi64>
+      //LSC: %c1_i16 = arith.constant 1 : i16
+      //LSC: %c0_i32 = arith.constant 0 : i32
+      //LSC: %c4_i8 = arith.constant 4 : i8
+      //LSC: %c2_i8 = arith.constant 2 : i8
+      //LSC: %9 = func.call @llvm.genx.lsc.load.stateless.v4i64.i1.i64(%true, %c0_i8, %c0_i8, %c0_i8, %c1_i16, %c0_i32, %c4_i8, %c4_i8, %c2_i8, %c0_i8, %8, %c0_i32) : (i1, i8, i8, i8, i16, i32, i8, i8, i8, i8, i64, i32) -> vector<4xi64>
+      %load_1d = xegpu.load_nd %tdesc_1d  : !xegpu.tensor_desc<16xf16> -> vector<16xf16>
+      gpu.return
+    }
+
+    // CHECK: gpu.func @test_load_nd_2d_strided_memref(%[[arg0:.*]]: memref<32x32xf16, strided<[64, 1]>>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+    gpu.func @test_load_nd_2d_strided_memref(%arg0: memref<32x32xf16, strided<[64,1], offset: 0>>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>}{
+      //CHECK: %cst = arith.constant dense<0> : vector<4xi64>
+      //CHECK: %intptr = memref.extract_aligned_pointer_as_index %arg0 : memref<32x32xf16, strided<[64, 1]>> -> index
+      //CHECK: %0 = arith.index_castui %intptr : index to i64
+      //CHECK: %1 = vector.insert %0, %cst [0] : i64 into vector<4xi64>
+      //CHECK: %2 = vector.bitcast %1 : vector<4xi64> to vector<8xi32>
+      //CHECK: %c63_i32 = arith.constant 63 : i32
+      //CHECK: %c31_i32 = arith.constant 31 : i32
+      //CHECK: %c127_i32 = arith.constant 127 : i32
+      //CHECK: %3 = vector.insert %c63_i32, %2 [2] : i32 into vector<8xi32>
+      //CHECK: %4 = vector.insert %c31_i32, %3 [3] : i32 into vector<8xi32>
+      //CHECK: %5 = vector.insert %c127_i32, %4 [4] : i32 into vector<8xi32>
+      //CHECK: %c0_i32 = arith.constant 0 : i32
+      //CHECK: %6 = vector.insert %c0_i32, %5 [5] : i32 into vector<8xi32>
+      //CHECK: %7 = vector.insert %c0_i32, %6 [6] : i32 into vector<8xi32>
+      //CHECK: %c1807_i32 = arith.constant 1807 : i32
+      %tdesc_2d = xegpu.create_nd_tdesc %arg0[0, 0] : memref<32x32xf16, strided<[64,1], offset: 0>> -> !xegpu.tensor_desc<8x16xf16>
+
+      //RAW: %8 = vector.insert %c1807_i32, %7 [7] : i32 into vector<8xi32>
+      //RAW: %c0_i8 = arith.constant 0 : i8
+      //RAW: %true = arith.constant true
+      //RAW: %c1_i8 = arith.constant 1 : i8
+      //RAW: %c4_i8 = arith.constant 4 : i8
+      //RAW: %c15_i8 = arith.constant 15 : i8
+      //RAW: %c37880323_i32 = arith.constant 37880323 : i32
+      //RAW: %cst_0 = arith.constant dense<0> : vector<64xi32>
+      //RAW: %9 = func.call @llvm.genx.raw.send2.v64i32.i1.v8i32(%c0_i8, %c0_i8, %true, %c1_i8, %c4_i8, %c15_i8, %c0_i32, %c37880323_i32, %8, %cst_0) : (i8, i8, i1, i8, i8, i8, i32, i32, vector<8xi32>, vector<64xi32>) -> vector<64xi32>
+
+      //LSC: %8 = vector.insert %c1807_i32, %7 [7] : i32 into vector<8xi32>
+      //LSC: %true = arith.constant true
+      //LSC: %c0_i8 = arith.constant 0 : i8
+      //LSC: %c2_i8 = arith.constant 2 : i8
+      //LSC: %c1_i8 = arith.constant 1 : i8
+      //LSC: %9 = vector.bitcast %8 : vector<8xi32> to vector<4xi64>
+      //LSC: %10 = vector.extract %9[0] : i64 from vector<4xi64>
+      //LSC: %c16_i32 = arith.constant 16 : i32
+      //LSC: %c8_i32 = arith.constant 8 : i32
+      //LSC: %11 = vector.extract %8[5] : i32 from vector<8xi32>
+      //LSC: %12 = vector.extract %8[6] : i32 from vector<8xi32>
+      //LSC: %13 = func.call @llvm.genx.lsc.load2d.stateless.v64i32.i1.i64(%true, %c0_i8, %c0_i8, %c2_i8, %c1_i8, %c1_i8, %c16_i32, %c8_i32, %c0_i8, %10, %c63_i32, %c31_i32, %c127_i32, %11, %12) : (i1, i8, i8, i8, i8, i8, i32, i32, i8, i64, i32, i32, i32, i32, i32) -> vector<64xi32>
+      %load_2d = xegpu.load_nd %tdesc_2d : !xegpu.tensor_desc<8x16xf16> -> vector<8x16xf16>
+      gpu.return
+    }
   }
 }

--- a/test/Conversion/XeGPUToVC/store_nd.mlir
+++ b/test/Conversion/XeGPUToVC/store_nd.mlir
@@ -50,5 +50,97 @@ module @gemm attributes {gpu.container_module} {
       // CHECK: gpu.return
       gpu.return
     }
+
+    // CHECK: gpu.func @test_store_nd_1d_strided_memref(%[[arg0:.*]]: memref<32x32xf16, strided<[64, 1]>>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+    gpu.func @test_store_nd_1d_strided_memref(%arg0: memref<32x32xf16, strided<[64,1], offset: 0>>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>}{
+      // CHECK: %cst = arith.constant dense<1.000000e+00> : vector<16xf16>
+      %c1 = arith.constant dense<1.0> : vector<16xf16>
+
+      //CHECK: %cst_0 = arith.constant dense<0> : vector<4xi64>
+      //CHECK: %intptr = memref.extract_aligned_pointer_as_index %arg0 : memref<32x32xf16, strided<[64, 1]>> -> index
+      //CHECK: %c2 = arith.constant 2 : index
+      //CHECK: %c0 = arith.constant 0 : index
+      //CHECK: %0 = arith.muli %c0, %c2 : index
+      //CHECK: %1 = arith.addi %intptr, %0 : index
+      //CHECK: %c128 = arith.constant 128 : index
+      //CHECK: %2 = arith.muli %c0, %c128 : index
+      //CHECK: %3 = arith.addi %1, %2 : index
+      //CHECK: %4 = arith.index_castui %3 : index to i64
+      //CHECK: %5 = vector.insert %4, %cst_0 [0] : i64 into vector<4xi64>
+      %tdesc_1d = xegpu.create_nd_tdesc %arg0[0, 0] : memref<32x32xf16, strided<[64,1], offset: 0>> -> !xegpu.tensor_desc<16xf16>
+
+      //RAW: %6 = vector.bitcast %5 : vector<4xi64> to vector<8xi32>
+      //RAW: %c0_i8 = arith.constant 0 : i8
+      //RAW: %true = arith.constant true
+      //RAW: %c1_i8 = arith.constant 1 : i8
+      //RAW: %c2_i8 = arith.constant 2 : i8
+      //RAW: %c15_i8 = arith.constant 15 : i8
+      //RAW: %c0_i32 = arith.constant 0 : i32
+      //RAW: %c33732484_i32 = arith.constant 33732484 : i32
+      //RAW: %7 = vector.bitcast %cst : vector<16xf16> to vector<4xi64>
+      //RAW: func.call @llvm.genx.raw.sends2.noresult.i1.v8i32.v4i64(%c0_i8, %c0_i8, %true, %c1_i8, %c2_i8, %c15_i8, %c0_i32, %c33732484_i32, %6, %7) : (i8, i8, i1, i8, i8, i8, i32, i32, vector<8xi32>, vector<4xi64>) -> ()
+
+      //LSC: %6 = vector.bitcast %5 : vector<4xi64> to vector<8xi32>
+      //LSC: %true = arith.constant true
+      //LSC: %c0_i8 = arith.constant 0 : i8
+      //LSC: %7 = vector.bitcast %6 : vector<8xi32> to vector<4xi64>
+      //LSC: %8 = vector.extract %7[0] : i64 from vector<4xi64>
+      //LSC: %c4_i8 = arith.constant 4 : i8
+      //LSC: %c1_i16 = arith.constant 1 : i16
+      //LSC: %c0_i32 = arith.constant 0 : i32
+      //LSC: %c2_i8 = arith.constant 2 : i8
+      //LSC: %9 = vector.bitcast %cst : vector<16xf16> to vector<4xi64>
+      //LSC: func.call @llvm.genx.lsc.store.stateless.i1.i64.v4i64(%true, %c4_i8, %c0_i8, %c0_i8, %c1_i16, %c0_i32, %c4_i8, %c4_i8, %c2_i8, %c0_i8, %8, %9, %c0_i32) : (i1, i8, i8, i8, i16, i32, i8, i8, i8, i8, i64, vector<4xi64>, i32) -> ()
+      xegpu.store_nd %c1, %tdesc_1d : vector<16xf16>, !xegpu.tensor_desc<16xf16>
+      gpu.return
+    }
+
+    // CHECK: gpu.func @test_store_nd_2d_strided_memref(%[[arg0:.*]]: memref<32x32xf16, strided<[64, 1]>>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+    gpu.func @test_store_nd_2d_strided_memref(%arg0: memref<32x32xf16, strided<[64,1], offset: 0>>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>}{
+
+      // CHECK: %cst = arith.constant dense<1.000000e+00> : vector<8x16xf16>
+      %c2 = arith.constant dense<1.0> : vector<8x16xf16>
+
+      //CHECK: %cst_0 = arith.constant dense<0> : vector<4xi64>
+      //CHECK: %intptr = memref.extract_aligned_pointer_as_index %arg0 : memref<32x32xf16, strided<[64, 1]>> -> index
+      //CHECK: %0 = arith.index_castui %intptr : index to i64
+      //CHECK: %1 = vector.insert %0, %cst_0 [0] : i64 into vector<4xi64>
+      //CHECK: %2 = vector.bitcast %1 : vector<4xi64> to vector<8xi32>
+      //CHECK: %c63_i32 = arith.constant 63 : i32
+      //CHECK: %c31_i32 = arith.constant 31 : i32
+      //CHECK: %c127_i32 = arith.constant 127 : i32
+      //CHECK: %3 = vector.insert %c63_i32, %2 [2] : i32 into vector<8xi32>
+      //CHECK: %4 = vector.insert %c31_i32, %3 [3] : i32 into vector<8xi32>
+      //CHECK: %5 = vector.insert %c127_i32, %4 [4] : i32 into vector<8xi32>
+      //CHECK: %c0_i32 = arith.constant 0 : i32
+      //CHECK: %6 = vector.insert %c0_i32, %5 [5] : i32 into vector<8xi32>
+      //CHECK: %7 = vector.insert %c0_i32, %6 [6] : i32 into vector<8xi32>
+      //CHECK: %c1807_i32 = arith.constant 1807 : i32
+      %tdesc_2d = xegpu.create_nd_tdesc %arg0[0, 0] : memref<32x32xf16, strided<[64,1], offset: 0>> -> !xegpu.tensor_desc<8x16xf16>
+
+      //RAW: %8 = vector.insert %c1807_i32, %7 [7] : i32 into vector<8xi32>
+      //RAW: %c0_i8 = arith.constant 0 : i8
+      //RAW: %true = arith.constant true
+      //RAW: %c1_i8 = arith.constant 1 : i8
+      //RAW: %c4_i8 = arith.constant 4 : i8
+      //RAW: %c15_i8 = arith.constant 15 : i8
+      //RAW: %c33686023_i32 = arith.constant 33686023 : i32
+      //RAW: func.call @llvm.genx.raw.sends2.noresult.i1.v8i32.v64i32(%c0_i8, %c0_i8, %true, %c1_i8, %c4_i8, %c15_i8, %c0_i32, %c33686023_i32, %8, %cst) : (i8, i8, i1, i8, i8, i8, i32, i32, vector<8xi32>, vector<8x16xf16>) -> ()
+
+      //LSC: %8 = vector.insert %c1807_i32, %7 [7] : i32 into vector<8xi32>
+      //LSC: %true = arith.constant true
+      //LSC: %c0_i8 = arith.constant 0 : i8
+      //LSC: %c2_i8 = arith.constant 2 : i8
+      //LSC: %c1_i8 = arith.constant 1 : i8
+      //LSC: %9 = vector.bitcast %8 : vector<8xi32> to vector<4xi64>
+      //LSC: %10 = vector.extract %9[0] : i64 from vector<4xi64>
+      //LSC: %c16_i32 = arith.constant 16 : i32
+      //LSC: %c8_i32 = arith.constant 8 : i32
+      //LSC: %11 = vector.extract %8[5] : i32 from vector<8xi32>
+      //LSC: %12 = vector.extract %8[6] : i32 from vector<8xi32>
+      //LSC: func.call @llvm.genx.lsc.store2d.stateless.i1.i64.v64i32(%true, %c0_i8, %c0_i8, %c2_i8, %c1_i8, %c1_i8, %c16_i32, %c8_i32, %c0_i8, %10, %c63_i32, %c31_i32, %c127_i32, %11, %12, %cst) : (i1, i8, i8, i8, i8, i8, i32, i32, i8, i64, i32, i32, i32, i32, i32, vector<8x16xf16>) -> ()
+      xegpu.store_nd %c2, %tdesc_2d : vector<8x16xf16>, !xegpu.tensor_desc<8x16xf16>
+      gpu.return
+    }
   }
 }

--- a/test/Integration/Dialect/XeGPU/strided_memref_1d.mlir
+++ b/test/Integration/Dialect/XeGPU/strided_memref_1d.mlir
@@ -1,0 +1,67 @@
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc-rawsend-false.pp \
+// RUN:                                       --runner imex-cpu-runner -e main \
+// RUN:                                       --entry-point-result=void \
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
+// RUN: %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc-rawsend-false.pp \
+// RUN:                                        --runner imex-cpu-runner -e main \
+// RUN:                                        --entry-point-result=void \
+// RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck
+module @gemm attributes {gpu.container_module} {
+  memref.global "private" @__Aconstant_8x32xf32 : memref<8x32xf32> = dense<1.0>
+  memref.global "private" @__Bconstant_8x32xf32 : memref<8x32xf32> = dense<2.0>
+  func.func @test(%arg0: memref<8x32xf32>, %arg1: memref<8x32xf32>) -> memref<8x32xf32> attributes {llvm.emit_c_interface} {
+    %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    %c0_f32 = arith.constant 0.0 : f32
+
+    %A = gpu.alloc  host_shared () : memref<8x32xf32>
+    memref.copy %arg0, %A : memref<8x32xf32> to memref<8x32xf32>
+    %B = gpu.alloc  host_shared () : memref<8x32xf32>
+    memref.copy %arg1, %B : memref<8x32xf32> to memref<8x32xf32>
+
+    %C = gpu.alloc  host_shared () : memref<8x32xf32>
+    %C_unranked = memref.cast %C : memref<8x32xf32> to memref<*xf32>
+    call @fillResource1DF32(%C_unranked, %c0_f32) : (memref<*xf32>, f32) -> ()
+
+    // Create the strided memrefs from A, B, C : first 16 elements of each row
+    %A_strided = memref.subview %A[0, 0][8, 16][1, 1] : memref<8x32xf32> to memref<8x16xf32, strided<[32,1], offset: 0>>
+    %B_strided = memref.subview %B[0, 0][8, 16][1, 1] : memref<8x32xf32> to memref<8x16xf32, strided<[32,1], offset: 0>>
+    %C_strided = memref.subview %C[0, 0][8, 16][1, 1] : memref<8x32xf32> to memref<8x16xf32, strided<[32,1], offset: 0>>
+
+    gpu.launch_func  @test_kernel::@test_kernel blocks in (%c1, %c1, %c1) threads in (%c8, %c1, %c1) args(%A_strided : memref<8x16xf32, strided<[32,1], offset: 0>>, %B_strided  : memref<8x16xf32, strided<[32,1], offset: 0>>, %C_strided : memref<8x16xf32, strided<[32,1], offset: 0>>)
+    gpu.dealloc  %A : memref<8x32xf32>
+    gpu.dealloc  %B : memref<8x32xf32>
+    return %C : memref<8x32xf32>
+  }
+  gpu.module @test_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
+    gpu.func @test_kernel(%arg0: memref<8x16xf32, strided<[32,1], offset: 0>>, %arg1: memref<8x16xf32, strided<[32,1], offset: 0>>, %arg2: memref<8x16xf32, strided<[32,1], offset: 0>>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %thread_id_x = gpu.thread_id x
+
+      %0 = xegpu.create_nd_tdesc %arg0[%thread_id_x, 0] : memref<8x16xf32, strided<[32,1], offset: 0>> -> !xegpu.tensor_desc<16xf32>
+      %1 = xegpu.load_nd %0  : !xegpu.tensor_desc<16xf32> -> vector<16xf32>
+      %2 = xegpu.create_nd_tdesc %arg1[%thread_id_x, 0] : memref<8x16xf32, strided<[32,1], offset: 0>> -> !xegpu.tensor_desc<16xf32>
+      %3 = xegpu.load_nd %2  : !xegpu.tensor_desc<16xf32> -> vector<16xf32>
+      %4 = arith.addf %3, %1 : vector<16xf32>
+      %5 = xegpu.create_nd_tdesc %arg2[%thread_id_x, 0] : memref<8x16xf32, strided<[32,1], offset: 0>> -> !xegpu.tensor_desc<16xf32>
+      xegpu.store_nd %4, %5  : vector<16xf32>, !xegpu.tensor_desc<16xf32>
+      gpu.return
+    }
+  }
+  func.func @main() attributes {llvm.emit_c_interface} {
+
+    // Allocate/get regular row major memrefs
+    %A = memref.get_global @__Aconstant_8x32xf32 : memref<8x32xf32>
+    %B = memref.get_global @__Bconstant_8x32xf32 : memref<8x32xf32>
+
+    %result = call @test(%A, %B) : (memref<8x32xf32>, memref<8x32xf32>) -> memref<8x32xf32>
+
+    %result_cast = memref.cast %result : memref<8x32xf32> to memref<*xf32>
+    call @printMemrefF32(%result_cast) : (memref<*xf32>) -> ()
+    // CHECK: Unranked Memref base@ = {{(0x)?[-9a-f]*}}
+    // CHECK-NEXT:[3,   3,   3,   3,   3,   3,   3,   3,   3,   3,   3,   3,   3,   3,   3,   3,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0],
+
+    return
+  }
+  func.func private @fillResource1DF32(memref<*xf32>, f32) attributes {llvm.emit_c_interface}
+  func.func private @printMemrefF32(memref<*xf32>) attributes {llvm.emit_c_interface}
+}

--- a/test/Integration/Dialect/XeGPU/strided_memref_2d.mlir
+++ b/test/Integration/Dialect/XeGPU/strided_memref_2d.mlir
@@ -1,0 +1,87 @@
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                       --runner imex-cpu-runner -e main \
+// RUN:                                       --entry-point-result=void \
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
+// RUN: %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                        --runner imex-cpu-runner -e main \
+// RUN:                                        --entry-point-result=void \
+// RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck
+module @gemm attributes {gpu.container_module} {
+  memref.global "private" @__Aconstant_32x64xf16 : memref<32x64xf16> = dense<1.0>
+  memref.global "private" @__Bconstant_32x64xf16 : memref<32x64xf16> = dense<2.0>
+  func.func @test(%arg0: memref<32x64xf16>, %arg1: memref<32x64xf16>) -> memref<32x64xf32> attributes {llvm.emit_c_interface} {
+    %c64 = arith.constant 64 : index
+    %c4 = arith.constant 4 : index
+    %c2 = arith.constant 2 : index
+    %c0_f32 = arith.constant 0.0 : f32
+
+    %c1 = arith.constant 1 : index
+    %A = gpu.alloc  host_shared () : memref<32x64xf16>
+    memref.copy %arg0, %A : memref<32x64xf16> to memref<32x64xf16>
+    %B = gpu.alloc  host_shared () : memref<32x64xf16>
+    memref.copy %arg1, %B : memref<32x64xf16> to memref<32x64xf16>
+
+    %C = gpu.alloc  host_shared () : memref<32x64xf32>
+    %C_unranked = memref.cast %C : memref<32x64xf32> to memref<*xf32>
+    call @fillResource1DF32(%C_unranked, %c0_f32) : (memref<*xf32>, f32) -> ()
+
+    // Create the strided memrefs from A, B, C : first 32 elements of each row
+    %A_strided = memref.subview %A[0, 0][32, 32][1, 1] : memref<32x64xf16> to memref<32x32xf16, strided<[64,1], offset: 0>>
+    %B_strided = memref.subview %B[0, 0][32, 32][1, 1] : memref<32x64xf16> to memref<32x32xf16, strided<[64,1], offset: 0>>
+    %C_strided = memref.subview %C[0, 0][32, 32][1, 1] : memref<32x64xf32> to memref<32x32xf32, strided<[64,1], offset: 0>>
+
+    gpu.launch_func  @test_kernel::@test_kernel blocks in (%c4, %c2, %c1) threads in (%c1, %c1, %c1) args(%A_strided : memref<32x32xf16, strided<[64,1], offset: 0>>, %B_strided : memref<32x32xf16, strided<[64,1], offset: 0>>, %C_strided : memref<32x32xf32, strided<[64,1], offset: 0>>)
+    gpu.dealloc  %A : memref<32x64xf16>
+    gpu.dealloc  %B : memref<32x64xf16>
+    return %C : memref<32x64xf32>
+  }
+
+gpu.module @test_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
+    gpu.func @test_kernel(%A: memref<32x32xf16, strided<[64,1], offset: 0>>, %B: memref<32x32xf16, strided<[64,1], offset: 0>>, %C: memref<32x32xf32, strided<[64,1], offset: 0>>) kernel attributes {VectorComputeFunctionINTEL, gpu.known_block_size = array<i32: 1, 1, 1>, gpu.known_grid_size = array<i32: 4, 2, 1>, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %c0 = arith.constant 0 : index
+      %c16 = arith.constant 16 : index
+      %c32 = arith.constant 32 : index
+      %c8 = arith.constant 8 : index
+      %cst = arith.constant dense<1.0> : vector<8x16xf16>
+      %0 = gpu.block_id  x
+      %1 = gpu.block_id  y
+
+      %2 = arith.muli %0, %c8 : index
+      %3 = arith.muli %1, %c16 : index
+
+      %4 = xegpu.create_nd_tdesc %C[%2, %3] : memref<32x32xf32, strided<[64,1], offset: 0>> -> !xegpu.tensor_desc<8x16xf32>
+      %5 = xegpu.load_nd %4 : !xegpu.tensor_desc<8x16xf32> -> vector<8x16xf32>
+
+      %6 = scf.for %arg3 = %c0 to %c32 step %c16 iter_args(%arg4 = %5) -> (vector<8x16xf32>) {
+        %A0 = xegpu.create_nd_tdesc %A[%2, %arg3] : memref<32x32xf16, strided<[64,1], offset: 0>> -> !xegpu.tensor_desc<8x16xf16>
+        %A0_val = xegpu.load_nd %A0 : !xegpu.tensor_desc<8x16xf16> -> vector<8x16xf16>
+
+        %B0 = xegpu.create_nd_tdesc %B[%arg3, %3] : memref<32x32xf16, strided<[64,1], offset: 0>> -> !xegpu.tensor_desc<16x16xf16>
+        %B0_val = xegpu.load_nd %B0 {packed} : !xegpu.tensor_desc<16x16xf16> -> vector<8x16x2xf16>
+
+        %A0_preop = arith.addf %A0_val, %cst : vector<8x16xf16>
+
+        %dpas0 = xegpu.dpas %A0_preop, %B0_val , %arg4: vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+        scf.yield %dpas0 : vector<8x16xf32>
+      }
+      xegpu.store_nd %6, %4 : vector<8x16xf32>, !xegpu.tensor_desc<8x16xf32>
+
+      gpu.return
+    }
+  }
+
+  func.func @main() attributes {llvm.emit_c_interface} {
+    // Allocate/get regular row major memrefs
+    %A = memref.get_global @__Aconstant_32x64xf16 : memref<32x64xf16>
+    %B = memref.get_global @__Bconstant_32x64xf16 : memref<32x64xf16>
+
+    %result = call @test(%A, %B) : (memref<32x64xf16>, memref<32x64xf16>) -> memref<32x64xf32>
+    %result_cast = memref.cast %result : memref<32x64xf32> to memref<*xf32>
+    call @printMemrefF32(%result_cast) : (memref<*xf32>) -> ()
+    // CHECK: Unranked Memref base@ = {{(0x)?[-9a-f]*}}
+    // CHECK-NEXT:[128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0],
+    return
+  }
+  func.func private @fillResource1DF32(memref<*xf32>, f32) attributes {llvm.emit_c_interface}
+  func.func private @printMemrefF32(memref<*xf32>) attributes {llvm.emit_c_interface}
+}


### PR DESCRIPTION
Only supports static memrefs.
Only support non-uniform strides in Non Fast Changing Dimensions(FCD), FCD stride must be 1.

Please review these guidelines to help with the review process:
- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [x] Have you organized your commits logically and ensured each can be built by itself?
