### PR TITLE
Align the interface of CreateDescOp and UpdateOffsetOp to the upstream definition

### DIFF
--- a/build_tools/patches/0007-Move-chunk_size-into-TensorDesc.patch
+++ b/build_tools/patches/0007-Move-chunk_size-into-TensorDesc.patch
@@ -1,3 +1,16 @@
+From c1a7d459790db5335907947cf44dcbd230cec783 Mon Sep 17 00:00:00 2001
+From: Chao Chen <chao.chen@intel.com>
+Date: Thu, 29 Aug 2024 17:58:34 +0000
+Subject: [PATCH] move chunk_size into TensorDesc
+
+---
+ .../mlir/Dialect/XeGPU/IR/XeGPUAttrs.td       | 46 +++++++++++---
+ .../include/mlir/Dialect/XeGPU/IR/XeGPUOps.td | 19 ++----
+ .../mlir/Dialect/XeGPU/IR/XeGPUTypes.td       | 63 ++++++++++++-------
+ mlir/lib/Dialect/XeGPU/IR/XeGPUDialect.cpp    | 40 ++++++++----
+ mlir/lib/Dialect/XeGPU/IR/XeGPUOps.cpp        | 31 ++++-----
+ 5 files changed, 122 insertions(+), 77 deletions(-)
+
 diff --git a/mlir/include/mlir/Dialect/XeGPU/IR/XeGPUAttrs.td b/mlir/include/mlir/Dialect/XeGPU/IR/XeGPUAttrs.td
 index f3ca09a6a68e..6ffb4eb3c60f 100644
 --- a/mlir/include/mlir/Dialect/XeGPU/IR/XeGPUAttrs.td
@@ -85,10 +98,10 @@ index f3ca09a6a68e..6ffb4eb3c60f 100644
 \ No newline at end of file
 +#endif // MLIR_DIALECT_XEGPU_IR_XEGPUATTRS_TD
 diff --git a/mlir/include/mlir/Dialect/XeGPU/IR/XeGPUOps.td b/mlir/include/mlir/Dialect/XeGPU/IR/XeGPUOps.td
-index c32c7541c397..f84c5a9d6e38 100644
+index c32c7541c397..13a0bff5de1a 100644
 --- a/mlir/include/mlir/Dialect/XeGPU/IR/XeGPUOps.td
 +++ b/mlir/include/mlir/Dialect/XeGPU/IR/XeGPUOps.td
-@@ -411,34 +411,30 @@ def XeGPU_CreateDescOp: XeGPU_Op<"create_tdesc", [Pure, ViewLikeOpInterface]> {
+@@ -411,42 +411,33 @@ def XeGPU_CreateDescOp: XeGPU_Op<"create_tdesc", [Pure, ViewLikeOpInterface]> {
        is fixed to the hardware supportted subgroup size, e.g., 16 on PVC,
        implying each element in the array corresponds to a work-item (SIMT lane)
        in the subgroup.
@@ -120,14 +133,22 @@ index c32c7541c397..f84c5a9d6e38 100644
    }];
 
    let arguments = (ins XeGPU_BaseAddrType: $source,
--                       Variadic<Index>: $offsets,
+                        Variadic<Index>: $offsets,
 -                       DenseI64ArrayAttr: $const_offsets,
 -                       DefaultValuedAttr<I64Attr, "1">: $chunk_size);
-+                       XeGPU_OffsetType: $offsets);
++                       DenseI64ArrayAttr: $const_offsets);
    let results = (outs XeGPU_TensorDesc:$TensorDesc);
 
-   let builders = [
-@@ -723,7 +691,7 @@ def XeGPU_DpasOp : XeGPU_Op<"dpas", [Pure, AllElementTypesMatch<["lhs", "rhs"]>]
+-  let builders = [
+-    OpBuilder<(ins "xegpu::TensorDescType": $TensorDesc, "Value": $source,
+-                   "llvm::ArrayRef<OpFoldResult>": $offsets,
+-                   CArg<"uint32_t", "1"> : $chunk_size)>,
+-  ];
+-
+   let assemblyFormat = [{
+     $source
+     custom<DynamicIndexList>($offsets, $const_offsets)
+@@ -723,7 +714,7 @@ def XeGPU_DpasOp : XeGPU_Op<"dpas", [Pure, AllElementTypesMatch<["lhs", "rhs"]>]
 
  def XeGPU_AtomicRMWOp: XeGPU_Op<"atomic_rmw", [Pure,
        AllElementTypesMatch<["tensorDesc", "value", "result"]>,
@@ -300,7 +321,7 @@ index 24719fe748fe..0eab601bbaac 100644
  }
 
 diff --git a/mlir/lib/Dialect/XeGPU/IR/XeGPUOps.cpp b/mlir/lib/Dialect/XeGPU/IR/XeGPUOps.cpp
-index 8e185b8d2586..a023c616333e 100644
+index 8e185b8d2586..ee3834bd0d9c 100644
 --- a/mlir/lib/Dialect/XeGPU/IR/XeGPUOps.cpp
 +++ b/mlir/lib/Dialect/XeGPU/IR/XeGPUOps.cpp
 @@ -153,7 +153,7 @@ LogicalResult CreateNdDescOp::verify() {
@@ -330,15 +351,6 @@ index 8e185b8d2586..a023c616333e 100644
      return emitOpError("Expects a non-scattered TensorDesc.\n");
 
    if (!valueTy)
-@@ -222,7 +222,7 @@ LogicalResult LoadNdOp::verify() {
-       emitWarning("Invalid transpose attr. It is ignored.");
-   }
-
--  if (getPacked()) {
-+  if (getPacked() || getTransposeBitWidth() == 32) {
-     if (tdescTy.getRank() == 2) {
-       const int axis = 0;
-       auto vnni_factor = valueShape.back();
 @@ -257,7 +257,7 @@ LogicalResult StoreNdOp::verify() {
    if (dstTy.getRank() > 2)
      return emitOpError("Expecting a 1D/2D TensorDesc.\n");
@@ -357,7 +369,20 @@ index 8e185b8d2586..a023c616333e 100644
      return emitOpError("Expects a non-scattered TensorDesc.\n");
 
    // number of offsets specified must match the rank of the tensor descriptor
-@@ -306,15 +306,16 @@ void CreateDescOp::build(OpBuilder &builder, OperationState &state,
+@@ -293,28 +293,19 @@ LogicalResult UpdateNdOffsetOp::verify() {
+ //===----------------------------------------------------------------------===//
+ // XeGPU_CreateDescOp
+ //===----------------------------------------------------------------------===//
+-void CreateDescOp::build(OpBuilder &builder, OperationState &state,
+-                         TensorDescType TensorDesc, Value source,
+-                         llvm::ArrayRef<OpFoldResult> offsets,
+-                         uint32_t chunk_size) {
+-  llvm::SmallVector<int64_t> staticOffsets;
+-  llvm::SmallVector<Value> dynamicOffsets;
+-  dispatchIndexOpFoldResults(offsets, dynamicOffsets, staticOffsets);
+-  build(builder, state, TensorDesc, source, dynamicOffsets, staticOffsets,
+-        chunk_size);
+-}
 
  LogicalResult CreateDescOp::verify() {
    auto tdescTy = getTensorDescType();
@@ -376,7 +401,7 @@ index 8e185b8d2586..a023c616333e 100644
    SmallVector<int64_t> shape({(int64_t)getNumOffsets()});
    if (chunkSize != 1)
      shape.push_back(chunkSize);
-@@ -332,7 +333,7 @@ LogicalResult CreateDescOp::verify() {
+@@ -332,7 +323,7 @@ LogicalResult CreateDescOp::verify() {
  //===----------------------------------------------------------------------===//
  LogicalResult PrefetchOp::verify() {
    auto tdescTy = getTensorDescType();
@@ -385,7 +410,7 @@ index 8e185b8d2586..a023c616333e 100644
      return emitOpError("Expects a scattered TensorDesc.\n");
 
    if (!isReadHintOrNone(getL1HintAttr()))
-@@ -355,7 +356,7 @@ LogicalResult LoadGatherOp::verify() {
+@@ -355,7 +346,7 @@ LogicalResult LoadGatherOp::verify() {
    auto maskTy = getMaskType();
    auto valueTy = getValueType();
 
@@ -394,7 +419,7 @@ index 8e185b8d2586..a023c616333e 100644
      return emitOpError("Expects a scattered TensorDesc.\n");
 
    if (!isReadHintOrNone(getL1HintAttr()))
-@@ -401,7 +402,7 @@ LogicalResult LoadGatherOp::verify() {
+@@ -401,7 +392,7 @@ LogicalResult LoadGatherOp::verify() {
  //===----------------------------------------------------------------------===//
  LogicalResult StoreScatterOp::verify() {
    auto tdescTy = getTensorDescType();
@@ -403,3 +428,5 @@ index 8e185b8d2586..a023c616333e 100644
      return emitOpError("Expects a scattered TensorDesc.\n");
 
    if (!isWriteHintOrNone(getL1HintAttr()))
+--
+2.34.1

--- a/build_tools/patches/0008-xegpu-temporary-downstream-defintion-changes.patch
+++ b/build_tools/patches/0008-xegpu-temporary-downstream-defintion-changes.patch
@@ -1,149 +1,48 @@
+From c5e6d0bd63d6aab004ae4e795f1466800c54b3ff Mon Sep 17 00:00:00 2001
+From: Chao Chen <chao.chen@intel.com>
+Date: Thu, 29 Aug 2024 19:18:42 +0000
+Subject: [PATCH] Add temporary changes for downstream: - add transposeBitWidth
+ for load_nd - add CompileHintOp
+
+---
+ mlir/include/mlir/Dialect/XeGPU/IR/XeGPUOps.td | 6 ++++++
+ mlir/lib/Dialect/XeGPU/IR/XeGPUOps.cpp         | 2 +-
+ 2 files changed, 7 insertions(+), 1 deletion(-)
+
 diff --git a/mlir/include/mlir/Dialect/XeGPU/IR/XeGPUOps.td b/mlir/include/mlir/Dialect/XeGPU/IR/XeGPUOps.td
-index f84c5a9d6e38..5f6ef2e237d6 100644
+index 13a0bff5de1a..64b15fd1cc32 100644
 --- a/mlir/include/mlir/Dialect/XeGPU/IR/XeGPUOps.td
 +++ b/mlir/include/mlir/Dialect/XeGPU/IR/XeGPUOps.td
 @@ -285,6 +285,7 @@ def XeGPU_LoadNdOp : XeGPU_Op<"load_nd", [AllElementTypesMatch<["value", "Tensor
    let arguments = (ins XeGPU_TensorDesc: $TensorDesc,
                         OptionalAttr<UnitAttr>: $packed,
                         OptionalAttr<DenseI64ArrayAttr>: $transpose,
-+		       OptionalAttr<I32Attr>: $transpose_bit_width,
++                       OptionalAttr<I32Attr>: $transpose_bit_width,
                         OptionalAttr<XeGPU_CacheHintAttr>: $l1_hint,
                         OptionalAttr<XeGPU_CacheHintAttr>: $l2_hint,
                         OptionalAttr<XeGPU_CacheHintAttr>: $l3_hint);
-@@ -437,38 +438,21 @@ def XeGPU_CreateDescOp: XeGPU_Op<"create_tdesc", [Pure, ViewLikeOpInterface]> {
-                        XeGPU_OffsetType: $offsets);
-   let results = (outs XeGPU_TensorDesc:$TensorDesc);
-
--  let builders = [
--    OpBuilder<(ins "xegpu::TensorDescType": $TensorDesc, "Value": $source,
--                   "llvm::ArrayRef<OpFoldResult>": $offsets,
--                   CArg<"uint32_t", "1"> : $chunk_size)>,
--  ];
--
-   let assemblyFormat = [{
--    $source
--    custom<DynamicIndexList>($offsets, $const_offsets)
--    attr-dict `:`  type($source) `->` qualified(type($TensorDesc))
-+  $source `,` $offsets attr-dict `:`  type($source) `,` type($offsets) `->` qualified(type($TensorDesc))
-   }];
-
--  let extraClassDeclaration = extraBaseClassDeclaration # [{
-+  let extraClassDeclaration = [{
-     xegpu::TensorDescType getTensorDescType() {
-       return getTensorDesc().getType();
-     }
-
--    SmallVector<OpFoldResult> getMixedOffsets() {
--      Builder b(getContext());
--      return getMixedValues(getConstOffsets(), getOffsets(), b);
--    }
--
-     size_t getNumOffsets() {
--      return getMixedOffsets().size();
-+      return getOffsets().getType().getShape()[0];
-     }
-
-     mlir::Value getViewSource() { return getSource(); }
-
--    OpFoldResult getOffset(unsigned idx) {
--      assert(idx < getNumOffsets() && "Invalid out of bound access.");
--      return getMixedOffsets()[idx];
--    }
-   }];
-
-   let hasVerifier = 1;
-@@ -632,34 +616,22 @@ def XeGPU_UpdateOffsetOp: XeGPU_Op<"update_offset",
-   }];
-
-   let arguments = (ins XeGPU_TensorDesc: $TensorDesc,
--                       Variadic<Index>: $offsets,
--                       DenseI64ArrayAttr: $const_offsets);
-+                       XeGPU_OffsetType: $offsets);
-   let results = (outs XeGPU_TensorDesc: $result);
-
--  let extraClassDeclaration = extraBaseClassDeclaration # [{
-+  let extraClassDeclaration = [{
-     xegpu::TensorDescType getTensorDescType() {
-       return getTensorDesc().getType();
-     }
-
--    SmallVector<OpFoldResult> getMixedOffsets() {
--      Builder b(getContext());
--      return getMixedValues(getConstOffsets(), getOffsets(), b);
--    }
--
-     size_t getNumOffsets() {
--      return getMixedOffsets().size();
--    }
--
--    OpFoldResult getOffset(unsigned idx) {
--      assert(idx < getNumOffsets() && "Invalid out of bound access.");
--      return getMixedOffsets()[idx];
-+      return getOffsets().getType().getShape()[0];
-     }
-   }];
-
-   let assemblyFormat = [{
--    $TensorDesc `,`
--    custom<DynamicIndexList>($offsets, $const_offsets)
--    attr-dict `:` qualified(type($TensorDesc))
-+     $TensorDesc `,` $offsets attr-dict `:`
-+     qualified(type($TensorDesc)) `,` type($offsets) `->` qualified(type($result))
-   }];
- }
-
-@@ -810,4 +782,13 @@ def XeGPU_FenceOp: XeGPU_Op<"fence", []> {
+@@ -805,4 +806,9 @@ def XeGPU_FenceOp: XeGPU_Op<"fence", []> {
    let extraClassDeclaration = extraBaseClassDeclaration;
  }
 
-+def XeGPU_CompileHintOp
-+  : XeGPU_Op<"compile_hint", []> {
-+      let summary = "prevents the compiler from scheduling.";
-+
-+      let assemblyFormat = [{
-+        attr-dict
-+      }];
-+  }
++def XeGPU_CompileHintOp : XeGPU_Op<"compile_hint", []> {
++  let summary = "prevents the compiler from scheduling.";
++  let assemblyFormat = [{ attr-dict }];
++}
 +
  #endif // MLIR_DIALECT_XEGPU_IR_XEGPUOPS_TD
 diff --git a/mlir/lib/Dialect/XeGPU/IR/XeGPUOps.cpp b/mlir/lib/Dialect/XeGPU/IR/XeGPUOps.cpp
-index a023c616333e..222cfa9fbc00 100644
+index ee3834bd0d9c..98fc3308d96e 100644
 --- a/mlir/lib/Dialect/XeGPU/IR/XeGPUOps.cpp
 +++ b/mlir/lib/Dialect/XeGPU/IR/XeGPUOps.cpp
-@@ -293,17 +293,6 @@ LogicalResult UpdateNdOffsetOp::verify() {
- //===----------------------------------------------------------------------===//
- // XeGPU_CreateDescOp
- //===----------------------------------------------------------------------===//
--void CreateDescOp::build(OpBuilder &builder, OperationState &state,
--                         TensorDescType TensorDesc, Value source,
--                         llvm::ArrayRef<OpFoldResult> offsets,
--                         uint32_t chunk_size) {
--  llvm::SmallVector<int64_t> staticOffsets;
--  llvm::SmallVector<Value> dynamicOffsets;
--  dispatchIndexOpFoldResults(offsets, dynamicOffsets, staticOffsets);
--  build(builder, state, TensorDesc, source, dynamicOffsets, staticOffsets,
--        chunk_size);
--}
--
- LogicalResult CreateDescOp::verify() {
-   auto tdescTy = getTensorDescType();
+@@ -222,7 +222,7 @@ LogicalResult LoadNdOp::verify() {
+       emitWarning("Invalid transpose attr. It is ignored.");
+   }
 
-@@ -429,14 +418,14 @@ LogicalResult DpasOp::verify() {
-   int64_t lhsRank = getLhsType().getRank();
-   int64_t rhsRank = getRhsType().getRank();
-
--  if (lhsRank != 2 || (rhsRank != 2 && rhsRank != 3))
--    return emitOpError("expecting lhs to be a 2D vector, and rhs to be either "
--                       "2D or 3D (packed) vector.");
-+  // if (lhsRank != 2 || (rhsRank != 2 && rhsRank != 3))
-+  //   return emitOpError("expecting lhs to be a 2D vector, and rhs to be either 2D or 3D (vnni transformed) vector.");
-
-   auto lhsShape = getLhsType().getShape();
-   auto rhsShape = getRhsType().getShape();
-+  auto aK = lhsRank == 3 ? lhsShape[1] * lhsShape[2] : lhsShape[1];
-   auto bK = rhsRank == 3 ? rhsShape[0] * rhsShape[2] : rhsShape[0];
--  if (bK != lhsShape[1])
-+  if (aK != bK)
-     return emitOpError("K-dimension mismatch.");
-
-   return success();
+-  if (getPacked()) {
++  if (getPacked() || getTransposeBitWidth() == 32) {
+     if (tdescTy.getRank() == 2) {
+       const int axis = 0;
+       auto vnni_factor = valueShape.back();
+--
+2.34.1

--- a/test/Conversion/XeGPUToVC/atomiclsc.mlir
+++ b/test/Conversion/XeGPUToVC/atomiclsc.mlir
@@ -4,30 +4,46 @@ module @gemm attributes {gpu.container_module} {
   gpu.module @test_kernel {
     // CHECK: func.func private @llvm.genx.lsc.xatomic.stateless.v16i32.v16i1.v16i64(vector<16xi1>, i8, i8, i8, i16, i32, i8, i8, i8, vector<16xi1>, vector<16xi64>, vector<16xi32>, vector<16xi32>, i32, vector<16xi32>) -> vector<16xi32> attributes {VectorComputeFunctionINTEL, linkage_attributes = #spirv.linkage_attributes<linkage_name = "llvm.genx.lsc.xatomic.stateless.v16i32.v16i1.v16i64", linkage_type = <Import>>}
     gpu.func @test_atomiclsc(%arg0: memref<128xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
-      // CHECK:  %[[cst:.*]] = arith.constant dense<true> : vector<16xi1>
-      %mask = arith.constant dense<true> : vector<16xi1>
 
-      // CHECK: %[[cst_0:.*]] = arith.constant dense<5.000000e-01> : vector<16xf32>
-      %1 = arith.constant dense<0.5> : vector<16xf32>
-
+      //CHECK: %[[cst:.*]] = arith.constant dense<true> : vector<16xi1>
+      //CHECK: %[[cst_0:.*]] = arith.constant dense<5.000000e-01> : vector<16xf32>
       //CHECK: %[[intptr:.*]] = memref.extract_aligned_pointer_as_index %{{.*}} : memref<128xf32> -> index
       //CHECK: %[[r0:.*]] = arith.index_castui %[[intptr]] : index to i64
-      //CHECK: %[[cst_1:.*]] = arith.constant dense<[0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60]> : vector<16xi64>
-      //CHECK: %[[r1:.*]] = vector.broadcast %[[r0]] : i64 to vector<16xi64>
-      //CHECK: %[[r2:.*]] = arith.addi %[[r1]], %[[cst_1]] : vector<16xi64>
+      //CHECK: %[[cst_1:.*]] = arith.constant dense<4> : vector<16xi64>
+      //CHECK: %[[c0:.*]] = arith.constant 0 : index
+      //CHECK: %[[c1:.*]] = arith.constant 1 : index
+      //CHECK: %[[c2:.*]] = arith.constant 2 : index
+      //CHECK: %[[c3:.*]] = arith.constant 3 : index
+      //CHECK: %[[c4:.*]] = arith.constant 4 : index
+      //CHECK: %[[c5:.*]] = arith.constant 5 : index
+      //CHECK: %[[c6:.*]] = arith.constant 6 : index
+      //CHECK: %[[c7:.*]] = arith.constant 7 : index
+      //CHECK: %[[c8:.*]] = arith.constant 8 : index
+      //CHECK: %[[c9:.*]] = arith.constant 9 : index
+      //CHECK: %[[c10:.*]] = arith.constant 10 : index
+      //CHECK: %[[c11:.*]] = arith.constant 11 : index
+      //CHECK: %[[c12:.*]] = arith.constant 12 : index
+      //CHECK: %[[c13:.*]] = arith.constant 13 : index
+      //CHECK: %[[c14:.*]] = arith.constant 14 : index
+      //CHECK: %[[c15:.*]] = arith.constant 15 : index
+      //CHECK: %[[r1:.*]] = vector.from_elements %[[c0]], %[[c1]], %[[c2]], %[[c3]], %[[c4]], %[[c5]], %[[c6]], %[[c7]], %[[c8]], %[[c9]], %[[c10]], %[[c11]], %[[c12]], %[[c13]], %[[c14]], %[[c15]] : vector<16xindex>
+      //CHECK: %[[r2:.*]] = arith.index_castui %[[r1]] : vector<16xindex> to vector<16xi64>
+      //CHECK: %[[r3:.*]] = arith.muli %[[r2]], %[[cst_1]] : vector<16xi64>
+      //CHECK: %[[r4:.*]] = vector.broadcast %[[r0]] : i64 to vector<16xi64>
+      //CHECK: %[[r5:.*]] = arith.addi %[[r4]], %[[r3]] : vector<16xi64>
       //CHECK: %[[c19_i8:.*]] = arith.constant 19 : i8
       //CHECK: %[[c1_i8:.*]] = arith.constant 1 : i8
       //CHECK: %[[c1_i16:.*]] = arith.constant 1 : i16
       //CHECK: %[[c0_i32:.*]] = arith.constant 0 : i32
       //CHECK: %[[c3_i8:.*]] = arith.constant 3 : i8
       //CHECK: %[[cst_2:.*]] = arith.constant dense<0> : vector<16xi32>
-      //CHECK: %[[r3:.*]] = vector.bitcast %[[cst_0]] : vector<16xf32> to vector<16xi32>
-      //CHECK: %[[r4:.*]] = func.call @llvm.genx.lsc.xatomic.stateless.v16i32.v16i1.v16i64(
-      //CHECK-SAME: %[[cst]], %[[c19_i8]], %[[c1_i8]], %[[c1_i8]], %[[c1_i16]], %[[c0_i32]], %[[c3_i8]],
-      //CHECK-SAME: %[[c1_i8]], %[[c1_i8]], %[[cst]], %[[r2]], %[[r3]], %[[cst_2]], %[[c0_i32]], %[[cst_2]])
-      //CHECK-SAME: (vector<16xi1>, i8, i8, i8, i16, i32, i8, i8, i8, vector<16xi1>, vector<16xi64>, vector<16xi32>, vector<16xi32>, i32, vector<16xi32>) -> vector<16xi32>
+      //CHECK: %[[r6:.*]] = vector.bitcast %[[cst_0]] : vector<16xf32> to vector<16xi32>
+      //CHECK: %[[r7:.*]] = func.call @llvm.genx.lsc.xatomic.stateless.v16i32.v16i1.v16i64(%[[cst]], %[[c19_i8]], %[[c1_i8]], %[[c1_i8]], %[[c1_i16]], %[[c0_i32]], %[[c3_i8]], %[[c1_i8]], %[[c1_i8]], %[[cst]], %[[r5]], %[[r6]], %[[cst_2]], %[[c0_i32]], %[[cst_2]]) : (vector<16xi1>, i8, i8, i8, i16, i32, i8, i8, i8, vector<16xi1>, vector<16xi64>, vector<16xi32>, vector<16xi32>, i32, vector<16xi32>) -> vector<16xi32>
+
+      %mask = arith.constant dense<true> : vector<16xi1>
+      %1 = arith.constant dense<0.5> : vector<16xf32>
       %offsets = arith.constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]> : vector<16xindex>
-      %2 = xegpu.create_tdesc %arg0, %offsets : memref<128xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
+      %2 = xegpu.create_tdesc %arg0[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : memref<128xf32> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
       %3 = xegpu.atomic_rmw "addf" %2, %mask, %1 : !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>, vector<16xi1>, vector<16xf32> -> vector<16xf32>
       gpu.return
     }

--- a/test/Conversion/XeGPUToVC/load_global_no_chunk_f16.mlir
+++ b/test/Conversion/XeGPUToVC/load_global_no_chunk_f16.mlir
@@ -9,38 +9,39 @@ gpu.module @test_kernel {
     //CHECK: %[[mask:.*]] = arith.constant dense<true> : vector<16xi1>
     %mask = arith.constant dense<1> : vector<16xi1>
 
-    %offsets = arith.constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]> : vector<16xindex>
-
     //CHECK: %[[a_ptr:.*]] = memref.extract_aligned_pointer_as_index %[[arg0]] : memref<16xf16> -> index
     //CHECK: %[[r0:.*]] = arith.index_castui %[[a_ptr]] : index to i64
-    //CHECK: %[[cst_0:.*]] = arith.constant dense<[0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30]> : vector<16xi64>
-    //CHECK: %[[r1:.*]] = vector.broadcast %[[r0]] : i64 to vector<16xi64>
-    //CHECK: %[[r2:.*]] = arith.addi %[[r1]], %[[cst_0]] : vector<16xi64>
-    %a_tdesc = xegpu.create_tdesc %a, %offsets : memref<16xf16>, vector<16xindex> -> !xegpu.tensor_desc<16xf16, #scatter>
+    //CHECK: %[[cst_0:.*]] = arith.constant dense<2> : vector<16xi64>
+    //CHECK: %[[r1:.*]] = vector.from_elements {{.*}} : vector<16xindex>
+    //CHECK: %[[r2:.*]] = arith.index_castui %[[r1]] : vector<16xindex> to vector<16xi64>
+    //CHECK: %[[r3:.*]] = arith.muli %[[r2]], %[[cst_0]] : vector<16xi64>
+    //CHECK: %[[r4:.*]] = vector.broadcast %[[r0]] : i64 to vector<16xi64>
+    //CHECK: %[[r5:.*]] = arith.addi %[[r4]], %[[r3]] : vector<16xi64>
+    %a_tdesc = xegpu.create_tdesc %a[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : memref<16xf16> -> !xegpu.tensor_desc<16xf16, #scatter>
 
     //CHECK: %[[c0_i8:.*]] = arith.constant 0 : i8
     //CHECK: %[[c1_i16:.*]] = arith.constant 1 : i16
     //CHECK: %[[c0_i32:.*]] = arith.constant 0 : i32
     //CHECK: %[[c6_i8:.*]] = arith.constant 6 : i8
     //CHECK: %[[c1_i8:.*]] = arith.constant 1 : i8
-    //CHECK: %[[r3:.*]] = func.call @llvm.genx.lsc.load.stateless.v16i32.v16i1.v16i64
-    //CHECK-SAME: (%[[mask]], %[[c0_i8]], %[[c0_i8]], %[[c0_i8]], %[[c1_i16]], %[[c0_i32]], %[[c6_i8]], %[[c1_i8]], %[[c1_i8]], %[[c0_i8]], %[[r2]], %[[c0_i32]])
+    //CHECK: %[[r6:.*]] = func.call @llvm.genx.lsc.load.stateless.v16i32.v16i1.v16i64
+    //CHECK-SAME: (%[[mask]], %[[c0_i8]], %[[c0_i8]], %[[c0_i8]], %[[c1_i16]], %[[c0_i32]], %[[c6_i8]], %[[c1_i8]], %[[c1_i8]], %[[c0_i8]], %[[r5]], %[[c0_i32]])
     //CHECK-SAME: (vector<16xi1>, i8, i8, i8, i16, i32, i8, i8, i8, i8, vector<16xi64>, i32) -> vector<16xi32>
-    //CHECK: %[[r4:.*]] = arith.trunci %[[r3]] : vector<16xi32> to vector<16xi16>
-    //CHECK: %[[r5:.*]] = vector.bitcast %[[r4]] : vector<16xi16> to vector<16xf16>
+    //CHECK: %[[r7:.*]] = arith.trunci %[[r6]] : vector<16xi32> to vector<16xi16>
+    //CHECK: %[[r8:.*]] = vector.bitcast %[[r7]] : vector<16xi16> to vector<16xf16>
     %data = xegpu.load %a_tdesc, %mask : !xegpu.tensor_desc<16xf16, #scatter>, vector<16xi1> -> vector<16xf16>
 
     //CHECK: %[[b_ptr:.*]] = memref.extract_aligned_pointer_as_index %[[arg1]] : memref<16xf16> -> index
-    //CHECK: %[[r6:.*]] = arith.index_castui %[[b_ptr]] : index to i64
-    //CHECK: %[[r7:.*]] = vector.broadcast %[[r6]] : i64 to vector<16xi64>
-    //CHECK: %[[r8:.*]] = arith.addi %[[r7]], %[[cst_0]] : vector<16xi64>
-    %b_tdesc = xegpu.create_tdesc %b, %offsets : memref<16xf16>, vector<16xindex> -> !xegpu.tensor_desc<16xf16, #scatter>
+    //CHECK: %[[r9:.*]] = arith.index_castui %[[b_ptr]] : index to i64
+    //CHECK: %[[r10:.*]] = vector.broadcast %[[r9]] : i64 to vector<16xi64>
+    //CHECK: %[[r11:.*]] = arith.addi %[[r10]], %[[r3]] : vector<16xi64>
+    %b_tdesc = xegpu.create_tdesc %b[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : memref<16xf16> -> !xegpu.tensor_desc<16xf16, #scatter>
 
-    //CHECK: %[[r9:.*]] = vector.bitcast %[[r5]] : vector<16xf16> to vector<16xi16>
-    //CHECK: %[[r10:.*]] = arith.extui %[[r9]] : vector<16xi16> to vector<16xi32>
+    //CHECK: %[[r12:.*]] = vector.bitcast %[[r8]] : vector<16xf16> to vector<16xi16>
+    //CHECK: %[[r13:.*]] = arith.extui %[[r12]] : vector<16xi16> to vector<16xi32>
     //CHECK: %[[c4_i8:.*]] = arith.constant 4 : i8
     //CHECK: func.call @llvm.genx.lsc.store.stateless.v16i1.v16i64.v16i32
-    //CHECK-SAME: (%[[mask]], %[[c4_i8]], %[[c0_i8]], %[[c0_i8]], %[[c1_i16]], %[[c0_i32]], %[[c6_i8]], %[[c1_i8]], %[[c1_i8]], %[[c0_i8]], %[[r8]], %[[r10]], %[[c0_i32]])
+    //CHECK-SAME: (%[[mask]], %[[c4_i8]], %[[c0_i8]], %[[c0_i8]], %[[c1_i16]], %[[c0_i32]], %[[c6_i8]], %[[c1_i8]], %[[c1_i8]], %[[c0_i8]], %[[r11]], %[[r13]], %[[c0_i32]])
     //CHECK-SAME: (vector<16xi1>, i8, i8, i8, i16, i32, i8, i8, i8, i8, vector<16xi64>, vector<16xi32>, i32) -> ()
     xegpu.store %data, %b_tdesc, %mask : vector<16xf16>, !xegpu.tensor_desc<16xf16, #scatter>, vector<16xi1>
     gpu.return

--- a/test/Conversion/XeGPUToVC/load_global_no_chunk_f32.mlir
+++ b/test/Conversion/XeGPUToVC/load_global_no_chunk_f32.mlir
@@ -9,34 +9,37 @@ gpu.module @test_kernel {
 
     //CHECK: %[[mask:.*]] = arith.constant dense<true> : vector<16xi1>
     %mask = arith.constant dense<1> : vector<16xi1>
-    %offsets = arith.constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]> : vector<16xindex>
 
     //CHECK: %[[a_ptr:.*]] = memref.extract_aligned_pointer_as_index %[[arg0]] : memref<16xf32> -> index
     //CHECK: %[[r0:.*]] = arith.index_castui %[[a_ptr]] : index to i64
-    //CHECK: %[[cst_0:.*]] = arith.constant dense<[0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60]> : vector<16xi64>
-    //CHECK: %[[r1:.*]] = vector.broadcast %[[r0]] : i64 to vector<16xi64>
-    //CHECK: %[[r2:.*]] = arith.addi %[[r1]], %[[cst_0]] : vector<16xi64>
-    %a_tdesc = xegpu.create_tdesc %a, %offsets : memref<16xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #scatter>
+    //CHECK: %[[cst_0:.*]] = arith.constant dense<4> : vector<16xi64>
+
+    //CHECK: %[[r1:.*]] = vector.from_elements {{.*}} : vector<16xindex>
+    //CHECK: %[[r2:.*]] = arith.index_castui %[[r1]] : vector<16xindex> to vector<16xi64>
+    //CHECK: %[[r3:.*]] = arith.muli %[[r2]], %[[cst_0]] : vector<16xi64>
+    //CHECK: %[[r4:.*]] = vector.broadcast %[[r0]] : i64 to vector<16xi64>
+    //CHECK: %[[r5:.*]] = arith.addi %[[r4]], %[[r3]] : vector<16xi64>
+    %a_tdesc = xegpu.create_tdesc %a[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : memref<16xf32> -> !xegpu.tensor_desc<16xf32, #scatter>
 
     //CHECK: %[[c0_i8:.*]] = arith.constant 0 : i8
     //CHECK: %[[c1_i16:.*]] = arith.constant 1 : i16
     //CHECK: %[[c0_i32:.*]] = arith.constant 0 : i32
     //CHECK: %[[c3_i8:.*]] = arith.constant 3 : i8
     //CHECK: %[[c1_i8:.*]] = arith.constant 1 : i8
-    //CHECK: %[[r3:.*]] = func.call @llvm.genx.lsc.load.stateless.v16f32.v16i1.v16i64
-    //CHECK-SAME: (%[[mask]], %[[c0_i8]], %[[c0_i8]], %[[c0_i8]], %[[c1_i16]], %[[c0_i32]], %[[c3_i8]], %[[c1_i8]], %[[c1_i8]], %[[c0_i8]], %[[r2]], %[[c0_i32]])
+    //CHECK: %[[r6:.*]] = func.call @llvm.genx.lsc.load.stateless.v16f32.v16i1.v16i64
+    //CHECK-SAME: (%[[mask]], %[[c0_i8]], %[[c0_i8]], %[[c0_i8]], %[[c1_i16]], %[[c0_i32]], %[[c3_i8]], %[[c1_i8]], %[[c1_i8]], %[[c0_i8]], %[[r5]], %[[c0_i32]])
     //CHECK-SAME: (vector<16xi1>, i8, i8, i8, i16, i32, i8, i8, i8, i8, vector<16xi64>, i32) -> vector<16xf32>
     %data = xegpu.load %a_tdesc, %mask : !xegpu.tensor_desc<16xf32, #scatter>, vector<16xi1> -> vector<16xf32>
 
     //CHECK: %[[b_ptr:.*]] = memref.extract_aligned_pointer_as_index %[[arg1]] : memref<16xf32> -> index
-    //CHECK: %[[r4:.*]] = arith.index_castui %[[b_ptr]] : index to i64
-    //CHECK: %[[r5:.*]] = vector.broadcast %[[r4]] : i64 to vector<16xi64>
-    //CHECK: %[[r6:.*]] = arith.addi %[[r5]], %[[cst_0]] : vector<16xi64>
-    %b_tdesc = xegpu.create_tdesc %b, %offsets : memref<16xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #scatter>
+    //CHECK: %[[r7:.*]] = arith.index_castui %[[b_ptr]] : index to i64
+    //CHECK: %[[r8:.*]] = vector.broadcast %[[r7]] : i64 to vector<16xi64>
+    //CHECK: %[[r9:.*]] = arith.addi %[[r8]], %[[r3]] : vector<16xi64>
+    %b_tdesc = xegpu.create_tdesc %b[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : memref<16xf32> -> !xegpu.tensor_desc<16xf32, #scatter>
 
     //CHECK: %[[c4_i8:.*]] = arith.constant 4 : i8
     //CHECK: func.call @llvm.genx.lsc.store.stateless.v16i1.v16i64.v16f32
-    //CHECK-SAME: (%[[mask]], %[[c4_i8]], %[[c0_i8]], %[[c0_i8]], %[[c1_i16]], %[[c0_i32]], %[[c3_i8]], %[[c1_i8]], %[[c1_i8]], %[[c0_i8]], %[[r6]], %[[r3]], %[[c0_i32]])
+    //CHECK-SAME: (%[[mask]], %[[c4_i8]], %[[c0_i8]], %[[c0_i8]], %[[c1_i16]], %[[c0_i32]], %[[c3_i8]], %[[c1_i8]], %[[c1_i8]], %[[c0_i8]], %[[r9]], %[[r6]], %[[c0_i32]])
     //CHECK-SAME: (vector<16xi1>, i8, i8, i8, i16, i32, i8, i8, i8, i8, vector<16xi64>, vector<16xf32>, i32) -> ()
     xegpu.store %data, %b_tdesc, %mask : vector<16xf32>, !xegpu.tensor_desc<16xf32, #scatter>, vector<16xi1>
     gpu.return

--- a/test/Conversion/XeGPUToVC/loadgather.mlir
+++ b/test/Conversion/XeGPUToVC/loadgather.mlir
@@ -1,40 +1,44 @@
 
-// RUN: imex-opt -convert-xegpu-to-vc='enable-vc-intrinsic=true useRawSend=true'  %s | FileCheck %s
+// RUN: imex-opt -convert-xegpu-to-vc='enable-vc-intrinsic=true useRawSend=true' --cse %s | FileCheck %s
 module @gemm attributes {gpu.container_module} {
    gpu.module @module0 {
     //CHECK: func.func private @llvm.genx.raw.sends2.noresult.v16i1.v16i64.v16i32(i8, i8, vector<16xi1>, i8, i8, i8, i32, i32, vector<16xi64>, vector<16xi32>) attributes {VectorComputeFunctionINTEL, linkage_attributes = #spirv.linkage_attributes<linkage_name = "llvm.genx.raw.sends2.noresult.v16i1.v16i64.v16i32", linkage_type = <Import>>}
     //CHECK: func.func private @llvm.genx.raw.send2.v16i32.v16i1.v16i64(i8, i8, vector<16xi1>, i8, i8, i8, i32, i32, vector<16xi64>, vector<16xi32>) -> vector<16xi32> attributes {VectorComputeFunctionINTEL, linkage_attributes = #spirv.linkage_attributes<linkage_name = "llvm.genx.raw.send2.v16i32.v16i1.v16i64", linkage_type = <Import>>}
     gpu.func @test_loadgather(%in: memref<?xf16>, %out: memref<16x2xf16>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>}{
 
-      //CHECK %[[reinterpret_cast:.*]] = memref.reinterpret_cast %{{.*}} to offset: [0], sizes: [32], strides: [1] : memref<16x2xf16> to memref<32xf16>
-      //CHECK %[[cst:.*]] = arith.constant dense<[true, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false]> : vector<16xi1>
-      //CHECK %[[intptr:.*]] = memref.extract_aligned_pointer_as_index %{{.*}} : memref<?xf16> -> index
-      //CHECK %[[r0:.*]] = arith.index_castui %[[intptr]] : index to i64
-      //CHECK %[[cst_0:.*]] = arith.constant dense<[0, 8, 16, 24, 32, 40, 48, 56, 64, 68, 76, 84, 92, 100, 108, 116]> : vector<16xi64>
-      //CHECK %[[r1:.*]] = vector.broadcast %[[r0]] : i64 to vector<16xi64>
-      //CHECK %[[r2:.*]] = arith.addi %[[r1]], %[[cst_0]] : vector<16xi64>
-      //CHECK %[[intptr_1:.*]] = memref.extract_aligned_pointer_as_index %[[reinterpret_cast]] : memref<32xf16> -> index
-      //CHECK %[[r3:.*]] = arith.index_castui %[[intptr_1]] : index to i64
-      //CHECK %[[r4:.*]] = vector.broadcast %[[r3]] : i64 to vector<16xi64>
-      //CHECK %[[r5:.*]] = arith.addi %[[r4]], %[[cst_0]] : vector<16xi64>
-      //CHECK %[[c0_i8:.*]] = arith.constant 0 : i8
-      //CHECK %[[c4_i8:.*]] = arith.constant 4 : i8
-      //CHECK %[[c2_i8:.*]] = arith.constant 2 : i8
-      //CHECK %[[c1_i8:.*]] = arith.constant 1 : i8
-      //CHECK %[[c15_i8:.*]] = arith.constant 15 : i8
-      //CHECK %[[c0_i32:.*]] = arith.constant 0 : i32
-      //CHECK %[[c68289920_i32:.*]] = arith.constant 68289920 : i32
-      //CHECK %[[cst_2:.*]] = arith.constant dense<0> : vector<16xi32>
-      //CHECK %[[r6:.*]] = func.call @llvm.genx.raw.send2.v16i32.v16i1.v16i64(%[[c0_i8]], %[[c4_i8]], %[[cst]], %[[c2_i8]], %[[c1_i8]], %[[c15_i8]], %[[c0_i32]], %[[c68289920_i32]], %[[r2]], %[[cst_2]]) : (i8, i8, vector<16xi1>, i8, i8, i8, i32, i32, vector<16xi64>, vector<16xi32>) -> vector<16xi32>
-      //CHECK %[[r7:.*]] = vector.bitcast %[[r6]] : vector<16xi32> to vector<32xf16>
-      //CHECK %[[c67241348_i32:.*]] = arith.constant 67241348 : i32
-      //CHECK %[[r8:.*]] = vector.bitcast %[[r7]] : vector<32xf16> to vector<16xi32>
-      //CHECK func.call @llvm.genx.raw.sends2.noresult.v16i1.v16i64.v16i32(%[[c0_i8]], %[[c4_i8]], %[[cst]], %[[c2_i8]], %[[c1_i8]], %[[c15_i8]], %[[c0_i32]], %[[c67241348_i32]], %[[r5]], %[[r8]]) : (i8, i8, vector<16xi1>, i8, i8, i8, i32, i32, vector<16xi64>, vector<16xi32>) -> ()
+      //CHECK: %[[reinterpret_cast:.*]] = memref.reinterpret_cast %{{.*}} to offset: [0], sizes: [32], strides: [1] : memref<16x2xf16> to memref<32xf16>
+      //CHECK: %[[cst:.*]] = arith.constant dense<[true, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false]> : vector<16xi1>
+      //CHECK: %[[intptr:.*]] = memref.extract_aligned_pointer_as_index %{{.*}} : memref<?xf16> -> index
+      //CHECK: %[[r0:.*]] = arith.index_castui %[[intptr]] : index to i64
+      //CHECK: %[[cst_0:.*]] = arith.constant dense<2> : vector<16xi64>
+
+      //CHECK: %[[r1:.*]] = vector.from_elements {{.*}} : vector<16xindex>
+      //CHECK: %[[r2:.*]] = arith.index_castui %[[r1]] : vector<16xindex> to vector<16xi64>
+      //CHECK: %[[r3:.*]] = arith.muli %[[r2]], %[[cst_0]] : vector<16xi64>
+      //CHECK: %[[r4:.*]] = vector.broadcast %[[r0]] : i64 to vector<16xi64>
+      //CHECK: %[[r5:.*]] = arith.addi %[[r4]], %[[r3]] : vector<16xi64>
+
+      //CHECK: %[[intptr_1:.*]] = memref.extract_aligned_pointer_as_index %[[reinterpret_cast]] : memref<32xf16> -> index
+      //CHECK: %[[r6:.*]] = arith.index_castui %[[intptr_1]] : index to i64
+      //CHECK: %[[r7:.*]] = vector.broadcast %[[r6]] : i64 to vector<16xi64>
+      //CHECK: %[[r8:.*]] = arith.addi %[[r7]], %[[r3]] : vector<16xi64>
+      //CHECK: %[[c0_i8:.*]] = arith.constant 0 : i8
+      //CHECK: %[[c4_i8:.*]] = arith.constant 4 : i8
+      //CHECK: %[[c2_i8:.*]] = arith.constant 2 : i8
+      //CHECK: %[[c1_i8:.*]] = arith.constant 1 : i8
+      //CHECK: %[[c15_i8:.*]] = arith.constant 15 : i8
+      //CHECK: %[[c0_i32:.*]] = arith.constant 0 : i32
+      //CHECK: %[[c68289920_i32:.*]] = arith.constant 68289920 : i32
+      //CHECK: %[[cst_2:.*]] = arith.constant dense<0> : vector<16xi32>
+      //CHECK: %[[r9:.*]] = func.call @llvm.genx.raw.send2.v16i32.v16i1.v16i64(%[[c0_i8]], %[[c4_i8]], %[[cst]], %[[c2_i8]], %[[c1_i8]], %[[c15_i8]], %[[c0_i32]], %[[c68289920_i32]], %[[r5]], %[[cst_2]]) : (i8, i8, vector<16xi1>, i8, i8, i8, i32, i32, vector<16xi64>, vector<16xi32>) -> vector<16xi32>
+      //CHECK: %[[r10:.*]] = vector.bitcast %[[r9]] : vector<16xi32> to vector<32xf16>
+      //CHECK: %[[c67241348_i32:.*]] = arith.constant 67241348 : i32
+      //CHECK: %[[r11:.*]] = vector.bitcast %[[r10]] : vector<32xf16> to vector<16xi32>
+      //CHECK: func.call @llvm.genx.raw.sends2.noresult.v16i1.v16i64.v16i32(%[[c0_i8]], %[[c4_i8]], %[[cst]], %[[c2_i8]], %[[c1_i8]], %[[c15_i8]], %[[c0_i32]], %[[c67241348_i32]], %[[r8]], %[[r11]]) : (i8, i8, vector<16xi1>, i8, i8, i8, i32, i32, vector<16xi64>, vector<16xi32>) -> ()
       %out_flat = memref.reinterpret_cast %out to offset: [0], sizes: [32], strides: [1] : memref<16x2xf16> to memref<32xf16>
-      %offsets = arith.constant dense<[0,4,8,12,16,20,24,28,32,34,38,42,46,50,54,58]> : vector<16xindex>
       %mask = arith.constant dense<[1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0]> : vector<16xi1>
-      %tdesc_in = xegpu.create_tdesc %in, %offsets : memref<?xf16>, vector<16xindex> -> !xegpu.tensor_desc<16x2xf16, #xegpu.scatter_tdesc_attr<chunk_size = 2>>
-      %tdesc_out = xegpu.create_tdesc %out_flat, %offsets {chunk_size = 2} : memref<32xf16>, vector<16xindex> -> !xegpu.tensor_desc<16x2xf16, #xegpu.scatter_tdesc_attr<chunk_size = 2>>
+      %tdesc_in = xegpu.create_tdesc %in[0,4,8,12,16,20,24,28,32,34,38,42,46,50,54,58] : memref<?xf16> -> !xegpu.tensor_desc<16x2xf16, #xegpu.scatter_tdesc_attr<chunk_size = 2>>
+      %tdesc_out = xegpu.create_tdesc %out_flat[0,4,8,12,16,20,24,28,32,34,38,42,46,50,54,58] : memref<32xf16> -> !xegpu.tensor_desc<16x2xf16, #xegpu.scatter_tdesc_attr<chunk_size = 2>>
       %loaded = xegpu.load %tdesc_in, %mask {transpose} : !xegpu.tensor_desc<16x2xf16, #xegpu.scatter_tdesc_attr<chunk_size = 2>>, vector<16xi1> -> vector<2x16xf16>
       xegpu.store %loaded, %tdesc_out, %mask {transpose} : vector<2x16xf16>, !xegpu.tensor_desc<16x2xf16, #xegpu.scatter_tdesc_attr<chunk_size = 2>>, vector<16xi1>
       gpu.return

--- a/test/Conversion/XeGPUToVC/loadgather_dpas.mlir
+++ b/test/Conversion/XeGPUToVC/loadgather_dpas.mlir
@@ -7,16 +7,18 @@ module @gemm attributes {gpu.container_module} {
     //CHECK: func.func private @llvm.genx.raw.send2.v128i32.i1.v16i32(i8, i8, i1, i8, i8, i8, i32, i32, vector<16xi32>, vector<128xi32>) -> vector<128xi32> attributes {VectorComputeFunctionINTEL, linkage_attributes = #spirv.linkage_attributes<linkage_name = "llvm.genx.raw.send2.v128i32.i1.v16i32", linkage_type = <Import>>}
     //CHECK: func.func private @llvm.genx.raw.send2.v64i32.v16i1.v16i64(i8, i8, vector<16xi1>, i8, i8, i8, i32, i32, vector<16xi64>, vector<64xi32>) -> vector<64xi32> attributes {VectorComputeFunctionINTEL, linkage_attributes = #spirv.linkage_attributes<linkage_name = "llvm.genx.raw.send2.v64i32.v16i1.v16i64", linkage_type = <Import>>}
     gpu.func @test_loadgather(%arg0: memref<128xf16>, %arg1: memref<16x16xf16>, %arg2: memref<128xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>}{
-         %offsets = arith.constant dense<[0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120]> : vector<16xindex>
          //CHECK: %[[cst:.*]] = arith.constant dense<true> : vector<16xi1>
          %mask = arith.constant dense<true> : vector<16xi1>
 
          //CHECK: %[[intptr:.*]] = memref.extract_aligned_pointer_as_index %{{.*}} : memref<128xf16> -> index
          //CHECK: %[[r0:.*]] = arith.index_castui %[[intptr]] : index to i64
-         //CHECK: %[[cst_0:.*]] = arith.constant dense<[0, 16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240]> : vector<16xi64>
-         //CHECK: %[[r1:.*]] = vector.broadcast %[[r0]] : i64 to vector<16xi64>
-         //CHECK: %[[r2:.*]] = arith.addi %[[r1]], %[[cst_0]] : vector<16xi64>
-         %0 = xegpu.create_tdesc %arg0, %offsets : memref<128xf16>, vector<16xindex> -> !xegpu.tensor_desc<16x8xf16, #xegpu.scatter_tdesc_attr<chunk_size = 8>>
+         //CHECK: %[[cst_0:.*]] = arith.constant dense<2> : vector<16xi64>
+         //CHECK: %[[r1:.*]] = vector.from_elements {{.*}} : vector<16xindex>
+         //CHECK: %[[r2:.*]] = arith.index_castui %[[r1]] : vector<16xindex> to vector<16xi64>
+         //CHECK: %[[r3:.*]] = arith.muli %[[r2]], %[[cst_0]] : vector<16xi64>
+         //CHECK: %[[r4:.*]] = vector.broadcast %[[r0]] : i64 to vector<16xi64>
+         //CHECK: %[[r5:.*]] = arith.addi %[[r4]], %[[r3]] : vector<16xi64>
+         %0 = xegpu.create_tdesc %arg0[0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120] : memref<128xf16> -> !xegpu.tensor_desc<16x8xf16, #xegpu.scatter_tdesc_attr<chunk_size = 8>>
 
          //CHECK: %[[c0_i8:.*]] = arith.constant 0 : i8
          //CHECK: %[[c4_i8:.*]] = arith.constant 4 : i8
@@ -25,24 +27,24 @@ module @gemm attributes {gpu.container_module} {
          //CHECK: %[[c0_i32:.*]] = arith.constant 0 : i32
          //CHECK: %[[c71447936_i32:.*]] = arith.constant 71447936 : i32
          //CHECK: %[[cst_1:.*]] = arith.constant dense<0> : vector<64xi32>
-         //CHECK: %[[r3:.*]] = func.call @llvm.genx.raw.send2.v64i32.v16i1.v16i64(%[[c0_i8]], %[[c4_i8]], %[[cst]], %[[c2_i8]], %[[c4_i8]], %[[c15_i8]], %[[c0_i32]], %[[c71447936_i32]], %[[r2]], %[[cst_1]]) : (i8, i8, vector<16xi1>, i8, i8, i8, i32, i32, vector<16xi64>, vector<64xi32>) -> vector<64xi32>
-         //CHECK: %[[r4:.*]] = vector.bitcast %[[r3]] : vector<64xi32> to vector<128xf16>
+         //CHECK: %[[r6:.*]] = func.call @llvm.genx.raw.send2.v64i32.v16i1.v16i64(%[[c0_i8]], %[[c4_i8]], %[[cst]], %[[c2_i8]], %[[c4_i8]], %[[c15_i8]], %[[c0_i32]], %[[c71447936_i32]], %[[r5]], %[[cst_1]]) : (i8, i8, vector<16xi1>, i8, i8, i8, i32, i32, vector<16xi64>, vector<64xi32>) -> vector<64xi32>
+         //CHECK: %[[r7:.*]] = vector.bitcast %[[r6]] : vector<64xi32> to vector<128xf16>
          %3 = xegpu.load %0, %mask {transpose} : !xegpu.tensor_desc<16x8xf16, #xegpu.scatter_tdesc_attr<chunk_size = 8>>, vector<16xi1> -> vector<8x16xf16>
 
          //CHECK: %[[intptr_2:.*]] = memref.extract_aligned_pointer_as_index %{{.*}} : memref<16x16xf16> -> index
-         //CHECK: %[[r5:.*]] = arith.index_castui %[[intptr_2]] : index to i64
+         //CHECK: %[[r8:.*]] = arith.index_castui %[[intptr_2]] : index to i64
          //CHECK: %[[cst_3:.*]] = arith.constant dense<0> : vector<8xi64>
-         //CHECK: %[[r6:.*]] = vector.insert %[[r5]], %[[cst_3]] [0] : i64 into vector<8xi64>
-         //CHECK: %[[r7:.*]] = vector.bitcast %[[r6]] : vector<8xi64> to vector<16xi32>
+         //CHECK: %[[r9:.*]] = vector.insert %[[r8]], %[[cst_3]] [0] : i64 into vector<8xi64>
+         //CHECK: %[[r10:.*]] = vector.bitcast %[[r9]] : vector<8xi64> to vector<16xi32>
          //CHECK: %[[c31_i32:.*]] = arith.constant 31 : i32
          //CHECK: %[[c15_i32:.*]] = arith.constant 15 : i32
-         //CHECK: %[[r8:.*]] = vector.insert %[[c31_i32]], %[[r7]] [2] : i32 into vector<16xi32>
-         //CHECK: %[[r9:.*]] = vector.insert %[[c15_i32]], %[[r8]] [3] : i32 into vector<16xi32>
-         //CHECK: %[[r10:.*]] = vector.insert %[[c31_i32]], %[[r9]] [4] : i32 into vector<16xi32>
-         //CHECK: %[[r11:.*]] = vector.insert %[[c0_i32]], %[[r10]] [5] : i32 into vector<16xi32>
-         //CHECK: %[[r12:.*]] = vector.insert %[[c0_i32]], %[[r11]] [6] : i32 into vector<16xi32>
+         //CHECK: %[[r11:.*]] = vector.insert %[[c31_i32]], %[[r10]] [2] : i32 into vector<16xi32>
+         //CHECK: %[[r12:.*]] = vector.insert %[[c15_i32]], %[[r11]] [3] : i32 into vector<16xi32>
+         //CHECK: %[[r13:.*]] = vector.insert %[[c31_i32]], %[[r12]] [4] : i32 into vector<16xi32>
+         //CHECK: %[[r14:.*]] = vector.insert %[[c0_i32]], %[[r13]] [5] : i32 into vector<16xi32>
+         //CHECK: %[[r15:.*]] = vector.insert %[[c0_i32]], %[[r14]] [6] : i32 into vector<16xi32>
          //CHECK: %[[c3855_i32:.*]] = arith.constant 3855 : i32
-         //CHECK: %[[r13:.*]] = vector.insert %[[c3855_i32]], %[[r12]] [7] : i32 into vector<16xi32>
+         //CHECK: %[[r16:.*]] = vector.insert %[[c3855_i32]], %[[r15]] [7] : i32 into vector<16xi32>
          %1 = xegpu.create_nd_tdesc %arg1[0, 0] {boundary_check = true} : memref<16x16xf16> -> !xegpu.tensor_desc<16x16xf16>
 
          //CHECK: %[[true:.*]] = arith.constant true
@@ -50,26 +52,27 @@ module @gemm attributes {gpu.container_module} {
          //CHECK: %[[c8_i8:.*]] = arith.constant 8 : i8
          //CHECK: %[[c42074755_i32:.*]] = arith.constant 42074755 : i32
          //CHECK: %[[cst_4:.*]] = arith.constant dense<0> : vector<128xi32>
-         //CHECK: %[[r14:.*]] = func.call @llvm.genx.raw.send2.v128i32.i1.v16i32(%[[c0_i8]], %[[c0_i8]], %[[true]], %[[c1_i8]], %[[c8_i8]], %[[c15_i8]], %[[c0_i32]], %[[c42074755_i32]], %[[r13]], %[[cst_4]]) : (i8, i8, i1, i8, i8, i8, i32, i32, vector<16xi32>, vector<128xi32>) -> vector<128xi32>
-         //CHECK: %[[r15:.*]] = vector.bitcast %[[r14]] : vector<128xi32> to vector<256xf16>
+         //CHECK: %[[r17:.*]] = func.call @llvm.genx.raw.send2.v128i32.i1.v16i32(%[[c0_i8]], %[[c0_i8]], %[[true]], %[[c1_i8]], %[[c8_i8]], %[[c15_i8]], %[[c0_i32]], %[[c42074755_i32]], %[[r16]], %[[cst_4]]) : (i8, i8, i1, i8, i8, i8, i32, i32, vector<16xi32>, vector<128xi32>) -> vector<128xi32>
+         //CHECK: %[[r18:.*]] = vector.bitcast %[[r17]] : vector<128xi32> to vector<256xf16>
          %4 = xegpu.load_nd %1 {packed} : !xegpu.tensor_desc<16x16xf16> -> vector<8x16x2xf16>
 
          //CHECK: %[[c134744586_i32:.*]] = arith.constant 134744586 : i32
-         //CHECK: %[[r16:.*]] = vector.bitcast %[[r4]] : vector<128xf16> to vector<64xi32>
-         //CHECK: %[[r17:.*]] = vector.bitcast %[[r15]] : vector<256xf16> to vector<128xi32>
-         //CHECK: %[[r18:.*]] = func.call @llvm.genx.dpas.nosrc0.v128f32.v128i32.v64i32(%[[r17]], %[[r16]], %[[c134744586_i32]]) : (vector<128xi32>, vector<64xi32>, i32) -> vector<128xf32>
+         //CHECK: %[[r19:.*]] = vector.bitcast %[[r7]] : vector<128xf16> to vector<64xi32>
+         //CHECK: %[[r20:.*]] = vector.bitcast %[[r18]] : vector<256xf16> to vector<128xi32>
+         //CHECK: %[[r21:.*]] = func.call @llvm.genx.dpas.nosrc0.v128f32.v128i32.v64i32(%[[r20]], %[[r19]], %[[c134744586_i32]]) : (vector<128xi32>, vector<64xi32>, i32) -> vector<128xf32>
          %5 = xegpu.dpas %3, %4 : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
-         %offsets2 = arith.constant dense<[0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120]> : vector<16xindex>
 
          //CHECK: %[[intptr_5:.*]] = memref.extract_aligned_pointer_as_index %{{.*}} : memref<128xf32> -> index
-         //CHECK: %[[r19:.*]] = arith.index_castui %[[intptr_5]] : index to i64
-         //CHECK: %[[cst_6:.*]] = arith.constant dense<[0, 32, 64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 416, 448, 480]> : vector<16xi64>
-         //CHECK: %[[r20:.*]] = vector.broadcast %[[r19]] : i64 to vector<16xi64>
-         //CHECK: %[[r21:.*]] = arith.addi %[[r20]], %[[cst_6]] : vector<16xi64>
-         %2 = xegpu.create_tdesc %arg2, %offsets2 : memref<128xf32>, vector<16xindex> -> !xegpu.tensor_desc<16x8xf32, #xegpu.scatter_tdesc_attr<chunk_size = 8>>
+         //CHECK: %[[r22:.*]] = arith.index_castui %[[intptr_5]] : index to i64
+         //CHECK: %[[cst_6:.*]] = arith.constant dense<4> : vector<16xi64>
+
+         //CHECK: %[[r23:.*]] = arith.muli %[[r2]], %[[cst_6]] : vector<16xi64>
+         //CHECK: %[[r24:.*]] = vector.broadcast %[[r22]] : i64 to vector<16xi64>
+         //CHECK: %[[r25:.*]] = arith.addi %[[r24]], %[[r23]] : vector<16xi64>
+         %2 = xegpu.create_tdesc %arg2[0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120] : memref<128xf32> -> !xegpu.tensor_desc<16x8xf32, #xegpu.scatter_tdesc_attr<chunk_size = 8>>
 
          //CHECK: %[[c67257732_i32:.*]] = arith.constant 67257732 : i32
-         //CHECK: func.call @llvm.genx.raw.sends2.noresult.v16i1.v16i64.v128f32(%c0_i8, %c4_i8, %cst, %c2_i8, %c8_i8, %c15_i8, %c0_i32, %c67257732_i32, %21, %18) : (i8, i8, vector<16xi1>, i8, i8, i8, i32, i32, vector<16xi64>, vector<128xf32>) -> ()
+         //CHECK: func.call @llvm.genx.raw.sends2.noresult.v16i1.v16i64.v128f32(%[[c0_i8]], %[[c4_i8]], %[[cst]], %[[c2_i8]], %[[c8_i8]], %[[c15_i8]], %[[c0_i32]], %[[c67257732_i32]], %[[r25]], %[[r21]]) : (i8, i8, vector<16xi1>, i8, i8, i8, i32, i32, vector<16xi64>, vector<128xf32>) -> ()
          xegpu.store %5, %2, %mask {transpose} : vector<8x16xf32>, !xegpu.tensor_desc<16x8xf32, #xegpu.scatter_tdesc_attr<chunk_size = 8>>, vector<16xi1>
 
          //CHECK: gpu.return

--- a/test/Conversion/XeGPUToVC/prefetch_global_no_chunk_f16.mlir
+++ b/test/Conversion/XeGPUToVC/prefetch_global_no_chunk_f16.mlir
@@ -8,14 +8,17 @@ gpu.module @test_kernel {
 
     //CHECK: %[[cst:.*]] = arith.constant dense<true> : vector<16xi1>
     %mask = arith.constant dense<1> : vector<16xi1>
-    %offsets = arith.constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]> : vector<16xindex>
 
     //CHECK: %[[intptr:.*]] = memref.extract_aligned_pointer_as_index %[[arg0]] : memref<16xf16> -> index
     //CHECK: %[[r0:.*]] = arith.index_castui %[[intptr]] : index to i64
-    //CHECK: %[[cst_0:.*]] = arith.constant dense<[0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30]> : vector<16xi64>
-    //CHECK: %[[r1:.*]] = vector.broadcast %[[r0]] : i64 to vector<16xi64>
-    //CHECK: %[[r2:.*]] = arith.addi %[[r1]], %[[cst_0]] : vector<16xi64>
-    %a_tdesc = xegpu.create_tdesc %a, %offsets : memref<16xf16>, vector<16xindex> -> !xegpu.tensor_desc<16xf16, #scatter>
+    //CHECK: %[[cst_0:.*]] = arith.constant dense<2> : vector<16xi64>
+
+    //CHECK: %[[r1:.*]] = vector.from_elements {{.*}} : vector<16xindex>
+    //CHECK: %[[r2:.*]] = arith.index_castui %[[r1]] : vector<16xindex> to vector<16xi64>
+    //CHECK: %[[r3:.*]] = arith.muli %[[r2]], %[[cst_0]] : vector<16xi64>
+    //CHECK: %[[r4:.*]] = vector.broadcast %[[r0]] : i64 to vector<16xi64>
+    //CHECK: %[[r5:.*]] = arith.addi %[[r4]], %[[r3]] : vector<16xi64>
+    %a_tdesc = xegpu.create_tdesc %a[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : memref<16xf16> -> !xegpu.tensor_desc<16xf16, #scatter>
 
     //CHECK: %[[c0_i8:.*]] = arith.constant 0 : i8
     //CHECK: %[[c1_i16:.*]] = arith.constant 1 : i16
@@ -24,12 +27,12 @@ gpu.module @test_kernel {
     //CHECK: %[[c1_i8:.*]] = arith.constant 1 : i8
 
     //CHECK: func.call @llvm.genx.lsc.prefetch.stateless.v16i1.v16i64
-    //CHECK-SAME: (%[[cst]], %[[c0_i8]], %[[c0_i8]], %[[c0_i8]], %[[c1_i16]], %[[c0_i32]], %[[c6_i8]], %[[c1_i8]], %[[c1_i8]], %[[c0_i8]], %[[r2]], %[[c0_i32]])
+    //CHECK-SAME: (%[[cst]], %[[c0_i8]], %[[c0_i8]], %[[c0_i8]], %[[c1_i16]], %[[c0_i32]], %[[c6_i8]], %[[c1_i8]], %[[c1_i8]], %[[c0_i8]], %[[r5]], %[[c0_i32]])
     //CHECK-SAME: (vector<16xi1>, i8, i8, i8, i16, i32, i8, i8, i8, i8, vector<16xi64>, i32) -> ()
     xegpu.prefetch %a_tdesc : !xegpu.tensor_desc<16xf16, #scatter>
     %data = xegpu.load %a_tdesc, %mask : !xegpu.tensor_desc<16xf16, #scatter>, vector<16xi1> -> vector<16xf16>
 
-    %b_tdesc = xegpu.create_tdesc %b, %offsets : memref<16xf16>, vector<16xindex> -> !xegpu.tensor_desc<16xf16, #scatter>
+    %b_tdesc = xegpu.create_tdesc %b[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : memref<16xf16> -> !xegpu.tensor_desc<16xf16, #scatter>
     xegpu.store %data, %b_tdesc, %mask : vector<16xf16>, !xegpu.tensor_desc<16xf16, #scatter>, vector<16xi1>
     gpu.return
   }

--- a/test/Conversion/XeGPUToVC/prefetch_global_no_chunk_f32.mlir
+++ b/test/Conversion/XeGPUToVC/prefetch_global_no_chunk_f32.mlir
@@ -7,14 +7,16 @@ gpu.module @test_kernel {
 
     //CHECK: %[[cst:.*]] = arith.constant dense<true> : vector<16xi1>
     %mask = arith.constant dense<1> : vector<16xi1>
-    %offsets = arith.constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]> : vector<16xindex>
 
     //CHECK: %[[intptr:.*]] = memref.extract_aligned_pointer_as_index %arg0 : memref<16xf32> -> index
     //CHECK: %[[r0:.*]] = arith.index_castui %[[intptr]] : index to i64
-    //CHECK: %[[cst_0:.*]] = arith.constant dense<[0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60]> : vector<16xi64>
-    //CHECK: %[[r1:.*]] = vector.broadcast %[[r0]] : i64 to vector<16xi64>
-    //CHECK: %[[r2:.*]] = arith.addi %[[r1]], %[[cst_0]] : vector<16xi64>
-    %a_tdesc = xegpu.create_tdesc %a, %offsets : memref<16xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #scatter>
+    //CHECK: %[[cst_0:.*]] = arith.constant dense<4> : vector<16xi64>
+    //CHECK: %[[r1:.*]] = vector.from_elements {{.*}} : vector<16xindex>
+    //CHECK: %[[r2:.*]] = arith.index_castui %[[r1]] : vector<16xindex> to vector<16xi64>
+    //CHECK: %[[r3:.*]] = arith.muli %[[r2]], %[[cst_0]] : vector<16xi64>
+    //CHECK: %[[r4:.*]] = vector.broadcast %[[r0]] : i64 to vector<16xi64>
+    //CHECK: %[[r5:.*]] = arith.addi %[[r4]], %[[r3]] : vector<16xi64>
+    %a_tdesc = xegpu.create_tdesc %a[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : memref<16xf32> -> !xegpu.tensor_desc<16xf32, #scatter>
 
     //CHECK: %[[c0_i8:.*]] = arith.constant 0 : i8
     //CHECK: %[[c1_i16:.*]] = arith.constant 1 : i16
@@ -23,11 +25,11 @@ gpu.module @test_kernel {
     //CHECK: %[[c1_i8:.*]] = arith.constant 1 : i8
 
     //CHECK: func.call @llvm.genx.lsc.prefetch.stateless.v16i1.v16i64
-    //CHECK-SAME: (%[[cst]], %[[c0_i8]], %[[c0_i8]], %[[c0_i8]], %[[c1_i16]], %[[c0_i32]], %[[c3_i8]], %[[c1_i8]], %[[c1_i8]], %[[c0_i8]], %[[r2]], %[[c0_i32]])
+    //CHECK-SAME: (%[[cst]], %[[c0_i8]], %[[c0_i8]], %[[c0_i8]], %[[c1_i16]], %[[c0_i32]], %[[c3_i8]], %[[c1_i8]], %[[c1_i8]], %[[c0_i8]], %[[r5]], %[[c0_i32]])
     //CHECK-SAME: (vector<16xi1>, i8, i8, i8, i16, i32, i8, i8, i8, i8, vector<16xi64>, i32) -> ()
     xegpu.prefetch %a_tdesc : !xegpu.tensor_desc<16xf32, #scatter>
     %data = xegpu.load %a_tdesc, %mask : !xegpu.tensor_desc<16xf32, #scatter>, vector<16xi1> -> vector<16xf32>
-    %b_tdesc = xegpu.create_tdesc %b, %offsets : memref<16xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #scatter>
+    %b_tdesc = xegpu.create_tdesc %b[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : memref<16xf32> -> !xegpu.tensor_desc<16xf32, #scatter>
     xegpu.store %data, %b_tdesc, %mask : vector<16xf32>, !xegpu.tensor_desc<16xf32, #scatter>, vector<16xi1>
     gpu.return
   }

--- a/test/Conversion/XeGPUToVC/store_load_slm_no_chunk_f16.mlir
+++ b/test/Conversion/XeGPUToVC/store_load_slm_no_chunk_f16.mlir
@@ -14,20 +14,21 @@ gpu.module @test_kernel {
     //CHECK: %[[cst_0:.*]] = arith.constant dense<true> : vector<16xi1>
     %mask = arith.constant dense<1> : vector<16xi1>
 
-    %offsets = arith.constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]> : vector<16xindex>
-
     //CHECK: %[[alloc:.*]] = memref.alloc() : memref<16xf16, 3>
     %slm = memref.alloc() : memref<16xf16, 3>
 
     //CHECK: %[[intptr:.*]] = memref.extract_aligned_pointer_as_index %[[alloc]] : memref<16xf16, 3> -> index
     //CHECK: %[[r0:.*]] = arith.index_castui %[[intptr]] : index to i32
-    //CHECK: %[[cst_1:.*]] = arith.constant dense<[0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30]> : vector<16xi32>
-    //CHECK: %[[r1:.*]] = vector.broadcast %[[r0]] : i32 to vector<16xi32>
-    //CHECK: %[[r2:.*]] = arith.addi %[[r1]], %[[cst_1]] : vector<16xi32>
-    %slm_tdesc = xegpu.create_tdesc %slm, %offsets : memref<16xf16, 3>, vector<16xindex> -> !xegpu.tensor_desc<16xf16, #slm>
+    //CHECK: %[[cst_1:.*]] = arith.constant dense<2> : vector<16xi32>
+    //CHECK: %[[r1:.*]] = vector.from_elements {{.*}} : vector<16xindex>
+    //CHECK: %[[r2:.*]] = arith.index_castui %[[r1]] : vector<16xindex> to vector<16xi32>
+    //CHECK: %[[r3:.*]] = arith.muli %[[r2]], %[[cst_1]] : vector<16xi32>
+    //CHECK: %[[r4:.*]] = vector.broadcast %[[r0]] : i32 to vector<16xi32>
+    //CHECK: %[[r5:.*]] = arith.addi %[[r4]], %[[r3]] : vector<16xi32>
+    %slm_tdesc = xegpu.create_tdesc %slm[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : memref<16xf16, 3> -> !xegpu.tensor_desc<16xf16, #slm>
 
-    //CHECK: %[[r3:.*]] = vector.bitcast %[[cst]] : vector<16xf16> to vector<16xi16>
-    //CHECK: %[[r4:.*]] = arith.extui %[[r3]] : vector<16xi16> to vector<16xi32>
+    //CHECK: %[[r6:.*]] = vector.bitcast %[[cst]] : vector<16xf16> to vector<16xi16>
+    //CHECK: %[[r7:.*]] = arith.extui %[[r6]] : vector<16xi16> to vector<16xi32>
     //CHECK: %[[c4_i8:.*]] = arith.constant 4 : i8
     //CHECK: %[[c0_i8:.*]] = arith.constant 0 : i8
     //CHECK: %[[c1_i16:.*]] = arith.constant 1 : i16
@@ -35,29 +36,32 @@ gpu.module @test_kernel {
     //CHECK: %[[c6_i8:.*]] = arith.constant 6 : i8
     //CHECK: %[[c1_i8:.*]] = arith.constant 1 : i8
     //CHECK: func.call @llvm.genx.lsc.store.slm.v16i1.v16i32.v16i32
-    //CHECK-SAME: (%[[cst_0]], %[[c4_i8]], %[[c0_i8]], %[[c0_i8]], %[[c1_i16]], %[[c0_i32]], %[[c6_i8]], %[[c1_i8]], %[[c1_i8]], %[[c0_i8]], %[[r2]], %[[r4]], %[[c0_i32]])
+    //CHECK-SAME: (%[[cst_0]], %[[c4_i8]], %[[c0_i8]], %[[c0_i8]], %[[c1_i16]], %[[c0_i32]], %[[c6_i8]], %[[c1_i8]], %[[c1_i8]], %[[c0_i8]], %[[r5]], %[[r7]], %[[c0_i32]])
     //CHECK-SAME: (vector<16xi1>, i8, i8, i8, i16, i32, i8, i8, i8, i8, vector<16xi32>, vector<16xi32>, i32) -> ()
     xegpu.store %cst, %slm_tdesc, %mask : vector<16xf16>, !xegpu.tensor_desc<16xf16, #slm>, vector<16xi1>
 
-    //CHECK: %[[r5:.*]] = func.call @llvm.genx.lsc.load.slm.v16i32.v16i1.v16i32
-    //CHECK-SAME: (%[[cst_0]], %[[c0_i8]], %[[c0_i8]], %[[c0_i8]], %[[c1_i16]], %[[c0_i32]], %[[c6_i8]], %[[c1_i8]], %[[c1_i8]], %[[c0_i8]], %[[r2]], %[[c0_i32]])
+    //CHECK: %[[r8:.*]] = func.call @llvm.genx.lsc.load.slm.v16i32.v16i1.v16i32
+    //CHECK-SAME: (%[[cst_0]], %[[c0_i8]], %[[c0_i8]], %[[c0_i8]], %[[c1_i16]], %[[c0_i32]], %[[c6_i8]], %[[c1_i8]], %[[c1_i8]], %[[c0_i8]], %[[r5]], %[[c0_i32]])
     //CHECK-SAME: (vector<16xi1>, i8, i8, i8, i16, i32, i8, i8, i8, i8, vector<16xi32>, i32) -> vector<16xi32>
-    //CHECK: %[[r6:.*]] = arith.trunci %[[r5]] : vector<16xi32> to vector<16xi16>
-    //CHECK: %[[r7:.*]] = vector.bitcast %[[r6]] : vector<16xi16> to vector<16xf16>
+    //CHECK: %[[r9:.*]] = arith.trunci %[[r8]] : vector<16xi32> to vector<16xi16>
+    //CHECK: %[[r10:.*]] = vector.bitcast %[[r9]] : vector<16xi16> to vector<16xf16>
     %data = xegpu.load %slm_tdesc, %mask : !xegpu.tensor_desc<16xf16, #slm>, vector<16xi1> -> vector<16xf16>
 
     //CHECK: %[[intptr_2:.*]] = memref.extract_aligned_pointer_as_index %[[arg0]] : memref<16xf16> -> index
 
-    //CHECK: %[[r8:.*]] = arith.index_castui %[[intptr_2]] : index to i64
-    //CHECK: %[[cst_3:.*]] = arith.constant dense<[0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30]> : vector<16xi64>
-    //CHECK: %[[r9:.*]] = vector.broadcast %[[r8]] : i64 to vector<16xi64>
-    //CHECK: %[[r10:.*]] = arith.addi %[[r9]], %[[cst_3]] : vector<16xi64>
-    %tdesc = xegpu.create_tdesc %mem, %offsets : memref<16xf16>, vector<16xindex> -> !xegpu.tensor_desc<16xf16, #global>
+    //CHECK: %[[r11:.*]] = arith.index_castui %[[intptr_2]] : index to i64
+    //CHECK: %[[cst_3:.*]] = arith.constant dense<2> : vector<16xi64>
 
-    //CHECK: %[[r11:.*]] = vector.bitcast %[[r7]] : vector<16xf16> to vector<16xi16>
-    //CHECK: %[[r12:.*]] = arith.extui %[[r11]] : vector<16xi16> to vector<16xi32>
+    //CHECK: %[[r12:.*]] = arith.index_castui %[[r1]] : vector<16xindex> to vector<16xi64>
+    //CHECK: %[[r13:.*]] = arith.muli %[[r12]], %[[cst_3]] : vector<16xi64>
+    //CHECK: %[[r14:.*]] = vector.broadcast %[[r11]] : i64 to vector<16xi64>
+    //CHECK: %[[r15:.*]] = arith.addi %[[r14]], %[[r13]] : vector<16xi64>
+    %tdesc = xegpu.create_tdesc %mem[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : memref<16xf16> -> !xegpu.tensor_desc<16xf16, #global>
+
+    //CHECK: %[[r16:.*]] = vector.bitcast %[[r10]] : vector<16xf16> to vector<16xi16>
+    //CHECK: %[[r17:.*]] = arith.extui %[[r16]] : vector<16xi16> to vector<16xi32>
     //CHECK: func.call @llvm.genx.lsc.store.stateless.v16i1.v16i64.v16i32
-    //CHECK-SAME: (%[[cst_0]], %[[c4_i8]], %[[c0_i8]], %[[c0_i8]], %[[c1_i16]], %[[c0_i32]], %[[c6_i8]], %[[c1_i8]], %[[c1_i8]], %[[c0_i8]], %[[r10]], %[[r12]], %[[c0_i32]])
+    //CHECK-SAME: (%[[cst_0]], %[[c4_i8]], %[[c0_i8]], %[[c0_i8]], %[[c1_i16]], %[[c0_i32]], %[[c6_i8]], %[[c1_i8]], %[[c1_i8]], %[[c0_i8]], %[[r15]], %[[r17]], %[[c0_i32]])
     //CHECK-SAME: (vector<16xi1>, i8, i8, i8, i16, i32, i8, i8, i8, i8, vector<16xi64>, vector<16xi32>, i32) -> ()
     xegpu.store %data, %tdesc, %mask : vector<16xf16>, !xegpu.tensor_desc<16xf16, #global>, vector<16xi1>
 

--- a/test/Conversion/XeGPUToVC/store_load_slm_no_chunk_f32.mlir
+++ b/test/Conversion/XeGPUToVC/store_load_slm_no_chunk_f32.mlir
@@ -12,17 +12,19 @@ gpu.module @test_kernel {
 
     //CHECK: %[[cst_0:.*]] = arith.constant dense<true> : vector<16xi1>
     %mask = arith.constant dense<1> : vector<16xi1>
-    %offsets = arith.constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]> : vector<16xindex>
 
     //CHECK: %[[alloc:.*]] = memref.alloc() : memref<16xf32, 3>
     %slm = memref.alloc() : memref<16xf32, 3>
 
     //CHECK: %[[intptr:.*]] = memref.extract_aligned_pointer_as_index %[[alloc]] : memref<16xf32, 3> -> index
     //CHECK: %[[r0:.*]] = arith.index_castui %[[intptr]] : index to i32
-    //CHECK: %[[cst_1:.*]] = arith.constant dense<[0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60]> : vector<16xi32>
-    //CHECK: %[[r1:.*]] = vector.broadcast %[[r0]] : i32 to vector<16xi32>
-    //CHECK: %[[r2:.*]] = arith.addi %[[r1]], %[[cst_1]] : vector<16xi32>
-    %slm_tdesc = xegpu.create_tdesc %slm, %offsets : memref<16xf32, 3>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #slm>
+    //CHECK: %[[cst_1:.*]] = arith.constant dense<4> : vector<16xi32>
+    //CHECK: %[[r1:.*]] = vector.from_elements {{.*}} : vector<16xindex>
+    //CHECK: %[[r2:.*]] = arith.index_castui %[[r1]] : vector<16xindex> to vector<16xi32>
+    //CHECK: %[[r3:.*]] = arith.muli %[[r2]], %[[cst_1]] : vector<16xi32>
+    //CHECK: %[[r4:.*]] = vector.broadcast %[[r0]] : i32 to vector<16xi32>
+    //CHECK: %[[r5:.*]] = arith.addi %[[r4]], %[[r3]] : vector<16xi32>
+    %slm_tdesc = xegpu.create_tdesc %slm[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : memref<16xf32, 3> -> !xegpu.tensor_desc<16xf32, #slm>
 
     //CHECK: %[[c4_i8:.*]] = arith.constant 4 : i8
     //CHECK: %[[c0_i8:.*]] = arith.constant 0 : i8
@@ -31,24 +33,26 @@ gpu.module @test_kernel {
     //CHECK: %[[c3_i8:.*]] = arith.constant 3 : i8
     //CHECK: %[[c1_i8:.*]] = arith.constant 1 : i8
     //CHECK: func.call @llvm.genx.lsc.store.slm.v16i1.v16i32.v16f32
-    //CHECK-SAME: (%[[cst_0]], %[[c4_i8]], %[[c0_i8]], %[[c0_i8]], %[[c1_i16]], %[[c0_i32]], %[[c3_i8]], %[[c1_i8]], %[[c1_i8]], %[[c0_i8]], %[[r2]], %[[cst]], %[[c0_i32]])
+    //CHECK-SAME: (%[[cst_0]], %[[c4_i8]], %[[c0_i8]], %[[c0_i8]], %[[c1_i16]], %[[c0_i32]], %[[c3_i8]], %[[c1_i8]], %[[c1_i8]], %[[c0_i8]], %[[r5]], %[[cst]], %[[c0_i32]])
     //CHECK-SAME: (vector<16xi1>, i8, i8, i8, i16, i32, i8, i8, i8, i8, vector<16xi32>, vector<16xf32>, i32) -> ()
     xegpu.store %cst, %slm_tdesc, %mask : vector<16xf32>, !xegpu.tensor_desc<16xf32, #slm>, vector<16xi1>
 
-    //CHECK: %[[r3:.*]] = func.call @llvm.genx.lsc.load.slm.v16f32.v16i1.v16i32
-    //CHECK-SAME: (%[[cst_0]], %[[c0_i8]], %[[c0_i8]], %[[c0_i8]], %[[c1_i16]], %[[c0_i32]], %[[c3_i8]], %[[c1_i8]], %[[c1_i8]], %[[c0_i8]], %[[r2]], %[[c0_i32]])
+    //CHECK: %[[r6:.*]] = func.call @llvm.genx.lsc.load.slm.v16f32.v16i1.v16i32
+    //CHECK-SAME: (%[[cst_0]], %[[c0_i8]], %[[c0_i8]], %[[c0_i8]], %[[c1_i16]], %[[c0_i32]], %[[c3_i8]], %[[c1_i8]], %[[c1_i8]], %[[c0_i8]], %[[r5]], %[[c0_i32]])
     //CHECK-SAME: (vector<16xi1>, i8, i8, i8, i16, i32, i8, i8, i8, i8, vector<16xi32>, i32) -> vector<16xf32>
     %data = xegpu.load %slm_tdesc, %mask : !xegpu.tensor_desc<16xf32, #slm>, vector<16xi1> -> vector<16xf32>
 
     //CHECK: %[[intptr_2:.*]] = memref.extract_aligned_pointer_as_index %[[arg0]] : memref<16xf32> -> index
-    //CHECK: %[[r4:.*]] = arith.index_castui %[[intptr_2]] : index to i64
-    //CHECK: %[[cst_3:.*]] = arith.constant dense<[0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60]> : vector<16xi64>
-    //CHECK: %[[r5:.*]] = vector.broadcast %[[r4]] : i64 to vector<16xi64>
-    //CHECK: %[[r6:.*]] = arith.addi %[[r5]], %[[cst_3]] : vector<16xi64>
-    %tdesc = xegpu.create_tdesc %mem, %offsets : memref<16xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #global>
+    //CHECK: %[[r7:.*]] = arith.index_castui %[[intptr_2]] : index to i64
+    //CHECK: %[[cst_3:.*]] = arith.constant dense<4> : vector<16xi64>
+    //CHECK: %[[r8:.*]] = arith.index_castui %[[r1]] : vector<16xindex> to vector<16xi64>
+    //CHECK: %[[r9:.*]] = arith.muli %[[r8]], %[[cst_3]] : vector<16xi64>
+    //CHECK: %[[r10:.*]] = vector.broadcast %[[r7]] : i64 to vector<16xi64>
+    //CHECK: %[[r11:.*]] = arith.addi %[[r10]], %[[r9]] : vector<16xi64>
+    %tdesc = xegpu.create_tdesc %mem[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : memref<16xf32> -> !xegpu.tensor_desc<16xf32, #global>
 
     //CHECK: func.call @llvm.genx.lsc.store.stateless.v16i1.v16i64.v16f32
-    //CHECK-SAME: (%[[cst_0]], %[[c4_i8]], %[[c0_i8]], %[[c0_i8]], %[[c1_i16]], %[[c0_i32]], %[[c3_i8]], %[[c1_i8]], %[[c1_i8]], %[[c0_i8]], %[[r6]], %[[r3]], %[[c0_i32]])
+    //CHECK-SAME: (%[[cst_0]], %[[c4_i8]], %[[c0_i8]], %[[c0_i8]], %[[c1_i16]], %[[c0_i32]], %[[c3_i8]], %[[c1_i8]], %[[c1_i8]], %[[c0_i8]], %[[r11]], %[[r6]], %[[c0_i32]])
     //CHECK-SAME: (vector<16xi1>, i8, i8, i8, i16, i32, i8, i8, i8, i8, vector<16xi64>, vector<16xf32>, i32) -> ()
     xegpu.store %data, %tdesc, %mask : vector<16xf32>, !xegpu.tensor_desc<16xf32, #global>, vector<16xi1>
 

--- a/test/Conversion/XeGPUToVC/xegpu-to-vc.mlir
+++ b/test/Conversion/XeGPUToVC/xegpu-to-vc.mlir
@@ -60,8 +60,8 @@ module @gemm attributes {gpu.container_module} {
       //CHECK: %[[r17:.*]] = vector.bitcast %[[r14]] : vector<128xf16> to vector<64xi32>
       //CHECK: %[[r18:.*]] = vector.bitcast %[[r16]] : vector<256xf16> to vector<128xi32>
       //CHECK: %[[r19:.*]] = func.call @llvm.genx.dpas.nosrc0.v128f32.v128i32.v64i32(%[[r18]], %[[r17]], %[[c134744586_i32]]) : (vector<128xi32>, vector<64xi32>, i32) -> vector<128xf32>
-      %6 = vector.shape_cast %3: vector<128xf16> to vector<8x8x2xf16>
-      %5 = xegpu.dpas %6, %4 : vector<8x8x2xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
+      %6 = vector.shape_cast %3: vector<128xf16> to vector<8x16xf16>
+      %5 = xegpu.dpas %6, %4 : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
       %7 = vector.shape_cast %5: vector<8x16xf32> to vector<128xf32>
 
       //RAW: %[[c33748868_i32:.*]] = arith.constant 33748868 : i32

--- a/test/Dialect/XeGPU/IR/XeGPUOps.mlir
+++ b/test/Dialect/XeGPU/IR/XeGPUOps.mlir
@@ -24,9 +24,9 @@ func.func @test_create_nd_tdesc_vc(%src: memref<24x32xf32>) {
 
 // CHECK-LABEL: func @test_create_tdesc_vc({{.*}}) {
 func.func @test_create_tdesc_vc(%src: ui64, %offsets : vector<16 x index>) {
-  // CHECK: xegpu.create_tdesc %{{.*}} : ui64, vector<16xindex>
+  // CHECK: xegpu.create_tdesc %{{.*}} : ui64
   // CHECK-SAME: !xegpu.tensor_desc<16x2xf32, #xegpu.scatter_tdesc_attr<memory_scope = slm, chunk_size = 2 : i64>>
-  %1 = xegpu.create_tdesc %src, %offsets : ui64, vector<16 x index>
+  %1 = xegpu.create_tdesc %src[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] : ui64
           -> !xegpu.tensor_desc<16x2xf32, #xegpu.scatter_tdesc_attr<memory_scope = slm, chunk_size = 2>>
   return
 }

--- a/test/Dialect/XeGPU/IR/atomic_rmw_vc.mlir
+++ b/test/Dialect/XeGPU/IR/atomic_rmw_vc.mlir
@@ -5,8 +5,8 @@
 // RUN: imex-opt -mlir-print-op-generic %s | imex-opt | FileCheck %s
 
 // CHECK-LABEL: func @test_atomic_rmw({{.*}}) {
-func.func @test_atomic_rmw(%src: ui64, %offsets : vector<16 x index>, %value : vector<16xf32>, %mask : vector<16xi1>) {
-  %1 = xegpu.create_tdesc %src, %offsets : ui64, vector<16 x index> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
+func.func @test_atomic_rmw(%src: ui64, %value : vector<16xf32>, %mask : vector<16xi1>) {
+  %1 = xegpu.create_tdesc %src[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] : ui64 -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
 
   // CHECK: xegpu.atomic_rmw
   // CHECK-SAME: !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>, vector<16xi1>, vector<16xf32>
@@ -16,8 +16,8 @@ func.func @test_atomic_rmw(%src: ui64, %offsets : vector<16 x index>, %value : v
 }
 
 // CHECK-LABEL: func @test_atomic_rmw_0({{.*}}) {
-func.func @test_atomic_rmw_0(%src: ui64, %offsets : vector<16 x index>, %value : vector<16x2xf32>, %mask : vector<16xi1>) {
-  %1 = xegpu.create_tdesc %src, %offsets : ui64, vector<16 x index> -> !xegpu.tensor_desc<16x2xf32, #xegpu.scatter_tdesc_attr<chunk_size = 2>>
+func.func @test_atomic_rmw_0(%src: ui64, %value : vector<16x2xf32>, %mask : vector<16xi1>) {
+  %1 = xegpu.create_tdesc %src[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] : ui64 -> !xegpu.tensor_desc<16x2xf32, #xegpu.scatter_tdesc_attr<chunk_size = 2>>
 
   // CHECK: xegpu.atomic_rmw
   // CHECK-SAME: !xegpu.tensor_desc<16x2xf32, #xegpu.scatter_tdesc_attr<chunk_size = 2 : i64>>, vector<16xi1>, vector<16x2xf32>
@@ -27,8 +27,8 @@ func.func @test_atomic_rmw_0(%src: ui64, %offsets : vector<16 x index>, %value :
 }
 
 // CHECK-LABEL: func @test_atomic_rmw_1({{.*}}) {
-func.func @test_atomic_rmw_1(%src: ui64, %offsets : vector<16 x index>, %value : vector<16x2xi32>, %mask : vector<16xi1>) {
-  %1 = xegpu.create_tdesc %src, %offsets : ui64, vector<16 x index> -> !xegpu.tensor_desc<16x2xi32, #xegpu.scatter_tdesc_attr<chunk_size = 2>>
+func.func @test_atomic_rmw_1(%src: ui64, %value : vector<16x2xi32>, %mask : vector<16xi1>) {
+  %1 = xegpu.create_tdesc %src[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] : ui64 -> !xegpu.tensor_desc<16x2xi32, #xegpu.scatter_tdesc_attr<chunk_size = 2>>
 
   // CHECK: xegpu.atomic_rmw
   // CHECK-SAME: !xegpu.tensor_desc<16x2xi32, #xegpu.scatter_tdesc_attr<chunk_size = 2 : i64>>, vector<16xi1>, vector<16x2xi32>

--- a/test/Dialect/XeGPU/IR/create_tdesc_vc.mlir
+++ b/test/Dialect/XeGPU/IR/create_tdesc_vc.mlir
@@ -6,47 +6,44 @@
 
 
 // CHECK-LABEL: func @test_create_tdesc_vc({{.*}}) {
-func.func @test_create_tdesc_vc(%src: ui64, %offsets : vector<16 x index>) {
-  // CHECK: xegpu.create_tdesc %arg0, %arg1
-  // CHECK-SAME: ui64, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
-  %1 = xegpu.create_tdesc %src, %offsets : ui64, vector<16 x index> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
+func.func @test_create_tdesc_vc(%src: ui64) {
+  // CHECK: xegpu.create_tdesc %{{.*}} : ui64 -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
+  %1 = xegpu.create_tdesc %src[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] : ui64 -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
   return
 }
 
 // CHECK-LABEL: func @test_create_tdesc_vc_2({{.*}}) {
-func.func @test_create_tdesc_vc_2(%src: ui64, %offsets : vector<16 x index>) {
-  // CHECK: xegpu.create_tdesc %arg0, %arg1
-  // CHECK-SAME: ui64, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<memory_scope =  slm>>
-  %1 = xegpu.create_tdesc %src, %offsets : ui64, vector<16 x index>
+func.func @test_create_tdesc_vc_2(%src: ui64) {
+  // CHECK: xegpu.create_tdesc %{{.*}} : ui64 -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<memory_scope =  slm>>
+  %1 = xegpu.create_tdesc %src[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] : ui64
                             -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<memory_scope = slm>>
   return
 }
 
 // CHECK-LABEL: func @test_create_tdesc_vc_3({{.*}}) {
-func.func @test_create_tdesc_vc_3(%src: ui64, %offsets : vector<16 x index>) {
-  // CHECK: xegpu.create_tdesc %arg0, %arg1
-  // CHECK-SAME: ui64, vector<16xindex> -> !xegpu.tensor_desc<16x8xf32, #xegpu.scatter_tdesc_attr<chunk_size = 8 : i64>>
-  %1 = xegpu.create_tdesc %src, %offsets : ui64, vector<16 x index>
+func.func @test_create_tdesc_vc_3(%src: ui64) {
+  // CHECK: xegpu.create_tdesc %{{.*}} : ui64 -> !xegpu.tensor_desc<16x8xf32, #xegpu.scatter_tdesc_attr<chunk_size = 8 : i64>>
+  %1 = xegpu.create_tdesc %src[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] : ui64
             -> !xegpu.tensor_desc<16x8xf32, #xegpu.scatter_tdesc_attr<chunk_size = 8>>
   return
 }
 
 // CHECK-LABEL: func @test_create_tdesc_vc_4({{.*}}) {
-func.func @test_create_tdesc_vc_4(%src: ui64, %offsets : vector<16 x index>) {
-  // CHECK: xegpu.create_tdesc %arg0, %arg1 : ui64, vector<16xindex>
+func.func @test_create_tdesc_vc_4(%src: ui64) {
+  // CHECK: xegpu.create_tdesc %{{.*}} : ui64
   // CHECK-SAME: !xegpu.tensor_desc<16x2xf32, #xegpu.scatter_tdesc_attr<memory_scope =  slm, chunk_size = 2 : i64>>
-  %1 = xegpu.create_tdesc %src, %offsets : ui64, vector<16 x index>
+  %1 = xegpu.create_tdesc %src[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] : ui64
             -> !xegpu.tensor_desc<16x2xf32, #xegpu.scatter_tdesc_attr<memory_scope = slm, chunk_size = 2>>
   return
 }
 
 
 // CHECK-LABEL: func @test_create_tdesc_vc_5({{.*}}) {
-func.func @test_create_tdesc_vc_5(%src: memref<?xf32>, %offsets : vector<16 x index>) {
+func.func @test_create_tdesc_vc_5(%src: memref<?xf32>) {
   // CHECK: xegpu.create_tdesc
-  // CHECK-SAME: memref<?xf32>, vector<16xindex>
+  // CHECK-SAME: memref<?xf32>
   // CHECK-SAME: !xegpu.tensor_desc<16x2xf32, #xegpu.scatter_tdesc_attr<memory_scope =  slm, chunk_size = 2 : i64>>
-  %1 = xegpu.create_tdesc %src, %offsets : memref<?xf32>, vector<16 x index>
+  %1 = xegpu.create_tdesc %src[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] : memref<?xf32>
             -> !xegpu.tensor_desc<16x2xf32, #xegpu.scatter_tdesc_attr<memory_scope = slm, chunk_size = 2>>
   return
 }

--- a/test/Dialect/XeGPU/IR/invalid_vc.mlir
+++ b/test/Dialect/XeGPU/IR/invalid_vc.mlir
@@ -47,19 +47,19 @@ func.func @test_create_nd_tdesc_vc_5(%input: memref<24x32x64xf32>) {
 }
 
 // -----
-func.func @test_create_tdesc(%src: ui64, %offsets : vector<16x8xindex>) {
-  // expected-error@+1 {{operand #1 must be vector of index values of ranks 1}}
-  %1 = xegpu.create_tdesc %src, %offsets
-                              : ui64, vector<16x8xindex> -> !xegpu.tensor_desc<16x8xf32, #xegpu.scatter_tdesc_attr<>>
+func.func @test_create_tdesc(%src: ui64) {
+  // expected-error@+1 {{Incorrect TensorDesc shape}}
+  %1 = xegpu.create_tdesc %src[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17]
+                              : ui64 -> !xegpu.tensor_desc<16x8xf32, #xegpu.scatter_tdesc_attr<>>
   return
 }
 
 // -----
-func.func @test_load_gather(%src: ui64, %offsets : vector<16xindex>) {
+func.func @test_load_gather(%src: ui64) {
   %0 = arith.constant dense<1>: vector<16xi1>
-  // CHECK: xegpu.create_tdesc {{.*}} : ui64, vector<16xindex>
+  // CHECK: xegpu.create_tdesc {{.*}} : ui64
   // CHECK-SAME: !xegpu.tensor_desc<16x8xf32, #xegpu.scatter_tdesc_attr<chunk_size = 8 : i64>>
-  %1 = xegpu.create_tdesc %src, %offsets : ui64, vector<16xindex>
+  %1 = xegpu.create_tdesc %src[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] : ui64
         -> !xegpu.tensor_desc<16x8xf16, #xegpu.scatter_tdesc_attr<chunk_size = 8>>
 
   // expected-error@+1 {{failed to verify that all of {value, TensorDesc} have same rank}}
@@ -69,25 +69,25 @@ func.func @test_load_gather(%src: ui64, %offsets : vector<16xindex>) {
 }
 
 // -----
-func.func @test_create_tdesc_oversized(%src: ui64, %offsets : vector<16xindex>) {
+func.func @test_create_tdesc_oversized(%src: ui64) {
   // expected-error@+1 {{total access size (simd_lanes * chunk_size * sizeof(elemTy)) is upto 512 bytes}}
-  %1 = xegpu.create_tdesc %src, %offsets : ui64, vector<16xindex>
+  %1 = xegpu.create_tdesc %src[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] : ui64
               -> !xegpu.tensor_desc<16x16xf32, #xegpu.scatter_tdesc_attr<chunk_size = 16>>
   return
 }
 
 // -----
-func.func @test_create_tdesc_invalid_chunk_size(%src: ui64, %offsets : vector<16xindex>) {
+func.func @test_create_tdesc_invalid_chunk_size(%src: ui64) {
   // expected-error@+1 {{Invalid chunk_size. Supported values are 1, 2, 3, 4, 8, 16, 32, 64, 128, or 256.}}
-  %1 = xegpu.create_tdesc %src, %offsets : ui64, vector<16xindex>
+  %1 = xegpu.create_tdesc %src[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] : ui64
               -> !xegpu.tensor_desc<16x7xf32, #xegpu.scatter_tdesc_attr<chunk_size = 7>>
   return
 }
 
 // -----
-func.func @test_create_tdesc_unaligned(%src: ui64, %offsets : vector<16xindex>) {
+func.func @test_create_tdesc_unaligned(%src: ui64) {
   // expected-error@+1 {{access size (chunk_size * sizeof(elemTy)) should be 32-bit aligned}}
-  %1 = xegpu.create_tdesc %src, %offsets : ui64, vector<16xindex>
+  %1 = xegpu.create_tdesc %src[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] : ui64
               -> !xegpu.tensor_desc<16x3xf16, #xegpu.scatter_tdesc_attr<chunk_size = 3>>
   return
 }

--- a/test/Dialect/XeGPU/IR/load_gather_vc.mlir
+++ b/test/Dialect/XeGPU/IR/load_gather_vc.mlir
@@ -6,11 +6,11 @@
 
 
 // CHECK-LABEL: func @test_load_gather_vc({{.*}}) {
-func.func @test_load_gather_vc(%src: ui64, %offsets : vector<16xindex>) {
+func.func @test_load_gather_vc(%src: ui64) {
   %0 = arith.constant dense<1>: vector<16xi1>
-  //CHECK: {{.*}} = xegpu.create_tdesc {{.*}}, {{.*}} : ui64, vector<16xindex>
+  //CHECK: {{.*}} = xegpu.create_tdesc {{.*}} : ui64
   //CHECK-SAME: !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
-  %1 = xegpu.create_tdesc %src, %offsets : ui64, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
+  %1 = xegpu.create_tdesc %src[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] : ui64 -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
 
   // CHECK: {{.*}} = xegpu.load {{.*}}, {{.*}} <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<uncached>}>
   // CHECK-SAME: !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>, vector<16xi1> -> vector<16xf32>
@@ -20,12 +20,12 @@ func.func @test_load_gather_vc(%src: ui64, %offsets : vector<16xindex>) {
 }
 
 // CHECK-LABEL: func @test_load_gather_vc_2({{.*}}) {
-func.func @test_load_gather_vc_2(%src: ui64, %offsets : vector<16xindex>) {
+func.func @test_load_gather_vc_2(%src: ui64) {
   %0 = arith.constant dense<1>: vector<16xi1>
 
-  //CHECK: {{.*}} = xegpu.create_tdesc {{.*}} : ui64, vector<16xindex>
+  //CHECK: {{.*}} = xegpu.create_tdesc {{.*}} : ui64
   //CHECK-SAME: !xegpu.tensor_desc<16x8xf32, #xegpu.scatter_tdesc_attr<chunk_size = 8 : i64>>
-  %1 = xegpu.create_tdesc %src, %offsets : ui64, vector<16xindex>
+  %1 = xegpu.create_tdesc %src[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] : ui64
           -> !xegpu.tensor_desc<16x8xf32, #xegpu.scatter_tdesc_attr<chunk_size = 8>>
 
   //CHECK: {{.*}} = xegpu.load {{.*}}, {{.*}} <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<uncached>, transpose}>
@@ -36,11 +36,11 @@ func.func @test_load_gather_vc_2(%src: ui64, %offsets : vector<16xindex>) {
 }
 
 // CHECK-LABEL: func @test_load_gather_vc_4({{.*}}) {
-func.func @test_load_gather_vc_4(%src: ui64, %offsets : vector<16xindex>) {
+func.func @test_load_gather_vc_4(%src: ui64) {
   %0 = arith.constant dense<1>: vector<16xi1>
 
-  //CHECK: {{.*}} = xegpu.create_tdesc {{.*}}, {{.*}} : ui64, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
-  %1 = xegpu.create_tdesc %src, %offsets : ui64, vector<16xindex>
+  //CHECK: {{.*}} = xegpu.create_tdesc {{.*}} : ui64 -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
+  %1 = xegpu.create_tdesc %src[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] : ui64
         -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
 
   //CHECK: {{.*}} = xegpu.load {{.*}}, {{.*}} <{l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<uncached>}>

--- a/test/Dialect/XeGPU/IR/store_scatter_vc.mlir
+++ b/test/Dialect/XeGPU/IR/store_scatter_vc.mlir
@@ -5,16 +5,13 @@
 // RUN: imex-opt -mlir-print-op-generic %s | imex-opt | FileCheck %s
 
 // CHECK-LABEL: func @test_store_scatter_vc({{.*}}) {
-func.func @test_store_scatter_vc(%src: ui64, %offsets : vector<16 x index>, %dst: ui64) {
+func.func @test_store_scatter_vc(%src: ui64, %dst: ui64) {
   %0 = arith.constant dense<1>: vector<16xi1>
-  // CHECK: xegpu.create_tdesc
-  // CHECK-SAME: ui64, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
-  %1 = xegpu.create_tdesc %src, %offsets : ui64, vector<16 x index> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
+  // CHECK: xegpu.create_tdesc %{{.*}} : ui64 -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
+  %1 = xegpu.create_tdesc %src[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] : ui64 -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
 
-  // CHECK: xegpu.create_tdesc
-  // CHECK-SAME: ui64, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
-  %2 = xegpu.create_tdesc %dst, %offsets
-          : ui64, vector<16 x index> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
+  // CHECK: xegpu.create_tdesc %{{.*}} : ui64 -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
+  %2 = xegpu.create_tdesc %dst[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] : ui64 -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
 
   // CHECK: xegpu.load
   // CHECK-SAME: {l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<uncached>}

--- a/test/Dialect/XeGPU/IR/update_offset_vc.mlir
+++ b/test/Dialect/XeGPU/IR/update_offset_vc.mlir
@@ -7,10 +7,8 @@
 // CHECK-LABEL: func @test_update_offset_VC({{.*}}) {
 func.func @test_update_offset_VC(%src: ui64, %offsets : vector<16 x index>) {
   %0 = arith.constant dense<1>: vector<16xi1>
-  // CHECK: xegpu.create_tdesc
-  // CHECK-SAME: ui64, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
-  %1 = xegpu.create_tdesc %src, %offsets
-              : ui64, vector<16 x index> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
+  // CHECK: xegpu.create_tdesc %{{.*}} : ui64 -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
+  %1 = xegpu.create_tdesc %src[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] : ui64 -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
 
   // CHECK: xegpu.load
   // CHECK-SAME: {l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<uncached>}
@@ -18,12 +16,8 @@ func.func @test_update_offset_VC(%src: ui64, %offsets : vector<16 x index>) {
   %2 = xegpu.load %1, %0 {l1_hint = #xegpu.cache_hint<cached>, l2_hint = #xegpu.cache_hint<uncached>}
         : !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>, vector<16xi1> -> vector<16xf32>
 
-  %3 = arith.constant dense<16>: vector<16 x index>
-
-  // CHECK: xegpu.update_offset
-  // CHECK-SAME: !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
-  %5 = xegpu.update_offset %1, %3
-      : !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>, vector<16 x index> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
+  // CHECK: xegpu.update_offset %{{.*}} : !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
+  %5 = xegpu.update_offset %1, [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] : !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
 
   return
 }

--- a/test/Integration/Dialect/XeGPU/flash_attention_fwd.mlir
+++ b/test/Integration/Dialect/XeGPU/flash_attention_fwd.mlir
@@ -169,29 +169,29 @@ module @flash_attention attributes {gpu.container_module} {
       %q_block_value_3_flat = vector.shape_cast %q_block_value_3 : vector<16x16xf16> to vector<256xf16>
 
       %q_block_value_0_0_t0 = vector.extract_strided_slice %q_block_value_0_flat { offsets = [0], sizes = [128], strides = [1]} : vector<256xf16> to vector<128xf16>
-      %q_block_value_0_0 = vector.shape_cast %q_block_value_0_0_t0 : vector<128xf16> to vector<8x8x2xf16>
+      %q_block_value_0_0 = vector.shape_cast %q_block_value_0_0_t0 : vector<128xf16> to vector<8x16xf16>
 
       %q_block_value_1_0_t0 = vector.extract_strided_slice %q_block_value_0_flat { offsets = [128], sizes = [128], strides = [1]} : vector<256xf16> to vector<128xf16>
-      %q_block_value_1_0 = vector.shape_cast %q_block_value_1_0_t0 : vector<128xf16> to vector<8x8x2xf16>
+      %q_block_value_1_0 = vector.shape_cast %q_block_value_1_0_t0 : vector<128xf16> to vector<8x16xf16>
 
       %q_block_value_0_1_t0 = vector.extract_strided_slice %q_block_value_1_flat { offsets = [0], sizes = [128], strides = [1]} : vector<256xf16> to vector<128xf16>
-      %q_block_value_0_1 = vector.shape_cast %q_block_value_0_1_t0 : vector<128xf16> to vector<8x8x2xf16>
+      %q_block_value_0_1 = vector.shape_cast %q_block_value_0_1_t0 : vector<128xf16> to vector<8x16xf16>
 
       %q_block_value_1_1_t0 = vector.extract_strided_slice %q_block_value_1_flat { offsets = [128], sizes = [128], strides = [1]} : vector<256xf16> to vector<128xf16>
-      %q_block_value_1_1 = vector.shape_cast %q_block_value_1_1_t0 : vector<128xf16> to vector<8x8x2xf16>
+      %q_block_value_1_1 = vector.shape_cast %q_block_value_1_1_t0 : vector<128xf16> to vector<8x16xf16>
 
       // ----
       %q_block_value_0_2_t0 = vector.extract_strided_slice %q_block_value_2_flat { offsets = [0], sizes = [128], strides = [1]} : vector<256xf16> to vector<128xf16>
-      %q_block_value_0_2 = vector.shape_cast %q_block_value_0_2_t0 : vector<128xf16> to vector<8x8x2xf16>
+      %q_block_value_0_2 = vector.shape_cast %q_block_value_0_2_t0 : vector<128xf16> to vector<8x16xf16>
 
       %q_block_value_1_2_t0 = vector.extract_strided_slice %q_block_value_2_flat { offsets = [128], sizes = [128], strides = [1]} : vector<256xf16> to vector<128xf16>
-      %q_block_value_1_2 = vector.shape_cast %q_block_value_1_2_t0 : vector<128xf16> to vector<8x8x2xf16>
+      %q_block_value_1_2 = vector.shape_cast %q_block_value_1_2_t0 : vector<128xf16> to vector<8x16xf16>
 
       %q_block_value_0_3_t0 = vector.extract_strided_slice %q_block_value_3_flat { offsets = [0], sizes = [128], strides = [1]} : vector<256xf16> to vector<128xf16>
-      %q_block_value_0_3 = vector.shape_cast %q_block_value_0_3_t0 : vector<128xf16> to vector<8x8x2xf16>
+      %q_block_value_0_3 = vector.shape_cast %q_block_value_0_3_t0 : vector<128xf16> to vector<8x16xf16>
 
       %q_block_value_1_3_t0 = vector.extract_strided_slice %q_block_value_3_flat { offsets = [128], sizes = [128], strides = [1]} : vector<256xf16> to vector<128xf16>
-      %q_block_value_1_3 = vector.shape_cast %q_block_value_1_3_t0 : vector<128xf16> to vector<8x8x2xf16>
+      %q_block_value_1_3 = vector.shape_cast %q_block_value_1_3_t0 : vector<128xf16> to vector<8x16xf16>
 
       xegpu.alloc_nbarrier 16
       %nbarrier_id = arith.constant 1 : i8
@@ -292,14 +292,14 @@ module @flash_attention attributes {gpu.container_module} {
 
 
           // compute first 16x16 of Q * K^T using DPAS
-          %qk_out_0_0_t0 = xegpu.dpas %q_block_value_0_0, %k_value_slice_0_0, %zero_dpas : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-          %qk_out_1_0_t0 = xegpu.dpas %q_block_value_1_0, %k_value_slice_0_0, %zero_dpas : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-          %qk_out_0_0_t1 = xegpu.dpas %q_block_value_0_1, %k_value_slice_0_1, %qk_out_0_0_t0 : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-          %qk_out_1_0_t1 = xegpu.dpas %q_block_value_1_1, %k_value_slice_0_1, %qk_out_1_0_t0 : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-          %qk_out_0_0_t2 = xegpu.dpas %q_block_value_0_2, %k_value_slice_0_2, %qk_out_0_0_t1 : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-          %qk_out_1_0_t2 = xegpu.dpas %q_block_value_1_2, %k_value_slice_0_2, %qk_out_1_0_t1 : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-          %qk_out_0_0 = xegpu.dpas %q_block_value_0_3, %k_value_slice_0_3, %qk_out_0_0_t2 : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-          %qk_out_1_0 = xegpu.dpas %q_block_value_1_3, %k_value_slice_0_3, %qk_out_1_0_t2 : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_0_0_t0 = xegpu.dpas %q_block_value_0_0, %k_value_slice_0_0, %zero_dpas : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_1_0_t0 = xegpu.dpas %q_block_value_1_0, %k_value_slice_0_0, %zero_dpas : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_0_0_t1 = xegpu.dpas %q_block_value_0_1, %k_value_slice_0_1, %qk_out_0_0_t0 : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_1_0_t1 = xegpu.dpas %q_block_value_1_1, %k_value_slice_0_1, %qk_out_1_0_t0 : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_0_0_t2 = xegpu.dpas %q_block_value_0_2, %k_value_slice_0_2, %qk_out_0_0_t1 : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_1_0_t2 = xegpu.dpas %q_block_value_1_2, %k_value_slice_0_2, %qk_out_1_0_t1 : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_0_0 = xegpu.dpas %q_block_value_0_3, %k_value_slice_0_3, %qk_out_0_0_t2 : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_1_0 = xegpu.dpas %q_block_value_1_3, %k_value_slice_0_3, %qk_out_1_0_t2 : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
           xegpu.compile_hint
 
           // load second 16x64 K slice
@@ -316,15 +316,15 @@ module @flash_attention attributes {gpu.container_module} {
           xegpu.compile_hint
 
           // compute second 16x16 of Q * K^T using DPAS
-          %qk_out_0_1_t0 = xegpu.dpas %q_block_value_0_0, %k_value_slice_1_0, %zero_dpas     : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-          %qk_out_0_1_t1 = xegpu.dpas %q_block_value_0_1, %k_value_slice_1_1, %qk_out_0_1_t0 : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-          %qk_out_0_1_t2 = xegpu.dpas %q_block_value_0_2, %k_value_slice_1_2, %qk_out_0_1_t1 : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-          %qk_out_0_1 = xegpu.dpas %q_block_value_0_3, %k_value_slice_1_3, %qk_out_0_1_t2    : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_0_1_t0 = xegpu.dpas %q_block_value_0_0, %k_value_slice_1_0, %zero_dpas     : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_0_1_t1 = xegpu.dpas %q_block_value_0_1, %k_value_slice_1_1, %qk_out_0_1_t0 : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_0_1_t2 = xegpu.dpas %q_block_value_0_2, %k_value_slice_1_2, %qk_out_0_1_t1 : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_0_1 = xegpu.dpas %q_block_value_0_3, %k_value_slice_1_3, %qk_out_0_1_t2    : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
 
-          %qk_out_1_1_t0 = xegpu.dpas %q_block_value_1_0, %k_value_slice_1_0, %zero_dpas      : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-          %qk_out_1_1_t1 = xegpu.dpas %q_block_value_1_1, %k_value_slice_1_1, %qk_out_1_1_t0  : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-          %qk_out_1_1_t2 = xegpu.dpas %q_block_value_1_2, %k_value_slice_1_2, %qk_out_1_1_t1  : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-          %qk_out_1_1 = xegpu.dpas %q_block_value_1_3, %k_value_slice_1_3, %qk_out_1_1_t2     : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_1_1_t0 = xegpu.dpas %q_block_value_1_0, %k_value_slice_1_0, %zero_dpas      : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_1_1_t1 = xegpu.dpas %q_block_value_1_1, %k_value_slice_1_1, %qk_out_1_1_t0  : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_1_1_t2 = xegpu.dpas %q_block_value_1_2, %k_value_slice_1_2, %qk_out_1_1_t1  : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_1_1 = xegpu.dpas %q_block_value_1_3, %k_value_slice_1_3, %qk_out_1_1_t2     : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
 
           xegpu.compile_hint
 
@@ -342,15 +342,15 @@ module @flash_attention attributes {gpu.container_module} {
           xegpu.compile_hint
 
           // compute third 16x16 of Q * K^T using DPAS
-          %qk_out_0_2_t0 = xegpu.dpas %q_block_value_0_0, %k_value_slice_2_0, %zero_dpas : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-          %qk_out_0_2_t1 = xegpu.dpas %q_block_value_0_1, %k_value_slice_2_1, %qk_out_0_2_t0 : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-          %qk_out_0_2_t2 = xegpu.dpas %q_block_value_0_2, %k_value_slice_2_2, %qk_out_0_2_t1 : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-          %qk_out_0_2 = xegpu.dpas %q_block_value_0_3, %k_value_slice_2_3, %qk_out_0_2_t2 : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_0_2_t0 = xegpu.dpas %q_block_value_0_0, %k_value_slice_2_0, %zero_dpas : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_0_2_t1 = xegpu.dpas %q_block_value_0_1, %k_value_slice_2_1, %qk_out_0_2_t0 : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_0_2_t2 = xegpu.dpas %q_block_value_0_2, %k_value_slice_2_2, %qk_out_0_2_t1 : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_0_2 = xegpu.dpas %q_block_value_0_3, %k_value_slice_2_3, %qk_out_0_2_t2 : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
 
-          %qk_out_1_2_t0 = xegpu.dpas %q_block_value_1_0, %k_value_slice_2_0, %zero_dpas : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-          %qk_out_1_2_t1 = xegpu.dpas %q_block_value_1_1, %k_value_slice_2_1, %qk_out_1_2_t0 : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-          %qk_out_1_2_t2 = xegpu.dpas %q_block_value_1_2, %k_value_slice_2_2, %qk_out_1_2_t1 : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-          %qk_out_1_2 = xegpu.dpas %q_block_value_1_3, %k_value_slice_2_3, %qk_out_1_2_t2 : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_1_2_t0 = xegpu.dpas %q_block_value_1_0, %k_value_slice_2_0, %zero_dpas : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_1_2_t1 = xegpu.dpas %q_block_value_1_1, %k_value_slice_2_1, %qk_out_1_2_t0 : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_1_2_t2 = xegpu.dpas %q_block_value_1_2, %k_value_slice_2_2, %qk_out_1_2_t1 : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_1_2 = xegpu.dpas %q_block_value_1_3, %k_value_slice_2_3, %qk_out_1_2_t2 : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
 
           xegpu.compile_hint
 
@@ -368,15 +368,15 @@ module @flash_attention attributes {gpu.container_module} {
           xegpu.compile_hint
 
           // compute forth 16x16 of Q * K^T using DPAS
-          %qk_out_0_3_t0 = xegpu.dpas %q_block_value_0_0, %k_value_slice_3_0, %zero_dpas : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-          %qk_out_0_3_t1 = xegpu.dpas %q_block_value_0_1, %k_value_slice_3_1, %qk_out_0_3_t0 : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-          %qk_out_0_3_t2 = xegpu.dpas %q_block_value_0_2, %k_value_slice_3_2, %qk_out_0_3_t1 : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-          %qk_out_0_3 = xegpu.dpas %q_block_value_0_3, %k_value_slice_3_3, %qk_out_0_3_t2  : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_0_3_t0 = xegpu.dpas %q_block_value_0_0, %k_value_slice_3_0, %zero_dpas : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_0_3_t1 = xegpu.dpas %q_block_value_0_1, %k_value_slice_3_1, %qk_out_0_3_t0 : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_0_3_t2 = xegpu.dpas %q_block_value_0_2, %k_value_slice_3_2, %qk_out_0_3_t1 : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_0_3 = xegpu.dpas %q_block_value_0_3, %k_value_slice_3_3, %qk_out_0_3_t2  : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
 
-          %qk_out_1_3_t0 = xegpu.dpas %q_block_value_1_0, %k_value_slice_3_0, %zero_dpas : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-          %qk_out_1_3_t1 = xegpu.dpas %q_block_value_1_1, %k_value_slice_3_1, %qk_out_1_3_t0 : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-          %qk_out_1_3_t2 = xegpu.dpas %q_block_value_1_2, %k_value_slice_3_2, %qk_out_1_3_t1 : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
-          %qk_out_1_3 = xegpu.dpas %q_block_value_1_3, %k_value_slice_3_3, %qk_out_1_3_t2 : vector<8x8x2xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_1_3_t0 = xegpu.dpas %q_block_value_1_0, %k_value_slice_3_0, %zero_dpas : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_1_3_t1 = xegpu.dpas %q_block_value_1_1, %k_value_slice_3_1, %qk_out_1_3_t0 : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_1_3_t2 = xegpu.dpas %q_block_value_1_2, %k_value_slice_3_2, %qk_out_1_3_t1 : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+          %qk_out_1_3 = xegpu.dpas %q_block_value_1_3, %k_value_slice_3_3, %qk_out_1_3_t2 : vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
 
           xegpu.compile_hint
 

--- a/test/Integration/Dialect/XeGPU/gather_scatter_global/load_global_chunk_4_f32.mlir
+++ b/test/Integration/Dialect/XeGPU/gather_scatter_global/load_global_chunk_4_f32.mlir
@@ -23,13 +23,11 @@ module @gemm attributes {gpu.container_module} {
 
   gpu.module @test_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
     gpu.func @test_copy(%a: memref<16x4xf32>, %b: memref<16x4xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
-
       %mask = arith.constant dense<1> : vector<16xi1>
-      %offsets = arith.constant dense<[0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60]> : vector<16xindex>
 
       // load from a using load_gather
       %a_cast = memref.reinterpret_cast %a to offset: [0], sizes: [64], strides: [1] : memref<16x4xf32> to memref<64xf32>
-      %a_tdesc = xegpu.create_tdesc %a_cast, %offsets : memref<64xf32>, vector<16xindex> -> !xegpu.tensor_desc<16x4xf32, #scatter>
+      %a_tdesc = xegpu.create_tdesc %a_cast[0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60] : memref<64xf32> -> !xegpu.tensor_desc<16x4xf32, #scatter>
       xegpu.prefetch %a_tdesc : !xegpu.tensor_desc<16x4xf32, #scatter>
       %data = xegpu.load %a_tdesc, %mask {transpose} : !xegpu.tensor_desc<16x4xf32, #scatter>, vector<16xi1> -> vector<4x16xf32>
 
@@ -40,7 +38,7 @@ module @gemm attributes {gpu.container_module} {
 
       // store to b using store_scatter
       %b_cast = memref.reinterpret_cast %b to offset: [0], sizes: [64], strides: [1] : memref<16x4xf32> to memref<64xf32>
-      %b_tdesc = xegpu.create_tdesc %b_cast, %offsets : memref<64xf32>, vector<16xindex> -> !xegpu.tensor_desc<16x4xf32, #scatter>
+      %b_tdesc = xegpu.create_tdesc %b_cast[0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60] : memref<64xf32> -> !xegpu.tensor_desc<16x4xf32, #scatter>
       xegpu.store %data, %b_tdesc, %mask {transpose} : vector<4x16xf32>, !xegpu.tensor_desc<16x4xf32, #scatter>, vector<16xi1>
       gpu.return
     }

--- a/test/Integration/Dialect/XeGPU/gather_scatter_global/load_global_chunk_8_f32.mlir
+++ b/test/Integration/Dialect/XeGPU/gather_scatter_global/load_global_chunk_8_f32.mlir
@@ -23,13 +23,11 @@ module @gemm attributes {gpu.container_module} {
 
   gpu.module @test_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
     gpu.func @test_copy(%a: memref<16x8xf32>, %b: memref<16x8xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
-
       %mask = arith.constant dense<[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]> : vector<16xi1>
-      %offsets = arith.constant dense<[0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120]> : vector<16xindex>
 
       // load from a using load_gather
       %a_cast = memref.reinterpret_cast %a to offset: [0], sizes: [128], strides: [1] : memref<16x8xf32> to memref<128xf32>
-      %a_tdesc = xegpu.create_tdesc %a_cast, %offsets : memref<128xf32>, vector<16xindex> -> !xegpu.tensor_desc<16x8xf32, #scatter>
+      %a_tdesc = xegpu.create_tdesc %a_cast[0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120] : memref<128xf32> -> !xegpu.tensor_desc<16x8xf32, #scatter>
       xegpu.prefetch %a_tdesc : !xegpu.tensor_desc<16x8xf32, #scatter>
       %data = xegpu.load %a_tdesc, %mask {transpose} : !xegpu.tensor_desc<16x8xf32, #scatter>, vector<16xi1> -> vector<8x16xf32>
 
@@ -40,7 +38,7 @@ module @gemm attributes {gpu.container_module} {
 
       // store to b using store_scatter
       %b_cast = memref.reinterpret_cast %b to offset: [0], sizes: [128], strides: [1] : memref<16x8xf32> to memref<128xf32>
-      %b_tdesc = xegpu.create_tdesc %b_cast, %offsets : memref<128xf32>, vector<16xindex> -> !xegpu.tensor_desc<16x8xf32, #scatter>
+      %b_tdesc = xegpu.create_tdesc %b_cast[0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120] : memref<128xf32> -> !xegpu.tensor_desc<16x8xf32, #scatter>
       xegpu.store %data, %b_tdesc, %mask {transpose} : vector<8x16xf32>, !xegpu.tensor_desc<16x8xf32, #scatter>, vector<16xi1>
       gpu.return
     }

--- a/test/Integration/Dialect/XeGPU/gather_scatter_global/load_global_no_chunk_f16.mlir
+++ b/test/Integration/Dialect/XeGPU/gather_scatter_global/load_global_no_chunk_f16.mlir
@@ -25,17 +25,16 @@ module @gemm attributes {gpu.container_module} {
     gpu.func @test_copy(%a: memref<16xf16>, %b: memref<16xf16>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
 
       %mask = arith.constant dense<1> : vector<16xi1>
-      %offsets = arith.constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]> : vector<16xindex>
 
       // load from a using load_gather
-      %a_tdesc = xegpu.create_tdesc %a, %offsets : memref<16xf16>, vector<16xindex> -> !xegpu.tensor_desc<16xf16, #scatter>
+      %a_tdesc = xegpu.create_tdesc %a[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : memref<16xf16> -> !xegpu.tensor_desc<16xf16, #scatter>
       %data = xegpu.load %a_tdesc, %mask : !xegpu.tensor_desc<16xf16, #scatter>, vector<16xi1> -> vector<16xf16>
 
       // %v1 = vector.extract %data[4]: f16 from vector<16xf16>
       // gpu.printf "\ndata[4] : %f.\n" %v1: f16
 
       // store to b using store_scatter
-      %b_tdesc = xegpu.create_tdesc %b, %offsets : memref<16xf16>, vector<16xindex> -> !xegpu.tensor_desc<16xf16, #scatter>
+      %b_tdesc = xegpu.create_tdesc %b[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : memref<16xf16> -> !xegpu.tensor_desc<16xf16, #scatter>
       xegpu.store %data, %b_tdesc, %mask : vector<16xf16>, !xegpu.tensor_desc<16xf16, #scatter>, vector<16xi1>
       gpu.return
     }

--- a/test/Integration/Dialect/XeGPU/gather_scatter_global/load_global_no_chunk_f32.mlir
+++ b/test/Integration/Dialect/XeGPU/gather_scatter_global/load_global_no_chunk_f32.mlir
@@ -28,12 +28,12 @@ module @gemm attributes {gpu.container_module} {
       %offsets = arith.constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]> : vector<16xindex>
 
       // load from a using load_gather
-      %a_tdesc = xegpu.create_tdesc %a, %offsets : memref<16xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #scatter>
+      %a_tdesc = xegpu.create_tdesc %a[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : memref<16xf32> -> !xegpu.tensor_desc<16xf32, #scatter>
       xegpu.prefetch %a_tdesc : !xegpu.tensor_desc<16xf32, #scatter>
       %data = xegpu.load %a_tdesc, %mask : !xegpu.tensor_desc<16xf32, #scatter>, vector<16xi1> -> vector<16xf32>
 
       // store to b using store_scatter
-      %b_tdesc = xegpu.create_tdesc %b, %offsets : memref<16xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #scatter>
+      %b_tdesc = xegpu.create_tdesc %b[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : memref<16xf32> -> !xegpu.tensor_desc<16xf32, #scatter>
       xegpu.store %data, %b_tdesc, %mask : vector<16xf32>, !xegpu.tensor_desc<16xf32, #scatter>, vector<16xi1>
       gpu.return
     }

--- a/test/Integration/Dialect/XeGPU/gather_scatter_global/store_global_chunk_4_f32.mlir
+++ b/test/Integration/Dialect/XeGPU/gather_scatter_global/store_global_chunk_4_f32.mlir
@@ -23,9 +23,8 @@ module @gemm attributes {gpu.container_module} {
                                    [48., 49., 50., 51., 52., 53., 54., 55., 56., 57., 58., 59., 60., 61., 62., 63.]]> : vector<4x16xf32>
 
       %mask = arith.constant dense<1> : vector<16xi1>
-      %offsets = arith.constant dense<[0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60]> : vector<16xindex>
       %cast = memref.reinterpret_cast %mem to offset: [0], sizes: [64], strides: [1] : memref<16x4xf32> to memref<64xf32>
-      %5 = xegpu.create_tdesc %cast, %offsets : memref<64xf32>, vector<16xindex> -> !xegpu.tensor_desc<16x4xf32, #scatter>
+      %5 = xegpu.create_tdesc %cast[0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60] : memref<64xf32> -> !xegpu.tensor_desc<16x4xf32, #scatter>
       xegpu.store %cst, %5, %mask {transpose} : vector<4x16xf32>, !xegpu.tensor_desc<16x4xf32, #scatter>, vector<16xi1>
       gpu.return
     }

--- a/test/Integration/Dialect/XeGPU/gather_scatter_global/store_global_chunk_8_f32.mlir
+++ b/test/Integration/Dialect/XeGPU/gather_scatter_global/store_global_chunk_8_f32.mlir
@@ -28,10 +28,9 @@ module @gemm attributes {gpu.container_module} {
                                    [112., 113., 114., 115., 116., 117., 118., 119., 120., 121., 122., 123., 124., 125., 126., 127.]]> : vector<8x16xf32>
 
       %mask = arith.constant dense<1> : vector<16xi1>
-      %offsets = arith.constant dense<[0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120]> : vector<16xindex>
 
       %cast = memref.reinterpret_cast %mem to offset: [0], sizes: [128], strides: [1] : memref<16x8xf32> to memref<128xf32>
-      %5 = xegpu.create_tdesc %cast, %offsets : memref<128xf32>, vector<16xindex> -> !xegpu.tensor_desc<16x8xf32, #scatter>
+      %5 = xegpu.create_tdesc %cast[0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120] : memref<128xf32> -> !xegpu.tensor_desc<16x8xf32, #scatter>
       xegpu.store %cst, %5, %mask {transpose} : vector<8x16xf32>, !xegpu.tensor_desc<16x8xf32, #scatter>, vector<16xi1>
 
       gpu.return

--- a/test/Integration/Dialect/XeGPU/gather_scatter_global/store_global_no_chunk_f16.mlir
+++ b/test/Integration/Dialect/XeGPU/gather_scatter_global/store_global_no_chunk_f16.mlir
@@ -20,8 +20,7 @@ module @gemm attributes {gpu.container_module} {
       %cst = arith.constant dense<[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0]> : vector<16xf16>
 
       %mask = arith.constant dense<1> : vector<16xi1>
-      %offsets = arith.constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]> : vector<16xindex>
-      %tdesc = xegpu.create_tdesc %mem, %offsets : memref<16xf16>, vector<16xindex> -> !xegpu.tensor_desc<16xf16, #scatter>
+      %tdesc = xegpu.create_tdesc %mem[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : memref<16xf16> -> !xegpu.tensor_desc<16xf16, #scatter>
       xegpu.store %cst, %tdesc, %mask : vector<16xf16>, !xegpu.tensor_desc<16xf16, #scatter>, vector<16xi1>
 
       gpu.return

--- a/test/Integration/Dialect/XeGPU/gather_scatter_global/store_global_no_chunk_f32.mlir
+++ b/test/Integration/Dialect/XeGPU/gather_scatter_global/store_global_no_chunk_f32.mlir
@@ -20,8 +20,7 @@ module @gemm attributes {gpu.container_module} {
       %cst = arith.constant dense<[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0]> : vector<16xf32>
 
       %mask = arith.constant dense<1> : vector<16xi1>
-      %offsets = arith.constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]> : vector<16xindex>
-      %tdesc = xegpu.create_tdesc %mem, %offsets : memref<16xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #scatter>
+      %tdesc = xegpu.create_tdesc %mem[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : memref<16xf32> -> !xegpu.tensor_desc<16xf32, #scatter>
       xegpu.store %cst, %tdesc, %mask : vector<16xf32>, !xegpu.tensor_desc<16xf32, #scatter>, vector<16xi1>
 
       gpu.return

--- a/test/Integration/Dialect/XeGPU/gather_scatter_slm/store_load_slm_chunk_4_f32.mlir
+++ b/test/Integration/Dialect/XeGPU/gather_scatter_slm/store_load_slm_chunk_4_f32.mlir
@@ -24,18 +24,17 @@ module @gemm attributes {gpu.container_module} {
                                    [48., 49., 50., 51., 52., 53., 54., 55., 56., 57., 58., 59., 60., 61., 62., 63.]]> : vector<4x16xf32>
 
       %mask = arith.constant dense<1> : vector<16xi1>
-      %offsets = arith.constant dense<[0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60]> : vector<16xindex>
 
       // store the cst into slm and load it back;
       %slm = memref.alloc() : memref<64xf32, 3>
-      %slm_tdesc = xegpu.create_tdesc %slm, %offsets : memref<64xf32, 3>, vector<16xindex> -> !xegpu.tensor_desc<16x4xf32, #slm>
+      %slm_tdesc = xegpu.create_tdesc %slm[0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60] : memref<64xf32, 3> -> !xegpu.tensor_desc<16x4xf32, #slm>
       xegpu.store %cst, %slm_tdesc, %mask {transpose} : vector<4x16xf32>, !xegpu.tensor_desc<16x4xf32, #slm>, vector<16xi1>
       // load from slm
       %data = xegpu.load %slm_tdesc, %mask {transpose} : !xegpu.tensor_desc<16x4xf32, #slm>, vector<16xi1> -> vector<4x16xf32>
 
       // store data to global memory
       %cast = memref.reinterpret_cast %mem to offset: [0], sizes: [64], strides: [1] : memref<16x4xf32> to memref<64xf32>
-      %5 = xegpu.create_tdesc %cast, %offsets : memref<64xf32>, vector<16xindex> -> !xegpu.tensor_desc<16x4xf32, #global>
+      %5 = xegpu.create_tdesc %cast[0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60] : memref<64xf32> -> !xegpu.tensor_desc<16x4xf32, #global>
       xegpu.store %data, %5, %mask {transpose} : vector<4x16xf32>, !xegpu.tensor_desc<16x4xf32, #global>, vector<16xi1>
       gpu.return
     }

--- a/test/Integration/Dialect/XeGPU/gather_scatter_slm/store_load_slm_chunk_8_f32.mlir
+++ b/test/Integration/Dialect/XeGPU/gather_scatter_slm/store_load_slm_chunk_8_f32.mlir
@@ -30,10 +30,9 @@ module @gemm attributes {gpu.container_module} {
                                    [112., 113., 114., 115., 116., 117., 118., 119., 120., 121., 122., 123., 124., 125., 126., 127.]]> : vector<8x16xf32>
 
       %mask = arith.constant dense<1> : vector<16xi1>
-      %offsets = arith.constant dense<[0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120]> : vector<16xindex>
 
       // store the cst into slm
-      %slm_tdesc = xegpu.create_tdesc %slm, %offsets : memref<128xf32, 3>, vector<16xindex> -> !xegpu.tensor_desc<16x8xf32, #slm>
+      %slm_tdesc = xegpu.create_tdesc %slm[0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120] : memref<128xf32, 3> -> !xegpu.tensor_desc<16x8xf32, #slm>
       xegpu.store %cst, %slm_tdesc, %mask {transpose} : vector<8x16xf32>, !xegpu.tensor_desc<16x8xf32, #slm>, vector<16xi1>
 
       // load from slm
@@ -41,7 +40,7 @@ module @gemm attributes {gpu.container_module} {
 
       // store data to global memory
       %cast = memref.reinterpret_cast %mem to offset: [0], sizes: [128], strides: [1] : memref<16x8xf32> to memref<128xf32>
-      %5 = xegpu.create_tdesc %cast, %offsets : memref<128xf32>, vector<16xindex> -> !xegpu.tensor_desc<16x8xf32, #global>
+      %5 = xegpu.create_tdesc %cast[0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120] : memref<128xf32> -> !xegpu.tensor_desc<16x8xf32, #global>
       xegpu.store %data, %5, %mask {transpose} : vector<8x16xf32>, !xegpu.tensor_desc<16x8xf32, #global>, vector<16xi1>
       gpu.return
     }

--- a/test/Integration/Dialect/XeGPU/gather_scatter_slm/store_load_slm_chunk_8_f32_mask.mlir
+++ b/test/Integration/Dialect/XeGPU/gather_scatter_slm/store_load_slm_chunk_8_f32_mask.mlir
@@ -33,7 +33,7 @@ module @gemm attributes {gpu.container_module} {
       %offsets = arith.constant dense<[0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120]> : vector<16xindex>
 
       // store the cst into slm
-      %slm_tdesc = xegpu.create_tdesc %slm, %offsets : memref<128xf32, 3>, vector<16xindex> -> !xegpu.tensor_desc<16x8xf32, #slm>
+      %slm_tdesc = xegpu.create_tdesc %slm[0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120] : memref<128xf32, 3> -> !xegpu.tensor_desc<16x8xf32, #slm>
       xegpu.store %cst, %slm_tdesc, %mask {transpose} : vector<8x16xf32>, !xegpu.tensor_desc<16x8xf32, #slm>, vector<16xi1>
 
       // load from slm
@@ -41,7 +41,7 @@ module @gemm attributes {gpu.container_module} {
 
       // store data to global memory
       %cast = memref.reinterpret_cast %mem to offset: [0], sizes: [128], strides: [1] : memref<16x8xf32> to memref<128xf32>
-      %5 = xegpu.create_tdesc %cast, %offsets : memref<128xf32>, vector<16xindex> -> !xegpu.tensor_desc<16x8xf32, #global>
+      %5 = xegpu.create_tdesc %cast[0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120] : memref<128xf32> -> !xegpu.tensor_desc<16x8xf32, #global>
       xegpu.store %data, %5, %mask {transpose} : vector<8x16xf32>, !xegpu.tensor_desc<16x8xf32, #global>, vector<16xi1>
       gpu.return
     }

--- a/test/Integration/Dialect/XeGPU/gather_scatter_slm/store_load_slm_no_chunk_f16.mlir
+++ b/test/Integration/Dialect/XeGPU/gather_scatter_slm/store_load_slm_no_chunk_f16.mlir
@@ -20,16 +20,15 @@ module @gemm attributes {gpu.container_module} {
     gpu.func @test_store_scatter(%mem: memref<16xf16>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
       %cst = arith.constant dense<[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0]> : vector<16xf16>
       %mask = arith.constant dense<1> : vector<16xi1>
-      %offsets = arith.constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]> : vector<16xindex>
 
       // store the cst into slm and load it back;
       %slm = memref.alloc() : memref<16xf16, 3>
-      %slm_tdesc = xegpu.create_tdesc %slm, %offsets : memref<16xf16, 3>, vector<16xindex> -> !xegpu.tensor_desc<16xf16, #slm>
+      %slm_tdesc = xegpu.create_tdesc %slm[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : memref<16xf16, 3> -> !xegpu.tensor_desc<16xf16, #slm>
       xegpu.store %cst, %slm_tdesc, %mask : vector<16xf16>, !xegpu.tensor_desc<16xf16, #slm>, vector<16xi1>
       %data = xegpu.load %slm_tdesc, %mask : !xegpu.tensor_desc<16xf16, #slm>, vector<16xi1> -> vector<16xf16>
 
       // store data to global memory
-      %tdesc = xegpu.create_tdesc %mem, %offsets : memref<16xf16>, vector<16xindex> -> !xegpu.tensor_desc<16xf16, #global>
+      %tdesc = xegpu.create_tdesc %mem[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : memref<16xf16> -> !xegpu.tensor_desc<16xf16, #global>
       xegpu.store %data, %tdesc, %mask : vector<16xf16>, !xegpu.tensor_desc<16xf16, #global>, vector<16xi1>
 
       gpu.return

--- a/test/Integration/Dialect/XeGPU/gather_scatter_slm/store_load_slm_no_chunk_f32.mlir
+++ b/test/Integration/Dialect/XeGPU/gather_scatter_slm/store_load_slm_no_chunk_f32.mlir
@@ -21,15 +21,14 @@ module @gemm attributes {gpu.container_module} {
       %cst = arith.constant dense<[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0]> : vector<16xf32>
 
       %mask = arith.constant dense<1> : vector<16xi1>
-      %offsets = arith.constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]> : vector<16xindex>
 
       // store the cst into slm and load it back;
       %slm = memref.alloc() : memref<16xf32, 3>
-      %slm_tdesc = xegpu.create_tdesc %slm, %offsets : memref<16xf32, 3>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #slm>
+      %slm_tdesc = xegpu.create_tdesc %slm[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : memref<16xf32, 3> -> !xegpu.tensor_desc<16xf32, #slm>
       xegpu.store %cst, %slm_tdesc, %mask : vector<16xf32>, !xegpu.tensor_desc<16xf32, #slm>, vector<16xi1>
       %data = xegpu.load %slm_tdesc, %mask : !xegpu.tensor_desc<16xf32, #slm>, vector<16xi1> -> vector<16xf32>
 
-      %tdesc = xegpu.create_tdesc %mem, %offsets : memref<16xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #global>
+      %tdesc = xegpu.create_tdesc %mem[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : memref<16xf32> -> !xegpu.tensor_desc<16xf32, #global>
       xegpu.store %cst, %tdesc, %mask : vector<16xf32>, !xegpu.tensor_desc<16xf32, #global>, vector<16xi1>
 
       gpu.return

--- a/test/Integration/Dialect/XeGPU/gemm_256x256x256_bf16_bf16_f32.mlir
+++ b/test/Integration/Dialect/XeGPU/gemm_256x256x256_bf16_bf16_f32.mlir
@@ -351,79 +351,79 @@ module @gemm attributes {gpu.container_module} {
 
         %a_val_0_0_flat = vector.extract_strided_slice %a_val_0_flat { offsets = [0], sizes = [128], strides = [1]} :
           vector<512xbf16> to vector<128xbf16>
-        %a_val_0_0 = vector.shape_cast %a_val_0_0_flat : vector<128xbf16> to vector<8x8x2xbf16>
+        %a_val_0_0 = vector.shape_cast %a_val_0_0_flat : vector<128xbf16> to vector<8x16xbf16>
 
         %a_val_1_0_flat = vector.extract_strided_slice %a_val_0_flat { offsets = [128], sizes = [128], strides = [1]} :
           vector<512xbf16> to vector<128xbf16>
-        %a_val_1_0 = vector.shape_cast %a_val_1_0_flat : vector<128xbf16> to vector<8x8x2xbf16>
+        %a_val_1_0 = vector.shape_cast %a_val_1_0_flat : vector<128xbf16> to vector<8x16xbf16>
 
         %a_val_0_1_flat = vector.extract_strided_slice %a_val_0_flat { offsets = [256], sizes = [128], strides = [1]} :
           vector<512xbf16> to vector<128xbf16>
-        %a_val_0_1 = vector.shape_cast %a_val_0_1_flat : vector<128xbf16> to vector<8x8x2xbf16>
+        %a_val_0_1 = vector.shape_cast %a_val_0_1_flat : vector<128xbf16> to vector<8x16xbf16>
         %a_val_1_1_flat = vector.extract_strided_slice %a_val_0_flat {offsets = [384], sizes = [128], strides = [1]} :
           vector<512xbf16> to vector<128xbf16>
-        %a_val_1_1 = vector.shape_cast %a_val_1_1_flat : vector<128xbf16> to vector<8x8x2xbf16>
+        %a_val_1_1 = vector.shape_cast %a_val_1_1_flat : vector<128xbf16> to vector<8x16xbf16>
 
         %a_val_2_0_flat = vector.extract_strided_slice %a_val_1_flat { offsets = [0], sizes = [128], strides = [1]} :
           vector<512xbf16> to vector<128xbf16>
-        %a_val_2_0 = vector.shape_cast %a_val_2_0_flat : vector<128xbf16> to vector<8x8x2xbf16>
+        %a_val_2_0 = vector.shape_cast %a_val_2_0_flat : vector<128xbf16> to vector<8x16xbf16>
 
         %a_val_3_0_flat = vector.extract_strided_slice %a_val_1_flat { offsets = [128], sizes = [128], strides = [1]} :
           vector<512xbf16> to vector<128xbf16>
-        %a_val_3_0 = vector.shape_cast %a_val_3_0_flat : vector<128xbf16> to vector<8x8x2xbf16>
+        %a_val_3_0 = vector.shape_cast %a_val_3_0_flat : vector<128xbf16> to vector<8x16xbf16>
 
         %a_val_2_1_flat = vector.extract_strided_slice %a_val_1_flat { offsets = [256], sizes = [128], strides = [1]} :
           vector<512xbf16> to vector<128xbf16>
-        %a_val_2_1 = vector.shape_cast %a_val_2_1_flat : vector<128xbf16> to vector<8x8x2xbf16>
+        %a_val_2_1 = vector.shape_cast %a_val_2_1_flat : vector<128xbf16> to vector<8x16xbf16>
         %a_val_3_1_flat = vector.extract_strided_slice %a_val_1_flat {offsets = [384], sizes = [128], strides = [1]} :
           vector<512xbf16> to vector<128xbf16>
-        %a_val_3_1 = vector.shape_cast %a_val_3_1_flat : vector<128xbf16> to vector<8x8x2xbf16>
+        %a_val_3_1 = vector.shape_cast %a_val_3_1_flat : vector<128xbf16> to vector<8x16xbf16>
 
 
         // do DPAS
         xegpu.compile_hint
 
-        %new_c_val_0_0_temp = xegpu.dpas %a_val_0_0, %b_val_0_0, %c_val_0_0 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_1_0_temp = xegpu.dpas %a_val_1_0, %b_val_0_0, %c_val_1_0 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_2_0_temp = xegpu.dpas %a_val_2_0, %b_val_0_0, %c_val_2_0 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_3_0_temp = xegpu.dpas %a_val_3_0, %b_val_0_0, %c_val_3_0 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_0_0_temp = xegpu.dpas %a_val_0_0, %b_val_0_0, %c_val_0_0 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_1_0_temp = xegpu.dpas %a_val_1_0, %b_val_0_0, %c_val_1_0 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_2_0_temp = xegpu.dpas %a_val_2_0, %b_val_0_0, %c_val_2_0 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_3_0_temp = xegpu.dpas %a_val_3_0, %b_val_0_0, %c_val_3_0 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
 
-        %new_c_val_0_1_temp = xegpu.dpas %a_val_0_0, %b_val_0_1, %c_val_0_1 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_1_1_temp = xegpu.dpas %a_val_1_0, %b_val_0_1, %c_val_1_1 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_2_1_temp = xegpu.dpas %a_val_2_0, %b_val_0_1, %c_val_2_1 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_3_1_temp = xegpu.dpas %a_val_3_0, %b_val_0_1, %c_val_3_1 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_0_1_temp = xegpu.dpas %a_val_0_0, %b_val_0_1, %c_val_0_1 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_1_1_temp = xegpu.dpas %a_val_1_0, %b_val_0_1, %c_val_1_1 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_2_1_temp = xegpu.dpas %a_val_2_0, %b_val_0_1, %c_val_2_1 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_3_1_temp = xegpu.dpas %a_val_3_0, %b_val_0_1, %c_val_3_1 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
 
-        %new_c_val_0_2_temp = xegpu.dpas %a_val_0_0, %b_val_0_2, %c_val_0_2 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_1_2_temp = xegpu.dpas %a_val_1_0, %b_val_0_2, %c_val_1_2 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_2_2_temp = xegpu.dpas %a_val_2_0, %b_val_0_2, %c_val_2_2 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_3_2_temp = xegpu.dpas %a_val_3_0, %b_val_0_2, %c_val_3_2 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_0_2_temp = xegpu.dpas %a_val_0_0, %b_val_0_2, %c_val_0_2 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_1_2_temp = xegpu.dpas %a_val_1_0, %b_val_0_2, %c_val_1_2 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_2_2_temp = xegpu.dpas %a_val_2_0, %b_val_0_2, %c_val_2_2 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_3_2_temp = xegpu.dpas %a_val_3_0, %b_val_0_2, %c_val_3_2 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
 
-        %new_c_val_0_3_temp = xegpu.dpas %a_val_0_0, %b_val_0_3, %c_val_0_3 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_1_3_temp = xegpu.dpas %a_val_1_0, %b_val_0_3, %c_val_1_3 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_2_3_temp = xegpu.dpas %a_val_2_0, %b_val_0_3, %c_val_2_3 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_3_3_temp = xegpu.dpas %a_val_3_0, %b_val_0_3, %c_val_3_3 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_0_3_temp = xegpu.dpas %a_val_0_0, %b_val_0_3, %c_val_0_3 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_1_3_temp = xegpu.dpas %a_val_1_0, %b_val_0_3, %c_val_1_3 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_2_3_temp = xegpu.dpas %a_val_2_0, %b_val_0_3, %c_val_2_3 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_3_3_temp = xegpu.dpas %a_val_3_0, %b_val_0_3, %c_val_3_3 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
 
         xegpu.compile_hint
 
-        %new_c_val_0_0 = xegpu.dpas %a_val_0_1, %b_val_1_0, %new_c_val_0_0_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_1_0 = xegpu.dpas %a_val_1_1, %b_val_1_0, %new_c_val_1_0_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_2_0 = xegpu.dpas %a_val_2_1, %b_val_1_0, %new_c_val_2_0_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_3_0 = xegpu.dpas %a_val_3_1, %b_val_1_0, %new_c_val_3_0_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_0_0 = xegpu.dpas %a_val_0_1, %b_val_1_0, %new_c_val_0_0_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_1_0 = xegpu.dpas %a_val_1_1, %b_val_1_0, %new_c_val_1_0_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_2_0 = xegpu.dpas %a_val_2_1, %b_val_1_0, %new_c_val_2_0_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_3_0 = xegpu.dpas %a_val_3_1, %b_val_1_0, %new_c_val_3_0_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
 
-        %new_c_val_0_1 = xegpu.dpas %a_val_0_1, %b_val_1_1, %new_c_val_0_1_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_1_1 = xegpu.dpas %a_val_1_1, %b_val_1_1, %new_c_val_1_1_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_2_1 = xegpu.dpas %a_val_2_1, %b_val_1_1, %new_c_val_2_1_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_3_1 = xegpu.dpas %a_val_3_1, %b_val_1_1, %new_c_val_3_1_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_0_1 = xegpu.dpas %a_val_0_1, %b_val_1_1, %new_c_val_0_1_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_1_1 = xegpu.dpas %a_val_1_1, %b_val_1_1, %new_c_val_1_1_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_2_1 = xegpu.dpas %a_val_2_1, %b_val_1_1, %new_c_val_2_1_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_3_1 = xegpu.dpas %a_val_3_1, %b_val_1_1, %new_c_val_3_1_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
 
-        %new_c_val_0_2 = xegpu.dpas %a_val_0_1, %b_val_1_2, %new_c_val_0_2_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_1_2 = xegpu.dpas %a_val_1_1, %b_val_1_2, %new_c_val_1_2_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_2_2 = xegpu.dpas %a_val_2_1, %b_val_1_2, %new_c_val_2_2_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_3_2 = xegpu.dpas %a_val_3_1, %b_val_1_2, %new_c_val_3_2_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_0_2 = xegpu.dpas %a_val_0_1, %b_val_1_2, %new_c_val_0_2_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_1_2 = xegpu.dpas %a_val_1_1, %b_val_1_2, %new_c_val_1_2_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_2_2 = xegpu.dpas %a_val_2_1, %b_val_1_2, %new_c_val_2_2_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_3_2 = xegpu.dpas %a_val_3_1, %b_val_1_2, %new_c_val_3_2_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
 
-        %new_c_val_0_3 = xegpu.dpas %a_val_0_1, %b_val_1_3, %new_c_val_0_3_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_1_3 = xegpu.dpas %a_val_1_1, %b_val_1_3, %new_c_val_1_3_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_2_3 = xegpu.dpas %a_val_2_1, %b_val_1_3, %new_c_val_2_3_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_3_3 = xegpu.dpas %a_val_3_1, %b_val_1_3, %new_c_val_3_3_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_0_3 = xegpu.dpas %a_val_0_1, %b_val_1_3, %new_c_val_0_3_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_1_3 = xegpu.dpas %a_val_1_1, %b_val_1_3, %new_c_val_1_3_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_2_3 = xegpu.dpas %a_val_2_1, %b_val_1_3, %new_c_val_2_3_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_3_3 = xegpu.dpas %a_val_3_1, %b_val_1_3, %new_c_val_3_3_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
 
         //  barrier wait
         scf.if %every_8th_iter_cond {

--- a/test/Integration/Dialect/XeGPU/gemm_4kx4kx4k_bf16_bf16_f32_xetla_like_load_store_prefetch.mlir
+++ b/test/Integration/Dialect/XeGPU/gemm_4kx4kx4k_bf16_bf16_f32_xetla_like_load_store_prefetch.mlir
@@ -358,79 +358,79 @@ module @gemm attributes {gpu.container_module} {
 
         %a_val_0_0_flat = vector.extract_strided_slice %a_val_0_flat { offsets = [0], sizes = [128], strides = [1]} :
           vector<512xbf16> to vector<128xbf16>
-        %a_val_0_0 = vector.shape_cast %a_val_0_0_flat : vector<128xbf16> to vector<8x8x2xbf16>
+        %a_val_0_0 = vector.shape_cast %a_val_0_0_flat : vector<128xbf16> to vector<8x16xbf16>
 
         %a_val_1_0_flat = vector.extract_strided_slice %a_val_0_flat { offsets = [128], sizes = [128], strides = [1]} :
           vector<512xbf16> to vector<128xbf16>
-        %a_val_1_0 = vector.shape_cast %a_val_1_0_flat : vector<128xbf16> to vector<8x8x2xbf16>
+        %a_val_1_0 = vector.shape_cast %a_val_1_0_flat : vector<128xbf16> to vector<8x16xbf16>
 
         %a_val_0_1_flat = vector.extract_strided_slice %a_val_0_flat { offsets = [256], sizes = [128], strides = [1]} :
           vector<512xbf16> to vector<128xbf16>
-        %a_val_0_1 = vector.shape_cast %a_val_0_1_flat : vector<128xbf16> to vector<8x8x2xbf16>
+        %a_val_0_1 = vector.shape_cast %a_val_0_1_flat : vector<128xbf16> to vector<8x16xbf16>
         %a_val_1_1_flat = vector.extract_strided_slice %a_val_0_flat {offsets = [384], sizes = [128], strides = [1]} :
           vector<512xbf16> to vector<128xbf16>
-        %a_val_1_1 = vector.shape_cast %a_val_1_1_flat : vector<128xbf16> to vector<8x8x2xbf16>
+        %a_val_1_1 = vector.shape_cast %a_val_1_1_flat : vector<128xbf16> to vector<8x16xbf16>
 
         %a_val_2_0_flat = vector.extract_strided_slice %a_val_1_flat { offsets = [0], sizes = [128], strides = [1]} :
           vector<512xbf16> to vector<128xbf16>
-        %a_val_2_0 = vector.shape_cast %a_val_2_0_flat : vector<128xbf16> to vector<8x8x2xbf16>
+        %a_val_2_0 = vector.shape_cast %a_val_2_0_flat : vector<128xbf16> to vector<8x16xbf16>
 
         %a_val_3_0_flat = vector.extract_strided_slice %a_val_1_flat { offsets = [128], sizes = [128], strides = [1]} :
           vector<512xbf16> to vector<128xbf16>
-        %a_val_3_0 = vector.shape_cast %a_val_3_0_flat : vector<128xbf16> to vector<8x8x2xbf16>
+        %a_val_3_0 = vector.shape_cast %a_val_3_0_flat : vector<128xbf16> to vector<8x16xbf16>
 
         %a_val_2_1_flat = vector.extract_strided_slice %a_val_1_flat { offsets = [256], sizes = [128], strides = [1]} :
           vector<512xbf16> to vector<128xbf16>
-        %a_val_2_1 = vector.shape_cast %a_val_2_1_flat : vector<128xbf16> to vector<8x8x2xbf16>
+        %a_val_2_1 = vector.shape_cast %a_val_2_1_flat : vector<128xbf16> to vector<8x16xbf16>
         %a_val_3_1_flat = vector.extract_strided_slice %a_val_1_flat {offsets = [384], sizes = [128], strides = [1]} :
           vector<512xbf16> to vector<128xbf16>
-        %a_val_3_1 = vector.shape_cast %a_val_3_1_flat : vector<128xbf16> to vector<8x8x2xbf16>
+        %a_val_3_1 = vector.shape_cast %a_val_3_1_flat : vector<128xbf16> to vector<8x16xbf16>
 
 
         // do DPAS
         xegpu.compile_hint
 
-        %new_c_val_0_0_temp = xegpu.dpas %a_val_0_0, %b_val_0_0, %c_val_0_0 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_1_0_temp = xegpu.dpas %a_val_1_0, %b_val_0_0, %c_val_1_0 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_2_0_temp = xegpu.dpas %a_val_2_0, %b_val_0_0, %c_val_2_0 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_3_0_temp = xegpu.dpas %a_val_3_0, %b_val_0_0, %c_val_3_0 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_0_0_temp = xegpu.dpas %a_val_0_0, %b_val_0_0, %c_val_0_0 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_1_0_temp = xegpu.dpas %a_val_1_0, %b_val_0_0, %c_val_1_0 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_2_0_temp = xegpu.dpas %a_val_2_0, %b_val_0_0, %c_val_2_0 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_3_0_temp = xegpu.dpas %a_val_3_0, %b_val_0_0, %c_val_3_0 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
 
-        %new_c_val_0_1_temp = xegpu.dpas %a_val_0_0, %b_val_0_1, %c_val_0_1 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_1_1_temp = xegpu.dpas %a_val_1_0, %b_val_0_1, %c_val_1_1 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_2_1_temp = xegpu.dpas %a_val_2_0, %b_val_0_1, %c_val_2_1 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_3_1_temp = xegpu.dpas %a_val_3_0, %b_val_0_1, %c_val_3_1 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_0_1_temp = xegpu.dpas %a_val_0_0, %b_val_0_1, %c_val_0_1 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_1_1_temp = xegpu.dpas %a_val_1_0, %b_val_0_1, %c_val_1_1 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_2_1_temp = xegpu.dpas %a_val_2_0, %b_val_0_1, %c_val_2_1 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_3_1_temp = xegpu.dpas %a_val_3_0, %b_val_0_1, %c_val_3_1 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
 
-        %new_c_val_0_2_temp = xegpu.dpas %a_val_0_0, %b_val_0_2, %c_val_0_2 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_1_2_temp = xegpu.dpas %a_val_1_0, %b_val_0_2, %c_val_1_2 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_2_2_temp = xegpu.dpas %a_val_2_0, %b_val_0_2, %c_val_2_2 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_3_2_temp = xegpu.dpas %a_val_3_0, %b_val_0_2, %c_val_3_2 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_0_2_temp = xegpu.dpas %a_val_0_0, %b_val_0_2, %c_val_0_2 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_1_2_temp = xegpu.dpas %a_val_1_0, %b_val_0_2, %c_val_1_2 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_2_2_temp = xegpu.dpas %a_val_2_0, %b_val_0_2, %c_val_2_2 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_3_2_temp = xegpu.dpas %a_val_3_0, %b_val_0_2, %c_val_3_2 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
 
-        %new_c_val_0_3_temp = xegpu.dpas %a_val_0_0, %b_val_0_3, %c_val_0_3 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_1_3_temp = xegpu.dpas %a_val_1_0, %b_val_0_3, %c_val_1_3 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_2_3_temp = xegpu.dpas %a_val_2_0, %b_val_0_3, %c_val_2_3 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_3_3_temp = xegpu.dpas %a_val_3_0, %b_val_0_3, %c_val_3_3 : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_0_3_temp = xegpu.dpas %a_val_0_0, %b_val_0_3, %c_val_0_3 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_1_3_temp = xegpu.dpas %a_val_1_0, %b_val_0_3, %c_val_1_3 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_2_3_temp = xegpu.dpas %a_val_2_0, %b_val_0_3, %c_val_2_3 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_3_3_temp = xegpu.dpas %a_val_3_0, %b_val_0_3, %c_val_3_3 : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
 
         xegpu.compile_hint
 
-        %new_c_val_0_0 = xegpu.dpas %a_val_0_1, %b_val_1_0, %new_c_val_0_0_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_1_0 = xegpu.dpas %a_val_1_1, %b_val_1_0, %new_c_val_1_0_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_2_0 = xegpu.dpas %a_val_2_1, %b_val_1_0, %new_c_val_2_0_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_3_0 = xegpu.dpas %a_val_3_1, %b_val_1_0, %new_c_val_3_0_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_0_0 = xegpu.dpas %a_val_0_1, %b_val_1_0, %new_c_val_0_0_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_1_0 = xegpu.dpas %a_val_1_1, %b_val_1_0, %new_c_val_1_0_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_2_0 = xegpu.dpas %a_val_2_1, %b_val_1_0, %new_c_val_2_0_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_3_0 = xegpu.dpas %a_val_3_1, %b_val_1_0, %new_c_val_3_0_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
 
-        %new_c_val_0_1 = xegpu.dpas %a_val_0_1, %b_val_1_1, %new_c_val_0_1_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_1_1 = xegpu.dpas %a_val_1_1, %b_val_1_1, %new_c_val_1_1_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_2_1 = xegpu.dpas %a_val_2_1, %b_val_1_1, %new_c_val_2_1_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_3_1 = xegpu.dpas %a_val_3_1, %b_val_1_1, %new_c_val_3_1_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_0_1 = xegpu.dpas %a_val_0_1, %b_val_1_1, %new_c_val_0_1_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_1_1 = xegpu.dpas %a_val_1_1, %b_val_1_1, %new_c_val_1_1_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_2_1 = xegpu.dpas %a_val_2_1, %b_val_1_1, %new_c_val_2_1_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_3_1 = xegpu.dpas %a_val_3_1, %b_val_1_1, %new_c_val_3_1_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
 
-        %new_c_val_0_2 = xegpu.dpas %a_val_0_1, %b_val_1_2, %new_c_val_0_2_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_1_2 = xegpu.dpas %a_val_1_1, %b_val_1_2, %new_c_val_1_2_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_2_2 = xegpu.dpas %a_val_2_1, %b_val_1_2, %new_c_val_2_2_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_3_2 = xegpu.dpas %a_val_3_1, %b_val_1_2, %new_c_val_3_2_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_0_2 = xegpu.dpas %a_val_0_1, %b_val_1_2, %new_c_val_0_2_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_1_2 = xegpu.dpas %a_val_1_1, %b_val_1_2, %new_c_val_1_2_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_2_2 = xegpu.dpas %a_val_2_1, %b_val_1_2, %new_c_val_2_2_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_3_2 = xegpu.dpas %a_val_3_1, %b_val_1_2, %new_c_val_3_2_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
 
-        %new_c_val_0_3 = xegpu.dpas %a_val_0_1, %b_val_1_3, %new_c_val_0_3_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_1_3 = xegpu.dpas %a_val_1_1, %b_val_1_3, %new_c_val_1_3_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_2_3 = xegpu.dpas %a_val_2_1, %b_val_1_3, %new_c_val_2_3_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
-        %new_c_val_3_3 = xegpu.dpas %a_val_3_1, %b_val_1_3, %new_c_val_3_3_temp : vector<8x8x2xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_0_3 = xegpu.dpas %a_val_0_1, %b_val_1_3, %new_c_val_0_3_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_1_3 = xegpu.dpas %a_val_1_1, %b_val_1_3, %new_c_val_1_3_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_2_3 = xegpu.dpas %a_val_2_1, %b_val_1_3, %new_c_val_2_3_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
+        %new_c_val_3_3 = xegpu.dpas %a_val_3_1, %b_val_1_3, %new_c_val_3_3_temp : vector<8x16xbf16>, vector<8x16x2xbf16>, vector<8x16xf32> -> vector<8x16xf32>
 
         //  barrier wait
         scf.if %every_8th_iter_cond {

--- a/test/Integration/Dialect/XeGPU/loadgather2d_masked_f32.mlir
+++ b/test/Integration/Dialect/XeGPU/loadgather2d_masked_f32.mlir
@@ -43,21 +43,20 @@ module @gemm attributes {gpu.container_module} {
 
       // Spirv has no lowering for memref.reinterpret_cast with different sizes (doesn't work: memref<3x16xf32> to memref<16xf32>)
       // Each row has a tdesc with offsets that determine linearized memref's values to be loaded
-      %offsets_row1 = arith.constant dense<[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]> : vector<16xindex>
-      %row_1_in_td = xegpu.create_tdesc %arg0, %offsets_row1 : memref<?xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
-      %row_1_out_td = xegpu.create_tdesc %arg1, %offsets_row1 : memref<?xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
+      %row_1_in_td = xegpu.create_tdesc %arg0[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] : memref<?xf32> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
+      %row_1_out_td = xegpu.create_tdesc %arg1[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] : memref<?xf32> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
       %row_1_loaded = xegpu.load %row_1_in_td, %row_mask : !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>, vector<16xi1> -> vector<16xf32>
       %row_1_store = arith.select %row_mask, %row_1_loaded, %user_val : vector<16xi1>, vector<16xf32>
       xegpu.store %row_1_store, %row_1_out_td, %store_mask : vector<16xf32>, !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>, vector<16xi1>
 
-      %row_2_in_td = xegpu.update_offset %row_1_in_td, %offset_step : !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
-      %row_2_out_td = xegpu.update_offset %row_1_out_td, %offset_step : !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
+      %row_2_in_td = xegpu.update_offset %row_1_in_td, [16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16] : !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
+      %row_2_out_td = xegpu.update_offset %row_1_out_td, [16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16] : !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
       %row_2_loaded = xegpu.load %row_2_in_td, %row_mask : !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>, vector<16xi1> -> vector<16xf32>
       %row_2_store = arith.select %row_mask, %row_2_loaded, %user_val : vector<16xi1>, vector<16xf32>
       xegpu.store %row_2_store, %row_2_out_td, %store_mask : vector<16xf32>, !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>, vector<16xi1>
 
       // The entire row is out of bounds
-      %row_3_out_td = xegpu.update_offset %row_2_out_td, %offset_step : !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
+      %row_3_out_td = xegpu.update_offset %row_2_out_td, [16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16] : !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
       xegpu.store %user_val, %row_3_out_td, %store_mask : vector<16xf32>, !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>, vector<16xi1>
       gpu.return
     }

--- a/test/Integration/Dialect/XeGPU/loadgather_chunk_size_f32.mlir
+++ b/test/Integration/Dialect/XeGPU/loadgather_chunk_size_f32.mlir
@@ -32,10 +32,9 @@ module @gemm attributes {gpu.container_module} {
     gpu.func @test_scattered(%in: memref<?xf32>, %out: memref<?xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
       // We have 16 work items, each accesses 2 elements: {chunk_size = 2}, hence 16x2 tensor.
       // Valid offsets (%offsets for which %mask is 1) should not exceed 16*2=32.
-      %offsets = arith.constant dense<[0,4,8,12,16,20,24,28,32,34,38,42,46,50,54,58]> : vector<16xindex>
       %mask = arith.constant dense<[1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0]> : vector<16xi1>
-      %tdesc_in = xegpu.create_tdesc %in, %offsets : memref<?xf32>, vector<16xindex> -> !xegpu.tensor_desc<16x2xf32, #xegpu.scatter_tdesc_attr<chunk_size = 2>>
-      %tdesc_out = xegpu.create_tdesc %out, %offsets : memref<?xf32>, vector<16xindex> -> !xegpu.tensor_desc<16x2xf32, #xegpu.scatter_tdesc_attr<chunk_size = 2>>
+      %tdesc_in = xegpu.create_tdesc %in[0,4,8,12,16,20,24,28,32,34,38,42,46,50,54,58] : memref<?xf32> -> !xegpu.tensor_desc<16x2xf32, #xegpu.scatter_tdesc_attr<chunk_size = 2>>
+      %tdesc_out = xegpu.create_tdesc %out[0,4,8,12,16,20,24,28,32,34,38,42,46,50,54,58] : memref<?xf32> -> !xegpu.tensor_desc<16x2xf32, #xegpu.scatter_tdesc_attr<chunk_size = 2>>
       %loaded = xegpu.load %tdesc_in, %mask {transpose} : !xegpu.tensor_desc<16x2xf32, #xegpu.scatter_tdesc_attr<chunk_size = 2>>, vector<16xi1> -> vector<2x16xf32>
       xegpu.store %loaded, %tdesc_out, %mask {transpose} : vector<2x16xf32>, !xegpu.tensor_desc<16x2xf32, #xegpu.scatter_tdesc_attr<chunk_size = 2>>, vector<16xi1>
       gpu.return

--- a/test/Integration/Dialect/XeGPU/loadgather_chunk_size_i32.mlir
+++ b/test/Integration/Dialect/XeGPU/loadgather_chunk_size_i32.mlir
@@ -32,10 +32,9 @@ module @gemm attributes {gpu.container_module} {
     gpu.func @test_scattered(%in: memref<?xi32>, %out: memref<?xi32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
       // We have 16 work items, each accesses 2 elements: {chunk_size = 2}, hence 16x2 tensor.
       // Valid offsets (%offsets for which %mask is 1) should not exceed 16*2=32.
-      %offsets = arith.constant dense<[0,4,8,12,16,20,24,28,32,34,38,42,46,50,54,58]> : vector<16xindex>
       %mask = arith.constant dense<[1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0]> : vector<16xi1>
-      %tdesc_in = xegpu.create_tdesc %in, %offsets : memref<?xi32>, vector<16xindex> -> !xegpu.tensor_desc<16x2xi32, #xegpu.scatter_tdesc_attr<chunk_size = 2>>
-      %tdesc_out = xegpu.create_tdesc %out, %offsets : memref<?xi32>, vector<16xindex> -> !xegpu.tensor_desc<16x2xi32, #xegpu.scatter_tdesc_attr<chunk_size = 2>>
+      %tdesc_in = xegpu.create_tdesc %in[0,4,8,12,16,20,24,28,32,34,38,42,46,50,54,58] : memref<?xi32> -> !xegpu.tensor_desc<16x2xi32, #xegpu.scatter_tdesc_attr<chunk_size = 2>>
+      %tdesc_out = xegpu.create_tdesc %out[0,4,8,12,16,20,24,28,32,34,38,42,46,50,54,58] : memref<?xi32> -> !xegpu.tensor_desc<16x2xi32, #xegpu.scatter_tdesc_attr<chunk_size = 2>>
       %loaded = xegpu.load %tdesc_in, %mask {transpose} : !xegpu.tensor_desc<16x2xi32, #xegpu.scatter_tdesc_attr<chunk_size = 2>>, vector<16xi1> -> vector<2x16xi32>
       xegpu.store %loaded, %tdesc_out, %mask {transpose} : vector<2x16xi32>, !xegpu.tensor_desc<16x2xi32, #xegpu.scatter_tdesc_attr<chunk_size = 2>>, vector<16xi1>
       gpu.return

--- a/test/Integration/Dialect/XeGPU/loadgather_f32.mlir
+++ b/test/Integration/Dialect/XeGPU/loadgather_f32.mlir
@@ -24,12 +24,11 @@ module @gemm attributes {gpu.container_module} {
   gpu.module @test_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
     gpu.func @test_scattered(%arg0: memref<1x16xf32>, %arg1: memref<1x16xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
       %c0 = arith.constant 0 : index
-      %offsets = arith.constant dense<[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]> : vector<16xindex>
       %mask = arith.constant dense<[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]> : vector<16xi1>
       %1 = memref.reinterpret_cast %arg0 to offset: [0], sizes: [16], strides: [1] : memref<1x16xf32> to memref<16xf32>
       %2 = memref.reinterpret_cast %arg1 to offset: [0], sizes: [16], strides: [1] : memref<1x16xf32> to memref<16xf32>
-      %tdesc1 = xegpu.create_tdesc %1, %offsets : memref<16xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
-      %tdesc2 = xegpu.create_tdesc %2, %offsets : memref<16xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
+      %tdesc1 = xegpu.create_tdesc %1[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] : memref<16xf32> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
+      %tdesc2 = xegpu.create_tdesc %2[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] : memref<16xf32> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
       %loaded = xegpu.load %tdesc1, %mask : !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>, vector<16xi1> -> vector<16xf32>
       xegpu.store %loaded, %tdesc2, %mask : vector<16xf32>, !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>, vector<16xi1>
       gpu.return

--- a/test/Integration/Dialect/XeGPU/loadgather_masked_f32.mlir
+++ b/test/Integration/Dialect/XeGPU/loadgather_masked_f32.mlir
@@ -24,12 +24,11 @@ module @gemm attributes {gpu.container_module} {
   gpu.module @test_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
     gpu.func @test_scattered(%arg0: memref<1x16xf32>, %arg1: memref<1x16xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
       %c0 = arith.constant 0 : index
-      %offsets = arith.constant dense<[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]> : vector<16xindex>
       %mask = arith.constant dense<[1,1,1,0,1,1,1,1,0,1,1,1,1,0,1,1]> : vector<16xi1>
       %1 = memref.reinterpret_cast %arg0 to offset: [0], sizes: [16], strides: [1] : memref<1x16xf32> to memref<16xf32>
       %2 = memref.reinterpret_cast %arg1 to offset: [0], sizes: [16], strides: [1] : memref<1x16xf32> to memref<16xf32>
-      %tdesc1 = xegpu.create_tdesc %1, %offsets : memref<16xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
-      %tdesc2 = xegpu.create_tdesc %2, %offsets : memref<16xf32>, vector<16xindex> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
+      %tdesc1 = xegpu.create_tdesc %1[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] : memref<16xf32> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
+      %tdesc2 = xegpu.create_tdesc %2[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] : memref<16xf32> -> !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>
       %loaded = xegpu.load %tdesc1, %mask : !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>, vector<16xi1> -> vector<16xf32>
       xegpu.store %loaded, %tdesc2, %mask : vector<16xf32>, !xegpu.tensor_desc<16xf32, #xegpu.scatter_tdesc_attr<>>, vector<16xi1>
       gpu.return

--- a/test/Integration/Dialect/XeGPU/xegpu-to-vc.mlir
+++ b/test/Integration/Dialect/XeGPU/xegpu-to-vc.mlir
@@ -62,9 +62,9 @@ spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer,
         %B0 = xegpu.create_nd_tdesc %arg1[%arg3, %3] {boundary_check = true} : memref<32x32xf16> -> !xegpu.tensor_desc<16x16xf16>
         %B0_val = xegpu.load_nd %B0 {packed} : !xegpu.tensor_desc<16x16xf16> -> vector<8x16x2xf16>
 
-        %A0_cast = vector.shape_cast %A0_val : vector<128xf16> to vector<8x8x2xf16>
+        %A0_cast = vector.shape_cast %A0_val : vector<128xf16> to vector<8x16xf16>
 
-        %dpas0 = xegpu.dpas %A0_cast, %B0_val : vector<8x8x2xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
+        %dpas0 = xegpu.dpas %A0_cast, %B0_val : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
         %dpas0_cast = vector.shape_cast %dpas0: vector<8x16xf32> to vector<128xf32>
 
         scf.yield %dpas0_cast : vector<128xf32>


### PR DESCRIPTION
In XeGPU upstream, offsets of these two ops are in favor of using pairs of Variadic<Index>: $offsets and DenseI64ArrayAttr: $const_offsets to represent (e.g. xegpu.create_tdesc %src[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]), while the downstream uses a vector (e.g., xegpu.create_tdesc %src, %offsets) because XeGPUToVC used this old interface. This PR updates the XeGPUToVC and drops the downstream format in favor of the upstream one.

Please review these guidelines to help with the review process:
- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [ ] Have you organized your commits logically and ensured each can be built by itself?
