### PR TITLE
[XeGPU] Add support for dynamic memref and i64/i32 source types for x…

### DIFF
--- a/test/Conversion/XeGPUToVC/create_nd_desc.mlir
+++ b/test/Conversion/XeGPUToVC/create_nd_desc.mlir
@@ -141,5 +141,49 @@ module @gemm attributes {gpu.container_module} {
       %tdesc_2d = xegpu.create_nd_tdesc %arg0[0, 0] : memref<32x32xf16, strided<[64,1], offset: 0>> -> !xegpu.tensor_desc<8x16xf16>
       gpu.return
     }
+
+    // CHECK: gpu.func @test_create_nd_tdesc_1d_dynamic_strided_memref(%[[arg0:.*]]: memref<?x?xf16, strided<[?, ?], offset: ?>>, %[[arg1:.*]]: index, %[[arg2:.*]]: index, %[[arg3:.*]]: index, %[[arg4:.*]]: index) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+    gpu.func @test_create_nd_tdesc_1d_dynamic_strided_memref(%arg0: memref<?x?xf16, strided<[?,?], offset: ?>>, %arg1 : index, %arg2 : index, %arg3 : index, %arg4 : index) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>}{
+      //CHECK: %[[c0:.*]] = arith.constant 0 : index
+      %c0 = arith.constant 0 : index
+      //CHECK: %[[intptr:.*]] = memref.extract_aligned_pointer_as_index %arg0 : memref<?x?xf16, strided<[?, ?], offset: ?>> -> index
+      //CHECK: %[[c2:.*]] = arith.constant 2 : index
+      //CHECK: %[[r0:.*]] = arith.muli %[[arg3]], %[[c2]] : index
+      //CHECK: %[[r1:.*]] = arith.muli %[[r0]], %[[c0]] : index
+      //CHECK: %[[r2:.*]] = arith.addi %[[intptr]], %[[r1]] : index
+      //CHECK: %[[r3:.*]] = arith.index_castui %[[r2]] : index to i64
+      %tdesc_1d = xegpu.create_nd_tdesc %arg0[%c0, %c0], [%arg1, %arg2], [%arg3, %arg4] : memref<?x?xf16, strided<[?,?], offset: ?>> -> !xegpu.tensor_desc<16xf16>
+      gpu.return
+    }
+
+    // CHECK: gpu.func @test_create_nd_tdesc_2d_dynamic_strided_memref(%[[arg0:.*]]: memref<?x?xf16, strided<[?, ?], offset: ?>>, %[[arg1:.*]]: index, %[[arg2:.*]]: index, %[[arg3:.*]]: index, %[[arg4:.*]]: index) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+    gpu.func @test_create_nd_tdesc_2d_dynamic_strided_memref(%arg0: memref<?x?xf16, strided<[?,?], offset: ?>>, %arg1 : index, %arg2 : index, %arg3 : index, %arg4 : index) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>}{
+      //CHECK: %[[c0:.*]] = arith.constant 0 : index
+      %c0 = arith.constant 0 : index
+      //CHECK: %[[intptr:.*]] = memref.extract_aligned_pointer_as_index %arg0 : memref<?x?xf16, strided<[?, ?], offset: ?>> -> index
+      //CHECK: %[[r0:.*]] = arith.index_castui %intptr : index to i64
+      //CHECK: %[[cst:.*]] = arith.constant dense<0> : vector<8xi64>
+      //CHECK: %[[r1:.*]] = vector.insert %[[r0]], %cst [0] : i64 into vector<8xi64>
+      //CHECK: %[[r2:.*]] = vector.bitcast %[[r1]] : vector<8xi64> to vector<16xi32>
+      //CHECK: %[[r3:.*]] = arith.index_castui %arg2 : index to i32
+      //CHECK: %[[c2_i32:.*]] = arith.constant 2 : i32
+      //CHECK: %[[r4:.*]] = arith.muli %[[r3]], %c2_i32 : i32
+      //CHECK: %[[c1_i32:.*]] = arith.constant 1 : i32
+      //CHECK: %[[r5:.*]] = arith.subi %[[r4]], %c1_i32 : i32
+      //CHECK: %[[r6:.*]] = arith.index_castui %arg1 : index to i32
+      //CHECK: %[[r7:.*]] = arith.subi %[[r6]], %c1_i32 : i32
+      //CHECK: %[[r8:.*]] = arith.index_castui %arg3 : index to i32
+      //CHECK: %[[r9:.*]] = arith.muli %[[r8]], %c2_i32 : i32
+      //CHECK: %[[r10:.*]] = arith.subi %[[r9]], %c1_i32 : i32
+      //CHECK: %[[r11:.*]] = vector.insert %[[r5]], %[[r2]] [2] : i32 into vector<16xi32>
+      //CHECK: %[[r12:.*]] = vector.insert %[[r7]], %[[r11]] [3] : i32 into vector<16xi32>
+      //CHECK: %[[r13:.*]] = vector.insert %[[r10]], %[[r12]] [4] : i32 into vector<16xi32>
+      //CHECK: %[[r14:.*]] = arith.index_castui %c0 : index to i32
+      //CHECK: %[[r15:.*]] = vector.insert %[[r14]], %[[r13]] [5] : i32 into vector<16xi32>
+      //CHECK: %[[r16:.*]] = vector.insert %[[r14]], %[[r15]] [6] : i32 into vector<16xi32>
+      //CHECK: %[[c1807_i32:.*]] = arith.constant 1807 : i32
+      %tdesc_2d = xegpu.create_nd_tdesc %arg0[%c0, %c0], [%arg1, %arg2], [%arg3, %arg4] : memref<?x?xf16, strided<[?,?], offset: ?>> -> !xegpu.tensor_desc<8x16xf16>
+      gpu.return
+    }
   }
 }

--- a/test/Integration/Dialect/XeGPU/dynamic_strided_memref_1d.mlir
+++ b/test/Integration/Dialect/XeGPU/dynamic_strided_memref_1d.mlir
@@ -1,0 +1,70 @@
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                       --runner imex-cpu-runner -e main \
+// RUN:                                       --entry-point-result=void \
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
+// RUN: %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                        --runner imex-cpu-runner -e main \
+// RUN:                                        --entry-point-result=void \
+// RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck
+module @gemm attributes {gpu.container_module} {
+  memref.global "private" @__Aconstant_8x32xf32 : memref<8x32xf32> = dense<1.0>
+  memref.global "private" @__Bconstant_8x32xf32 : memref<8x32xf32> = dense<2.0>
+  func.func @test(%arg0: memref<8x32xf32>, %arg1: memref<8x32xf32>) -> memref<8x32xf32> attributes {llvm.emit_c_interface} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    %c16 = arith.constant 16 : index
+    %c32 = arith.constant 32 : index
+    %c0_f32 = arith.constant 0.0 : f32
+
+    %A = gpu.alloc  host_shared () : memref<8x32xf32>
+    memref.copy %arg0, %A : memref<8x32xf32> to memref<8x32xf32>
+    %B = gpu.alloc  host_shared () : memref<8x32xf32>
+    memref.copy %arg1, %B : memref<8x32xf32> to memref<8x32xf32>
+
+    %C = gpu.alloc  host_shared () : memref<8x32xf32>
+    %C_unranked = memref.cast %C : memref<8x32xf32> to memref<*xf32>
+    call @fillResource1DF32(%C_unranked, %c0_f32) : (memref<*xf32>, f32) -> ()
+
+    %A_strided_dynamic = memref.subview %A[%c0, %c0][%c8, %c16][%c1, %c1] : memref<8x32xf32> to memref<?x?xf32, strided<[?,?], offset: ?>>
+    %B_strided_dynamic = memref.subview %B[%c0, %c0][%c8, %c16][%c1, %c1] : memref<8x32xf32> to memref<?x?xf32, strided<[?,?], offset: ?>>
+    %C_strided_dynamic = memref.subview %C[%c0, %c0][%c8, %c16][%c1, %c1] : memref<8x32xf32> to memref<?x?xf32, strided<[?,?], offset: ?>>
+
+
+    gpu.launch_func  @test_kernel::@test_kernel blocks in (%c1, %c1, %c1) threads in (%c8, %c1, %c1) args(%A_strided_dynamic : memref<?x?xf32, strided<[?,?], offset: ?>>, %B_strided_dynamic  : memref<?x?xf32, strided<[?,?], offset: ?>>, %C_strided_dynamic : memref<?x?xf32, strided<[?,?], offset: ?>>, %c8 : index, %c16 : index, %c32 : index, %c1 : index)
+    gpu.dealloc  %A : memref<8x32xf32>
+    gpu.dealloc  %B : memref<8x32xf32>
+    return %C : memref<8x32xf32>
+  }
+  gpu.module @test_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
+    gpu.func @test_kernel(%arg0: memref<?x?xf32, strided<[?,?], offset: ?>>, %arg1: memref<?x?xf32, strided<[?,?], offset: ?>>, %arg2: memref<?x?xf32, strided<[?,?], offset: ?>>, %shape_x : index, %shape_y : index, %stride_x : index, %stride_y : index) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %thread_id_x = gpu.thread_id x
+
+      %0 = xegpu.create_nd_tdesc %arg0[%thread_id_x, 0], [%shape_x, %shape_y], [%stride_x, %stride_y] : memref<?x?xf32, strided<[?,?], offset: ?>> -> !xegpu.tensor_desc<16xf32>
+      %1 = xegpu.load_nd %0  : !xegpu.tensor_desc<16xf32> -> vector<16xf32>
+      %2 = xegpu.create_nd_tdesc %arg1[%thread_id_x, 0], [%shape_x, %shape_y], [%stride_x, %stride_y] : memref<?x?xf32, strided<[?,?], offset: ?>> -> !xegpu.tensor_desc<16xf32>
+      %3 = xegpu.load_nd %2  : !xegpu.tensor_desc<16xf32> -> vector<16xf32>
+      %4 = arith.addf %3, %1 : vector<16xf32>
+      %5 = xegpu.create_nd_tdesc %arg2[%thread_id_x, 0], [%shape_x, %shape_y], [%stride_x, %stride_y] : memref<?x?xf32, strided<[?,?], offset: ?>> -> !xegpu.tensor_desc<16xf32>
+      xegpu.store_nd %4, %5  : vector<16xf32>, !xegpu.tensor_desc<16xf32>
+      gpu.return
+    }
+  }
+  func.func @main() attributes {llvm.emit_c_interface} {
+
+    // Allocate/get regular row major memrefs
+    %A = memref.get_global @__Aconstant_8x32xf32 : memref<8x32xf32>
+    %B = memref.get_global @__Bconstant_8x32xf32 : memref<8x32xf32>
+
+    %result = call @test(%A, %B) : (memref<8x32xf32>, memref<8x32xf32>) -> memref<8x32xf32>
+
+    %result_cast = memref.cast %result : memref<8x32xf32> to memref<*xf32>
+    call @printMemrefF32(%result_cast) : (memref<*xf32>) -> ()
+    // CHECK: Unranked Memref base@ = {{(0x)?[-9a-f]*}}
+    // CHECK-NEXT:[3,   3,   3,   3,   3,   3,   3,   3,   3,   3,   3,   3,   3,   3,   3,   3,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0],
+
+    return
+  }
+  func.func private @fillResource1DF32(memref<*xf32>, f32) attributes {llvm.emit_c_interface}
+  func.func private @printMemrefF32(memref<*xf32>) attributes {llvm.emit_c_interface}
+}

--- a/test/Integration/Dialect/XeGPU/dynamic_strided_memref_2d.mlir
+++ b/test/Integration/Dialect/XeGPU/dynamic_strided_memref_2d.mlir
@@ -1,0 +1,89 @@
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                       --runner imex-cpu-runner -e main \
+// RUN:                                       --entry-point-result=void \
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
+// RUN: %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                        --runner imex-cpu-runner -e main \
+// RUN:                                        --entry-point-result=void \
+// RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck
+module @gemm attributes {gpu.container_module} {
+  memref.global "private" @__Aconstant_32x64xf16 : memref<32x64xf16> = dense<1.0>
+  memref.global "private" @__Bconstant_32x64xf16 : memref<32x64xf16> = dense<2.0>
+  func.func @test(%arg0: memref<32x64xf16>, %arg1: memref<32x64xf16>) -> memref<32x64xf32> attributes {llvm.emit_c_interface} {
+    %c64 = arith.constant 64 : index
+    %c32 = arith.constant 32 : index
+    %c4 = arith.constant 4 : index
+    %c2 = arith.constant 2 : index
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %c0_f32 = arith.constant 0.0 : f32
+
+
+    %A = gpu.alloc  host_shared () : memref<32x64xf16>
+    memref.copy %arg0, %A : memref<32x64xf16> to memref<32x64xf16>
+    %B = gpu.alloc  host_shared () : memref<32x64xf16>
+    memref.copy %arg1, %B : memref<32x64xf16> to memref<32x64xf16>
+
+    %C = gpu.alloc  host_shared () : memref<32x64xf32>
+    %C_unranked = memref.cast %C : memref<32x64xf32> to memref<*xf32>
+    call @fillResource1DF32(%C_unranked, %c0_f32) : (memref<*xf32>, f32) -> ()
+
+    %A_strided_dynamic = memref.subview %A[%c0, %c0][%c32, %c32][%c1, %c1] : memref<32x64xf16> to memref<?x?xf16, strided<[?,?], offset: ?>>
+    %B_strided_dynamic = memref.subview %B[%c0, %c0][%c32, %c32][%c1, %c1] : memref<32x64xf16> to memref<?x?xf16, strided<[?,?], offset: ?>>
+    %C_strided_dynamic = memref.subview %C[%c0, %c0][%c32, %c32][%c1, %c1] : memref<32x64xf32> to memref<?x?xf32, strided<[?,?], offset: ?>>
+
+    gpu.launch_func  @test_kernel::@test_kernel blocks in (%c4, %c2, %c1) threads in (%c1, %c1, %c1) args(%A_strided_dynamic : memref<?x?xf16, strided<[?,?], offset: ?>>, %B_strided_dynamic : memref<?x?xf16, strided<[?,?], offset: ?>>, %C_strided_dynamic : memref<?x?xf32, strided<[?,?], offset: ?>>, %c32 : index, %c32 : index, %c64 : index, %c1 : index)
+    gpu.dealloc  %A : memref<32x64xf16>
+    gpu.dealloc  %B : memref<32x64xf16>
+    return %C : memref<32x64xf32>
+  }
+
+gpu.module @test_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
+    gpu.func @test_kernel(%A: memref<?x?xf16, strided<[?,?], offset: ?>>, %B: memref<?x?xf16, strided<[?,?], offset: ?>>, %C: memref<?x?xf32, strided<[?,?], offset: ?>>, %shape_x : index, %shape_y : index, %stride_x : index, %stride_y : index) kernel attributes {VectorComputeFunctionINTEL, gpu.known_block_size = array<i32: 1, 1, 1>, gpu.known_grid_size = array<i32: 4, 2, 1>, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %c0 = arith.constant 0 : index
+      %c16 = arith.constant 16 : index
+      %c32 = arith.constant 32 : index
+      %c8 = arith.constant 8 : index
+      %cst = arith.constant dense<1.0> : vector<8x16xf16>
+      %0 = gpu.block_id  x
+      %1 = gpu.block_id  y
+
+      %2 = arith.muli %0, %c8 : index
+      %3 = arith.muli %1, %c16 : index
+
+      %4 = xegpu.create_nd_tdesc %C[%2, %3], [%shape_x, %shape_y], [%stride_x, %stride_y] : memref<?x?xf32, strided<[?,?], offset: ?>> -> !xegpu.tensor_desc<8x16xf32>
+      %5 = xegpu.load_nd %4 : !xegpu.tensor_desc<8x16xf32> -> vector<8x16xf32>
+
+      %6 = scf.for %arg3 = %c0 to %c32 step %c16 iter_args(%arg4 = %5) -> (vector<8x16xf32>) {
+        %A0 = xegpu.create_nd_tdesc %A[%2, %arg3], [%shape_x, %shape_y], [%stride_x, %stride_y] : memref<?x?xf16, strided<[?,?], offset: ?>> -> !xegpu.tensor_desc<8x16xf16>
+        %A0_val = xegpu.load_nd %A0 : !xegpu.tensor_desc<8x16xf16> -> vector<8x16xf16>
+
+        %B0 = xegpu.create_nd_tdesc %B[%arg3, %3], [%shape_x, %shape_y], [%stride_x, %stride_y] : memref<?x?xf16, strided<[?,?], offset: ?>> -> !xegpu.tensor_desc<16x16xf16>
+        %B0_val = xegpu.load_nd %B0 {packed} : !xegpu.tensor_desc<16x16xf16> -> vector<8x16x2xf16>
+
+        %A0_preop = arith.addf %A0_val, %cst : vector<8x16xf16>
+
+        %dpas0 = xegpu.dpas %A0_preop, %B0_val , %arg4: vector<8x16xf16>, vector<8x16x2xf16>, vector<8x16xf32> -> vector<8x16xf32>
+        scf.yield %dpas0 : vector<8x16xf32>
+      }
+      xegpu.store_nd %6, %4 : vector<8x16xf32>, !xegpu.tensor_desc<8x16xf32>
+
+      gpu.return
+    }
+  }
+
+  func.func @main() attributes {llvm.emit_c_interface} {
+    // Allocate/get regular row major memrefs
+    %A = memref.get_global @__Aconstant_32x64xf16 : memref<32x64xf16>
+    %B = memref.get_global @__Bconstant_32x64xf16 : memref<32x64xf16>
+
+    %result = call @test(%A, %B) : (memref<32x64xf16>, memref<32x64xf16>) -> memref<32x64xf32>
+    %result_cast = memref.cast %result : memref<32x64xf32> to memref<*xf32>
+    call @printMemrefF32(%result_cast) : (memref<*xf32>) -> ()
+    // CHECK: Unranked Memref base@ = {{(0x)?[-9a-f]*}}
+    // CHECK-NEXT:[128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   128,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0],
+    return
+  }
+  func.func private @fillResource1DF32(memref<*xf32>, f32) attributes {llvm.emit_c_interface}
+  func.func private @printMemrefF32(memref<*xf32>) attributes {llvm.emit_c_interface}
+}

--- a/test/Integration/Dialect/XeGPU/eltwise_add_1_d.mlir
+++ b/test/Integration/Dialect/XeGPU/eltwise_add_1_d.mlir
@@ -1,0 +1,80 @@
+// RUN: %python_executable %imex_runner --requires=l0-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                       --runner imex-cpu-runner -e main \
+// RUN:                                       --entry-point-result=void \
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
+// RUN: %python_executable %imex_runner --requires=sycl-runtime -i %s --pass-pipeline-file=%p/xegpu-to-func-vc.pp \
+// RUN:                                        --runner imex-cpu-runner -e main \
+// RUN:                                        --entry-point-result=void \
+// RUN:                                        --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%sycl_runtime --filecheck
+module @gemm attributes {gpu.container_module} {
+  memref.global "private" constant @__constant_512xf32 : memref<512xf32> = dense<0.0>
+  func.func @test(%arg0: memref<512xf32>, %arg1: memref<512xf32>) -> memref<512xf32> attributes {llvm.emit_c_interface} {
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %memref = gpu.alloc  host_shared () : memref<512xf32>
+    memref.copy %arg0, %memref : memref<512xf32> to memref<512xf32>
+    %memref_1 = gpu.alloc  host_shared () : memref<512xf32>
+    memref.copy %arg1, %memref_1 : memref<512xf32> to memref<512xf32>
+    %memref_2 = gpu.alloc  host_shared () : memref<512xf32>
+    gpu.launch_func  @test_kernel::@test_kernel blocks in (%c1, %c1, %c1) threads in (%c32, %c1, %c1) args(%memref : memref<512xf32>, %memref_1 : memref<512xf32>, %memref_2 : memref<512xf32>)
+    gpu.dealloc  %memref : memref<512xf32>
+    gpu.dealloc  %memref_1 : memref<512xf32>
+    return %memref_2 : memref<512xf32>
+  }
+  gpu.module @test_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
+    gpu.func @test_kernel(%arg0: memref<512xf32>, %arg1: memref<512xf32>, %arg2: memref<512xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %thread_id_x = gpu.thread_id x
+      %c16 = arith.constant 16 : index
+      cf.br ^bb1
+    ^bb1:
+      %t = arith.muli %thread_id_x, %c16 : index
+      %0 = xegpu.create_nd_tdesc %arg1[%t]: memref<512xf32> -> !xegpu.tensor_desc<16xf32>
+      %1 = xegpu.load_nd %0  : !xegpu.tensor_desc<16xf32> -> vector<16xf32>
+      %2 = xegpu.create_nd_tdesc %arg0[%t] : memref<512xf32> -> !xegpu.tensor_desc<16xf32>
+      %3 = xegpu.load_nd %2  : !xegpu.tensor_desc<16xf32> -> vector<16xf32>
+      %4 = arith.addf %3, %1 : vector<16xf32>
+      %5 = xegpu.create_nd_tdesc %arg2[%t] : memref<512xf32> -> !xegpu.tensor_desc<16xf32>
+      xegpu.store_nd %4, %5  : vector<16xf32>, !xegpu.tensor_desc<16xf32>
+      gpu.return
+    }
+  }
+  func.func @main() attributes {llvm.emit_c_interface} {
+    %c_gen_int = arith.constant 0 : i1
+    %cf_lower = arith.constant -1. : f32
+    %cf_upper = arith.constant 1. : f32
+
+    %A = memref.alloc() : memref<512xf32>
+    %A_random = memref.cast %A : memref<512xf32> to memref<*xf32>
+    call @fillResource1DRandomF32(%A_random, %cf_lower, %cf_upper, %c_gen_int) : (memref<*xf32>, f32, f32, i1) -> ()
+
+    %B = memref.alloc() : memref<512xf32>
+    %B_random = memref.cast %B : memref<512xf32> to memref<*xf32>
+    call @fillResource1DRandomF32(%B_random, %cf_lower, %cf_upper, %c_gen_int) : (memref<*xf32>, f32, f32, i1) -> ()
+
+    // calculate the result of C vector
+    %c512 = arith.constant 512 : index
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %ref = memref.alloc() : memref<512xf32>
+    scf.for %i = %c0 to %c512 step %c1 {
+      %a = memref.load %A[%i] : memref<512xf32>
+      %b = memref.load %B[%i] : memref<512xf32>
+      %c = arith.addf %a, %b : f32
+      memref.store %c, %ref[%i] : memref<512xf32>
+    }
+
+    %C = call @test(%A, %B) : (memref<512xf32>, memref<512xf32>) -> memref<512xf32>
+
+    %C_cast = memref.cast %C : memref<512xf32> to memref<*xf32>
+    %ref_cast = memref.cast %ref : memref<512xf32> to memref<*xf32>
+    call @printMemrefF32(%ref_cast) : (memref<*xf32>) -> ()
+    call @printMemrefF32(%C_cast) : (memref<*xf32>) -> ()
+    // CHECK: [ALLCLOSE: TRUE]
+    call @printAllcloseF32(%ref_cast, %C_cast) : (memref<*xf32>, memref<*xf32>) -> ()
+    return
+  }
+  func.func private @printMemrefF32(memref<*xf32>) attributes {llvm.emit_c_interface}
+  func.func private @fillResource1DRandomF32(memref<*xf32>, f32, f32, i1) attributes {llvm.emit_c_interface}
+  func.func private @printAllcloseF32(memref<*xf32>, memref<*xf32>) attributes {llvm.emit_c_interface}
+}


### PR DESCRIPTION
…egpu.create_nd_tdesc.

Add support for dynamic memref and i64/i32 source types for xegpu.create_nd_tdesc. Add generic interface to get the strides from the xegpu.create_nd_tdesc op. Use XeGPU interface to get strides.

Please review these guidelines to help with the review process:
- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [x] Have you organized your commits logically and ensured each can be built by itself?
