### PR TITLE
[NFC] Adding tablegened dialect headers into IMEX_CONFIG_INCLUDE_DIRS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,7 +265,8 @@ endif()
 # IMEX headers in source tree
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 # Generated IMEX headers
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
+set(IMEX_GENERATED_HEADER_DIR ${CMAKE_CURRENT_BINARY_DIR})
+include_directories(${IMEX_GENERATED_HEADER_DIR}/include)
 message(STATUS "LLVM_DEFINITIONS: ${LLVM_DEFINITIONS}")
 add_definitions(${LLVM_DEFINITIONS})
 

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -96,7 +96,7 @@ set(IMEX_CONFIG_INCLUDE_EXPORTS "include(\"\${IMEX_CMAKE_DIR}/IMEXTargets.cmake\
 set(IMEX_CONFIG_INCLUDE_DIRS
     "${IMEX_SOURCE_DIR}/include"
     "${IMEX_BINARY_DIR}/include"
-    "${IMEX_BINARY_DIR}/tools/Imex/include"
+    "${IMEX_GENERATED_HEADER_DIR}/include"
 )
 
 configure_file(

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -96,6 +96,7 @@ set(IMEX_CONFIG_INCLUDE_EXPORTS "include(\"\${IMEX_CMAKE_DIR}/IMEXTargets.cmake\
 set(IMEX_CONFIG_INCLUDE_DIRS
     "${IMEX_SOURCE_DIR}/include"
     "${IMEX_BINARY_DIR}/include"
+    "${IMEX_BINARY_DIR}/tools/Imex/include"
 )
 
 configure_file(


### PR DESCRIPTION
Added dialect headers into IMEX_CONFIG_INCLUDE_DIRS, so that other project can build their projects using imex build folder directly, without deploying it (save disk space)