### PR TITLE
[GC-STAGING] Filter out `LLVM_DEFINITIONS` that were already defined 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,7 +267,25 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 # Generated IMEX headers
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 message(STATUS "LLVM_DEFINITIONS: ${LLVM_DEFINITIONS}")
-add_definitions(${LLVM_DEFINITIONS})
+
+string(REPLACE "-D" "" CLEANED_LLVM_DEFINITION_STRING "${LLVM_DEFINITIONS}")
+string(REGEX REPLACE " " ";" LLVM_DEFINITION_LIST "${CLEANED_LLVM_DEFINITION_STRING}")
+
+get_property(existing_compile_definitions DIRECTORY PROPERTY COMPILE_DEFINITIONS)
+
+# HACK: Sometimes 'LLVM_DEFINITIONS' may contain definitions that were already added
+# by parent libraries (like openvino). Adding 'LLVM_DEFINITIONS' as is in such cases
+# may result into duplicate definitions. To avoid this, we check if the definition
+# is already in the list of existing definitions and add only if it's not found.
+foreach(definition ${LLVM_DEFINITION_LIST})
+    # Check if the definition is already in the list of existing definitions
+    list(FIND existing_compile_definitions ${definition} index)
+
+    # If it's not found (index == -1), add the compile definition
+    if(index EQUAL -1)
+        add_compile_definitions(${definition})
+    endif()
+endforeach()
 
 set(LLVM_LIT_ARGS "-sv" CACHE STRING "lit default options")
 if (IMEX_ENABLE_SYCL_RUNTIME OR IMEX_ENABLE_L0_RUNTIME)


### PR DESCRIPTION
I don't know why, but `LLVM_DEFINITIONS` variable (that is populated by `find_package(llvm...)`) contains all compile definitions that were added prior calling `find_package(llvm...)` when I build IMEX with OpenVino. 

In particular, `LLVM_DEFINITIONS` contains `-DOV_BUILD_POSTFIX=...` and `-DOV_BUILD_PATH=...` variables that were already defined by OV which causes the IMEX build to fail due to double definition (because they were already added as `add_definitions()` on OV side and now we're trying to add them again in IMEX). 

There's nothing special of how those two variables are defined in OV. In fact, any variable that is added as `add_definitions(...)` or `add_compile_definitions(...)` prior [calling `FetchContent_Declare(GC, ...)`](https://github.com/slyalin/openvino/blob/21ed9ac767688e6038eafa6d2f842eea966920c8/cmake/graph-compiler.cmake#L12) in OV is being propagated to `LLVM_DEFINITIONS`.

To fix this, I've added a logic that goes through every variable in `LLVM_DEFINITIONS` and checks if it was already defined.

p.s.
This problem is not IMEX specific. In GC the OV variables are also propagated to `LLVM_DEFINITIONS`. However [in GC we're adding `LLVM_DEFINITIONS` as compile options](https://github.com/intel/graph-compiler/blob/199501e3580a1dc2cdee110e53f3c1b5c5229204/cmake/mlir.cmake#L30-L31) rather than as compile definitions, which works just fine.

@AndreyPavlenko @kurapov-peter is there a better fix for this or we can merge this one?
