### PR TITLE
[InsertGPUAllocs] Modify insert-gpu-allocs pass to also consider xegpu.load/store

### DIFF
--- a/lib/Transforms/InsertGPUAllocs.cpp
+++ b/lib/Transforms/InsertGPUAllocs.cpp
@@ -28,8 +28,8 @@
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/GPU/Transforms/Passes.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
-#include <mlir/Dialect/XeGPU/IR/XeGPU.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/Dialect/XeGPU/IR/XeGPU.h>
 #include <mlir/Pass/Pass.h>
 
 #include <optional>
@@ -267,31 +267,32 @@ public:
     }
 
     // walk over the users and find xegpu.load/store ops
-    std::function<void(mlir::Operation*, bool, AccessType&)> findXeGPULoadStore;
-    findXeGPULoadStore = [&](mlir::Operation *use, bool onDevice, AccessType& ret) {
-      if (auto tile_update = mlir::dyn_cast<mlir::xegpu::UpdateNdOffsetOp>(use)) {
+    std::function<void(mlir::Operation *, bool, AccessType &)>
+        findXeGPULoadStore;
+    findXeGPULoadStore = [&](mlir::Operation *use, bool onDevice,
+                             AccessType &ret) {
+      if (auto tile_update =
+              mlir::dyn_cast<mlir::xegpu::UpdateNdOffsetOp>(use)) {
         auto res = tile_update->getResult(0);
         for (auto u : res.getUsers()) {
           findXeGPULoadStore(u, onDevice, ret);
         }
       }
       if (auto tile_for = mlir::dyn_cast<::mlir::scf::ForOp>(use)) {
-        for (size_t idx=0; idx<tile_for.getInits().size(); idx++) {
+        for (size_t idx = 0; idx < tile_for.getInits().size(); idx++) {
           auto a = tile_for.getRegionIterArg(idx);
           for (auto u : a.getUsers()) {
             findXeGPULoadStore(u, onDevice, ret);
           }
         }
       }
-      if (auto tile_load =
-              mlir::dyn_cast<mlir::xegpu::LoadNdOp>(use)) {
+      if (auto tile_load = mlir::dyn_cast<mlir::xegpu::LoadNdOp>(use)) {
         (onDevice ? ret.deviceRead : ret.hostRead) = true;
-      }
-      else if (auto tile_prefetch =
-                    mlir::dyn_cast<mlir::xegpu::PrefetchNdOp>(use)) {
+      } else if (auto tile_prefetch =
+                     mlir::dyn_cast<mlir::xegpu::PrefetchNdOp>(use)) {
         (onDevice ? ret.deviceRead : ret.hostRead) = true;
       } else if (auto tile_store =
-                    mlir::dyn_cast<mlir::xegpu::StoreNdOp>(use)) {
+                     mlir::dyn_cast<mlir::xegpu::StoreNdOp>(use)) {
         (onDevice ? ret.deviceWrite : ret.hostWrite) = true;
       }
     };
@@ -335,7 +336,8 @@ public:
             continue;
           }
 
-          if (auto init_xedesc = mlir::dyn_cast<mlir::xegpu::CreateNdDescOp>(user)) {
+          if (auto init_xedesc =
+                  mlir::dyn_cast<mlir::xegpu::CreateNdDescOp>(user)) {
             bool onDevice = user->getParentOfType<mlir::gpu::LaunchOp>();
             auto res = init_xedesc->getResult(0);
             for (auto use : res.getUsers()) {

--- a/test/Transforms/InsertGpuAllocs/add-gpu-alloc-xegpu.mlir
+++ b/test/Transforms/InsertGpuAllocs/add-gpu-alloc-xegpu.mlir
@@ -1,0 +1,23 @@
+// RUN: imex-opt --insert-gpu-allocs='client-api=opencl' %s | FileCheck %s --check-prefix=OPENCL
+// RUN: imex-opt --insert-gpu-allocs='client-api=vulkan' %s | FileCheck %s --check-prefix=VULKAN
+
+func.func @addt(%arg0: memref<2x5xf32>, %arg1: memref<2x5xf32>) -> memref<2x5xf32> {
+  %c1 = arith.constant 1 : index
+  // OPENCL: %[[MEMREF0:.*]] = gpu.alloc () : memref<2x5xf32>
+  // OPENCL: %[[MEMREF1:.*]] = gpu.alloc host_shared () : memref<2x5xf32>
+  // VULKAN: %[[MEMREF0:.*]] = memref.alloc() {alignment = 128 : i64} : memref<2x5xf32>
+  // VULKAN: %[[MEMREF1:.*]] = memref.alloc() {alignment = 128 : i64} : memref<2x5xf32>
+
+  %0 = memref.alloc() {alignment = 128 : i64} : memref<2x5xf32>
+  %1 = memref.alloc() {alignment = 128 : i64} : memref<2x5xf32>
+
+  gpu.launch blocks(%arg2, %arg3, %arg4) in (%arg8 = %c1, %arg9 = %c1, %arg10 = %c1) threads(%arg5, %arg6, %arg7) in (%arg11 = %c1, %arg12 = %c1, %arg13 = %c1) {
+    %c0 = arith.constant 0 : index
+    %src_tile = xegpu.create_nd_tdesc %0[%c0, %c0] : memref<2x5xf32> -> !xegpu.tensor_desc<2x5xf32>
+    %src_value = xegpu.load_nd %src_tile  : !xegpu.tensor_desc<2x5xf32> -> vector<2x5xf32>
+    %res_tile = xegpu.create_nd_tdesc %1[%c0, %c0] : memref<2x5xf32> -> !xegpu.tensor_desc<2x5xf32>
+    xegpu.store_nd %src_value, %res_tile: vector<2x5xf32>, !xegpu.tensor_desc<2x5xf32>
+    gpu.terminator
+  } {SCFToGPU_visited}
+  return %1 : memref<2x5xf32>
+}

--- a/test/Transforms/InsertGpuAllocs/xegpu-mem-copy.mlir
+++ b/test/Transforms/InsertGpuAllocs/xegpu-mem-copy.mlir
@@ -1,0 +1,30 @@
+// RUN: imex-opt --insert-gpu-allocs='client-api=opencl' %s | FileCheck %s --check-prefix=OPENCL
+// RUN: imex-opt --insert-gpu-allocs='client-api=vulkan' %s | FileCheck %s --check-prefix=VULKAN
+
+// OPENCL-LABEL: func.func @addt
+// OPENCL-SAME:  %[[arg0:.+]]: memref<2x5xf32>, %[[arg1:.+]]: memref<2x5xf32>
+// VULKAN-LABEL: func.func @addt
+// VULKAN-SAME:  %[[arg0:.+]]: memref<2x5xf32>, %[[arg1:.+]]: memref<2x5xf32>
+func.func @addt(%arg0: memref<2x5xf32>, %arg1: memref<2x5xf32>) -> memref<2x5xf32> {
+  %c1 = arith.constant 1 : index
+  // OPENCL: %[[MEMREF0:.*]] = gpu.alloc host_shared () : memref<2x5xf32>
+  // OPENCL: %[[MEMREF1:.*]] = gpu.alloc host_shared () : memref<2x5xf32>
+  // OPENCL: memref.copy %[[arg0]], %[[MEMREF1:.*]]
+  // VULKAN: %[[MEMREF0:.*]] = memref.alloc() : memref<2x5xf32>
+  // VULKAN: %[[MEMREF1:.*]] = memref.alloc() : memref<2x5xf32>
+  // VULKAN: memref.copy %[[arg0]], %[[MEMREF1:.*]]
+
+  gpu.launch blocks(%arg2, %arg3, %arg4) in (%arg8 = %c1, %arg9 = %c1, %arg10 = %c1) threads(%arg5, %arg6, %arg7) in (%arg11 = %c1, %arg12 = %c1, %arg13 = %c1) {
+    %c0 = arith.constant 0 : index
+    %src_tile = xegpu.create_nd_tdesc %arg0[%c0, %c0] : memref<2x5xf32> -> !xegpu.tensor_desc<2x5xf32>
+    %src_value = xegpu.load_nd %src_tile  : !xegpu.tensor_desc<2x5xf32> -> vector<2x5xf32>
+    %res_tile = xegpu.create_nd_tdesc %arg1[%c0, %c0] : memref<2x5xf32> -> !xegpu.tensor_desc<2x5xf32>
+    xegpu.store_nd %src_value, %res_tile: vector<2x5xf32>, !xegpu.tensor_desc<2x5xf32>
+    gpu.terminator
+  } {SCFToGPU_visited}
+
+  // OPENCL: memref.copy %[[MEMREF0]], %[[arg1]] : memref<2x5xf32> to memref<2x5xf32>
+  // VULKAN: memref.copy %[[MEMREF0]], %[[arg1]] : memref<2x5xf32> to memref<2x5xf32>
+
+  return %arg1 : memref<2x5xf32>
+}


### PR DESCRIPTION
This PR fixes intel/mlir-extensions#865 and makes `insert-gpu-allocs` pass to recognize xegpu.load/store ops the same as it's done for xetile.load/store 

Upstream PR for intel-innersource/frameworks.ai.mlir.mlir-extensions#699