### PR TITLE
[Pass-pipeline] Modify IMEX pass pipeline to handle complex memref lo…

### DIFF
--- a/test/Integration/Dialect/Gpu/gpu-to-llvm.pp
+++ b/test/Integration/Dialect/Gpu/gpu-to-llvm.pp
@@ -14,6 +14,8 @@ builtin.module(
     convert-vector-to-scf
     convert-gpu-to-gpux
     convert-scf-to-cf
+    expand-strided-metadata
+    finalize-memref-to-llvm
     convert-cf-to-llvm
     convert-vector-to-llvm
     convert-index-to-llvm
@@ -22,8 +24,6 @@ builtin.module(
     convert-math-to-llvm
     convert-gpux-to-llvm
     convert-index-to-llvm
-    expand-strided-metadata
     lower-affine
-    finalize-memref-to-llvm
     reconcile-unrealized-casts)
 // End

--- a/test/Integration/Dialect/Linalg/OpenCL/linalg-to-gpux-opencl.pp
+++ b/test/Integration/Dialect/Linalg/OpenCL/linalg-to-gpux-opencl.pp
@@ -27,8 +27,8 @@ builtin.module(convert-tensor-to-linalg
     func.func(llvm-request-c-wrappers)
     serialize-spirv
     convert-gpu-to-gpux
+    finalize-memref-to-llvm
     convert-func-to-llvm
     convert-gpux-to-llvm
-    finalize-memref-to-llvm
     reconcile-unrealized-casts)
 // End

--- a/test/Integration/Dialect/XeGPU/xegpu-to-func-vc-optimize-transpose.pp
+++ b/test/Integration/Dialect/XeGPU/xegpu-to-func-vc-optimize-transpose.pp
@@ -16,6 +16,8 @@ builtin.module(
     convert-vector-to-scf
     convert-gpu-to-gpux
     convert-scf-to-cf
+    expand-strided-metadata
+    finalize-memref-to-llvm
     convert-cf-to-llvm
     convert-vector-to-llvm
     convert-index-to-llvm
@@ -23,9 +25,6 @@ builtin.module(
     convert-func-to-llvm
     convert-math-to-llvm
     convert-gpux-to-llvm
-    convert-index-to-llvm
-    expand-strided-metadata
     lower-affine
-    finalize-memref-to-llvm
     reconcile-unrealized-casts)
 // End

--- a/test/Integration/Dialect/XeGPU/xegpu-to-func-vc.pp
+++ b/test/Integration/Dialect/XeGPU/xegpu-to-func-vc.pp
@@ -16,6 +16,8 @@ builtin.module(
     convert-vector-to-scf
     convert-gpu-to-gpux
     convert-scf-to-cf
+    expand-strided-metadata
+    finalize-memref-to-llvm
     convert-cf-to-llvm
     convert-vector-to-llvm
     convert-index-to-llvm
@@ -23,9 +25,6 @@ builtin.module(
     convert-func-to-llvm
     convert-math-to-llvm
     convert-gpux-to-llvm
-    convert-index-to-llvm
-    expand-strided-metadata
     lower-affine
-    finalize-memref-to-llvm
     reconcile-unrealized-casts)
 // End

--- a/test/Integration/Dialect/XeGPU/xegpu-to-llvm-joint-matrix.pp
+++ b/test/Integration/Dialect/XeGPU/xegpu-to-llvm-joint-matrix.pp
@@ -10,6 +10,8 @@ builtin.module(
     convert-vector-to-scf
     convert-gpu-to-gpux
     convert-scf-to-cf
+    expand-strided-metadata
+    finalize-memref-to-llvm
     convert-cf-to-llvm
     convert-vector-to-llvm
     convert-index-to-llvm
@@ -17,9 +19,6 @@ builtin.module(
     convert-func-to-llvm
     convert-math-to-llvm
     convert-gpux-to-llvm
-    convert-index-to-llvm
-    expand-strided-metadata
     lower-affine
-    finalize-memref-to-llvm
     reconcile-unrealized-casts)
 // End

--- a/test/Integration/Dialect/XeTile/xetile-to-func-vc-optimize-transpose.pp
+++ b/test/Integration/Dialect/XeTile/xetile-to-func-vc-optimize-transpose.pp
@@ -26,6 +26,8 @@ builtin.module(
     convert-vector-to-scf
     convert-gpu-to-gpux
     convert-scf-to-cf
+    expand-strided-metadata
+    finalize-memref-to-llvm
     convert-cf-to-llvm
     convert-vector-to-llvm
     convert-index-to-llvm
@@ -33,8 +35,5 @@ builtin.module(
     convert-func-to-llvm
     convert-math-to-llvm
     convert-gpux-to-llvm
-    convert-index-to-llvm
-    expand-strided-metadata
     lower-affine
-    finalize-memref-to-llvm
     reconcile-unrealized-casts)

--- a/test/Integration/Dialect/XeTile/xetile-to-func-vc.pp
+++ b/test/Integration/Dialect/XeTile/xetile-to-func-vc.pp
@@ -23,6 +23,8 @@ builtin.module(
     convert-vector-to-scf
     convert-gpu-to-gpux
     convert-scf-to-cf
+    expand-strided-metadata
+    finalize-memref-to-llvm
     convert-cf-to-llvm
     convert-vector-to-llvm
     convert-index-to-llvm
@@ -30,8 +32,5 @@ builtin.module(
     convert-func-to-llvm
     convert-math-to-llvm
     convert-gpux-to-llvm
-    convert-index-to-llvm
-    expand-strided-metadata
     lower-affine
-    finalize-memref-to-llvm
     reconcile-unrealized-casts)

--- a/test/Integration/Dialect/XeTile/xetile-wg-to-func-vc.pp
+++ b/test/Integration/Dialect/XeTile/xetile-wg-to-func-vc.pp
@@ -23,6 +23,8 @@ builtin.module(
     convert-vector-to-scf
     convert-gpu-to-gpux
     convert-scf-to-cf
+    expand-strided-metadata
+    finalize-memref-to-llvm
     convert-cf-to-llvm
     convert-vector-to-llvm
     convert-index-to-llvm
@@ -30,8 +32,5 @@ builtin.module(
     convert-func-to-llvm
     convert-math-to-llvm
     convert-gpux-to-llvm
-    convert-index-to-llvm
-    expand-strided-metadata
     lower-affine
-    finalize-memref-to-llvm
     reconcile-unrealized-casts)

--- a/test/PlaidML/linalg-to-llvm-caching.pp
+++ b/test/PlaidML/linalg-to-llvm-caching.pp
@@ -30,13 +30,14 @@ builtin.module(convert-tensor-to-linalg
     serialize-spirv
     convert-gpu-to-gpux
     convert-scf-to-cf
-    convert-cf-to-llvm
-    convert-arith-to-llvm
-    convert-func-to-llvm
-    convert-math-to-llvm
-    convert-gpux-to-llvm
     expand-strided-metadata
-    lower-affine
     finalize-memref-to-llvm
+    convert-cf-to-llvm
+    convert-index-to-llvm
+    convert-arith-to-llvm
+    convert-math-to-llvm
+    convert-func-to-llvm
+    convert-gpux-to-llvm
+    lower-affine
     reconcile-unrealized-casts)
 // End

--- a/test/PlaidML/linalg-to-llvm.pp
+++ b/test/PlaidML/linalg-to-llvm.pp
@@ -29,11 +29,11 @@ builtin.module(convert-tensor-to-linalg
     func.func(llvm-request-c-wrappers)
     serialize-spirv
     convert-gpu-to-gpux
+    expand-strided-metadata
+    finalize-memref-to-llvm
     convert-func-to-llvm
     convert-math-to-llvm
     convert-gpux-to-llvm
-    expand-strided-metadata
     lower-affine
-    finalize-memref-to-llvm
     reconcile-unrealized-casts)
 // End

--- a/test/SPIRV/spirv-to-llvm.pp
+++ b/test/SPIRV/spirv-to-llvm.pp
@@ -4,13 +4,13 @@ builtin.module(
     serialize-spirv
     convert-gpu-to-gpux
     convert-scf-to-cf
+    expand-strided-metadata
+    finalize-memref-to-llvm
     convert-cf-to-llvm
     convert-arith-to-llvm
     convert-func-to-llvm
     convert-math-to-llvm
     convert-gpux-to-llvm
-    expand-strided-metadata
     lower-affine
-    finalize-memref-to-llvm
     reconcile-unrealized-casts)
 // End


### PR DESCRIPTION
…wering.

For complex memref lowering (e.g., dynamic strided memref), memref has to be lowered (-expand-strided-metadata -finalize-memref-to-llvm) before func lowering (-func-to-llvm) is done.

Please review these guidelines to help with the review process:
- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [x] Have you organized your commits logically and ensured each can be built by itself?
