### PR TITLE
[GPU] Allow passing 'clientAPI' arg using public API

### DIFF
--- a/include/imex/Transforms/Passes.h
+++ b/include/imex/Transforms/Passes.h
@@ -23,9 +23,11 @@ namespace imex {
 // Passes
 //===----------------------------------------------------------------------===//
 std::unique_ptr<mlir::Pass> createSerializeSPIRVPass();
-std::unique_ptr<mlir::Pass> createInsertGPUAllocsPass();
+std::unique_ptr<mlir::Pass>
+createInsertGPUAllocsPass(const char *clientAPI = "vulkan");
 std::unique_ptr<mlir::Pass> createSetSPIRVCapabilitiesPass();
-std::unique_ptr<mlir::Pass> createSetSPIRVAbiAttributePass();
+std::unique_ptr<mlir::Pass>
+createSetSPIRVAbiAttributePass(const char *clientAPI = "vulkan");
 std::unique_ptr<mlir::Pass> createAddOuterParallelLoopPass();
 std::unique_ptr<mlir::Pass> createLowerMemRefCopyPass();
 std::unique_ptr<mlir::Pass> createBF16ToGPUPass();

--- a/lib/Transforms/InsertGPUAllocs.cpp
+++ b/lib/Transforms/InsertGPUAllocs.cpp
@@ -503,7 +503,7 @@ private:
 } // namespace
 
 namespace imex {
-std::unique_ptr<mlir::Pass> createInsertGPUAllocsPass() {
-  return std::make_unique<InsertGPUAllocsPass>();
+std::unique_ptr<mlir::Pass> createInsertGPUAllocsPass(const char *clientAPI) {
+  return std::make_unique<InsertGPUAllocsPass>(clientAPI);
 }
 } // namespace imex

--- a/lib/Transforms/SetSPIRVAbiAttribute.cpp
+++ b/lib/Transforms/SetSPIRVAbiAttribute.cpp
@@ -88,7 +88,8 @@ private:
 } // namespace
 
 namespace imex {
-std::unique_ptr<mlir::Pass> createSetSPIRVAbiAttributePass() {
-  return std::make_unique<SetSPIRVAbiAttributePass>();
+std::unique_ptr<mlir::Pass>
+createSetSPIRVAbiAttributePass(const char *clientAPI) {
+  return std::make_unique<SetSPIRVAbiAttributePass>(clientAPI);
 }
 } // namespace imex


### PR DESCRIPTION
These changes allow users of IMEX to pass clientAPI to the InsertGPUAllocs and SetSPIRVAbiAttribute passes using their public interface (via createInsertGPUAllocs() function).

Please review these guidelines to help with the review process:
- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [ ] Have you organized your commits logically and ensured each can be built by itself?
