### PR TITLE
[XeGPUToVC] Encode block width and height using i16 for 2d.ugm

### DIFF
--- a/lib/Conversion/XeGPUToVC/LSCPatterns.cpp
+++ b/lib/Conversion/XeGPUToVC/LSCPatterns.cpp
@@ -634,11 +634,11 @@ static func::CallOp gen2DBlockIntrinsicCall(
   // arg2: i8, Number of blocks
   auto nBlks = i8_val(nblocks);
 
-  // arg3: i8, block width (in elements)
-  auto blkW = i8_val(blockShape[1]);
+  // arg3: i16, block width (in elements)
+  auto blkW = i16_val(blockShape[1]);
 
-  // arg4: i8, block height
-  auto blkH = i8_val(blockShape[0]);
+  // arg4: i16, block height
+  auto blkH = i16_val(blockShape[0]);
 
   // arg5: payload from parameter
 

--- a/test/Conversion/XeGPUToVC/gemm-scf.mlir
+++ b/test/Conversion/XeGPUToVC/gemm-scf.mlir
@@ -36,10 +36,10 @@ module @gemm attributes {gpu.container_module} {
       //LSC: %[[c0_i8:.*]] = arith.constant 0 : i8
       //LSC: %[[r13:.*]] = vector.from_elements %[[c0_i8]], %[[c0_i8]] : vector<2xi8>
       //LSC: %[[c1_i8:.*]] = arith.constant 1 : i8
-      //LSC: %[[c16_i8:.*]] = arith.constant 16 : i8
-      //LSC: %[[c8_i8:.*]] = arith.constant 8 : i8
+      //LSC: %[[c16_i16:.*]] = arith.constant 16 : i16
+      //LSC: %[[c8_i16:.*]] = arith.constant 8 : i16
       //LSC: %[[c0_i32:.*]] = arith.constant 0 : i32
-      //LSC: %[[CVALUE:.*]] = func.call @llvm.genx.lsc.load.2d.ugm.desc.v128f32.v2i8(%[[true]], %[[r13]], %[[c1_i8]], %[[c16_i8]], %[[c8_i8]], %[[r12]], %[[c0_i32]], %[[c0_i32]], %[[cst_0]]) : (i1, vector<2xi8>, i8, i8, i8, vector<16xi32>, i32, i32, vector<128xf32>) -> vector<128xf32>
+      //LSC: %[[CVALUE:.*]] = func.call @llvm.genx.lsc.load.2d.ugm.desc.v128f32.v2i8(%[[true]], %[[r13]], %[[c1_i8]], %[[c16_i16]], %[[c8_i16]], %[[r12]], %[[c0_i32]], %[[c0_i32]], %[[cst_0]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, vector<128xf32>) -> vector<128xf32>
       %5 = xegpu.load_nd %4  : !xegpu.tensor_desc<8x16xf32> -> vector<8x16xf32>
 
       // CHECK: %[[SCF_RESULT:.*]] = scf.for {{.*}} iter_args(%[[arg4:.*]] = %[[CVALUE]]) -> (vector<128xf32>)
@@ -73,11 +73,11 @@ module @gemm attributes {gpu.container_module} {
         %8 = xegpu.create_nd_tdesc %arg1[%arg3, %3] : memref<1016x1016xf16> -> !xegpu.tensor_desc<16x16xf16>
 
         //LSC: %[[cst_3:.*]] = arith.constant dense<0.000000e+00> : vector<128xf16>
-        //LSC: %[[r39:.*]] = func.call @llvm.genx.lsc.load.2d.ugm.desc.v128f16.v2i8(%[[true]], %[[r13]], %[[c1_i8]], %[[c16_i8]], %[[c8_i8]], %[[r27]], %[[c0_i32]], %[[c0_i32]], %[[cst_3]]) : (i1, vector<2xi8>, i8, i8, i8, vector<16xi32>, i32, i32, vector<128xf16>) -> vector<128xf16>
+        //LSC: %[[r39:.*]] = func.call @llvm.genx.lsc.load.2d.ugm.desc.v128f16.v2i8(%[[true]], %[[r13]], %[[c1_i8]], %[[c16_i16]], %[[c8_i16]], %[[r27]], %[[c0_i32]], %[[c0_i32]], %[[cst_3]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, vector<128xf16>) -> vector<128xf16>
         %9 = xegpu.load_nd %7 : !xegpu.tensor_desc<8x16xf16> -> vector<8x16xf16>
 
         //LSC: %[[cst_4:.*]] = arith.constant dense<0.000000e+00> : vector<256xf16>
-        //LSC: %[[r42:.*]] = func.call @llvm.genx.lsc.load.2d.ugm.desc.vnni.v256f16.v2i8(%[[true]], %[[r13]], %[[c1_i8]], %[[c16_i8]], %[[c16_i8]], %[[r36]], %[[c0_i32]], %[[c0_i32]], %[[cst_4]]) : (i1, vector<2xi8>, i8, i8, i8, vector<16xi32>, i32, i32, vector<256xf16>) -> vector<256xf16>
+        //LSC: %[[r42:.*]] = func.call @llvm.genx.lsc.load.2d.ugm.desc.vnni.v256f16.v2i8(%[[true]], %[[r13]], %[[c1_i8]], %[[c16_i16]], %[[c16_i16]], %[[r36]], %[[c0_i32]], %[[c0_i32]], %[[cst_4]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, vector<256xf16>) -> vector<256xf16>
         %10 = xegpu.load_nd %8 {packed} : !xegpu.tensor_desc<16x16xf16> -> vector<8x16x2xf16>
 
         //CHECK: %[[r43:.*]] = vector.bitcast %[[r39]] : vector<128xf16> to vector<64xi32>
@@ -90,7 +90,7 @@ module @gemm attributes {gpu.container_module} {
         scf.yield %11 : vector<8x16xf32>
       }
 
-      // LSC: func.call @llvm.genx.lsc.store.2d.ugm.desc.v2i8.v128f32(%[[true]], %[[r13]], %[[c1_i8]], %[[c16_i8]], %[[c8_i8]], %[[r12]], %[[c0_i32]], %[[c0_i32]], %[[SCF_RESULT]]) : (i1, vector<2xi8>, i8, i8, i8, vector<16xi32>, i32, i32, vector<128xf32>) -> ()
+      // LSC: func.call @llvm.genx.lsc.store.2d.ugm.desc.v2i8.v128f32(%[[true]], %[[r13]], %[[c1_i8]], %[[c16_i16]], %[[c8_i16]], %[[r12]], %[[c0_i32]], %[[c0_i32]], %[[SCF_RESULT]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, vector<128xf32>) -> ()
       xegpu.store_nd %6, %4 : vector<8x16xf32>, !xegpu.tensor_desc<8x16xf32>
       gpu.return
     }

--- a/test/Conversion/XeGPUToVC/load_nd.mlir
+++ b/test/Conversion/XeGPUToVC/load_nd.mlir
@@ -27,9 +27,9 @@ module @gemm attributes {gpu.container_module} {
       //LSC: %[[c0_i8:.*]] = arith.constant 0 : i8
       //LSC: %[[r9:.*]] = vector.from_elements %[[c0_i8]], %[[c0_i8]] : vector<2xi8>
       //LSC: %[[c1_i8:.*]] = arith.constant 1 : i8
-      //LSC: %[[c16_i8:.*]] = arith.constant 16 : i8
-      //LSC: %[[c8_i8:.*]] = arith.constant 8 : i8
-      //LSC: %[[r10:.*]] = func.call @llvm.genx.lsc.load.2d.ugm.desc.v128f16.v2i8(%[[true]], %[[r9]], %[[c1_i8]], %[[c16_i8]], %[[c8_i8]], %[[r8]], %[[c0_i32]], %[[c0_i32]], %[[cst_0]]) : (i1, vector<2xi8>, i8, i8, i8, vector<16xi32>, i32, i32, vector<128xf16>) -> vector<128xf16>
+      //LSC: %[[c16_i16:.*]] = arith.constant 16 : i16
+      //LSC: %[[c8_i16:.*]] = arith.constant 8 : i16
+      //LSC: %[[r10:.*]] = func.call @llvm.genx.lsc.load.2d.ugm.desc.v128f16.v2i8(%[[true]], %[[r9]], %[[c1_i8]], %[[c16_i16]], %[[c8_i16]], %[[r8]], %[[c0_i32]], %[[c0_i32]], %[[cst_0]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, vector<128xf16>) -> vector<128xf16>
       %1 = xegpu.load_nd %0 : !xegpu.tensor_desc<8x16xf16> -> vector<8x16xf16>
       // CHECK: gpu.return
       gpu.return
@@ -59,9 +59,9 @@ module @gemm attributes {gpu.container_module} {
       //LSC: %[[c0_i8:.*]] = arith.constant 0 : i8
       //LSC: %[[r9:.*]] = vector.from_elements %[[c0_i8]], %[[c0_i8]] : vector<2xi8>
       //LSC: %[[c1_i8:.*]] = arith.constant 1 : i8
-      //LSC: %[[c16_i8:.*]] = arith.constant 16 : i8
-      //LSC: %[[c8_i8:.*]] = arith.constant 8 : i8
-      //LSC: %[[r10:.*]] = func.call @llvm.genx.lsc.load.2d.ugm.desc.vnni.v128f16.v2i8(%[[true]], %[[r9]], %[[c1_i8]], %[[c16_i8]], %[[c8_i8]], %[[r8]], %[[c0_i32]], %[[c0_i32]], %[[cst_0]]) : (i1, vector<2xi8>, i8, i8, i8, vector<16xi32>, i32, i32, vector<128xf16>) -> vector<128xf16>
+      //LSC: %[[c16_i16:.*]] = arith.constant 16 : i16
+      //LSC: %[[c8_i16:.*]] = arith.constant 8 : i16
+      //LSC: %[[r10:.*]] = func.call @llvm.genx.lsc.load.2d.ugm.desc.vnni.v128f16.v2i8(%[[true]], %[[r9]], %[[c1_i8]], %[[c16_i16]], %[[c8_i16]], %[[r8]], %[[c0_i32]], %[[c0_i32]], %[[cst_0]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, vector<128xf16>) -> vector<128xf16>
       %1 = xegpu.load_nd %0 <{packed}> : !xegpu.tensor_desc<8x16xf16> -> vector<4x16x2xf16>
       // CHECK: gpu.return
       gpu.return
@@ -93,9 +93,9 @@ module @gemm attributes {gpu.container_module} {
       //LSC: %[[c0_i8:.*]] = arith.constant 0 : i8
       //LSC: %[[r9:.*]] = vector.from_elements %c0_i8, %c0_i8 : vector<2xi8>
       //LSC: %[[c1_i8:.*]] = arith.constant 1 : i8
-      //LSC: %[[c16_i8:.*]] = arith.constant 16 : i8
-      //LSC: %[[c8_i8:.*]] = arith.constant 8 : i8
-      //LSC: %[[r10:.*]] = func.call @llvm.genx.lsc.load.2d.ugm.desc.v128f16.v2i8(%[[true]], %[[r9]], %[[c1_i8]], %[[c16_i8]], %[[c8_i8]], %[[r8]], %[[c0_i32]], %[[c0_i32]], %[[cst_0]]) : (i1, vector<2xi8>, i8, i8, i8, vector<16xi32>, i32, i32, vector<128xf16>) -> vector<128xf16>
+      //LSC: %[[c16_i16:.*]] = arith.constant 16 : i16
+      //LSC: %[[c8_i16:.*]] = arith.constant 8 : i16
+      //LSC: %[[r10:.*]] = func.call @llvm.genx.lsc.load.2d.ugm.desc.v128f16.v2i8(%[[true]], %[[r9]], %[[c1_i8]], %[[c16_i16]], %[[c8_i16]], %[[r8]], %[[c0_i32]], %[[c0_i32]], %[[cst_0]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, vector<128xf16>) -> vector<128xf16>
       %1 = xegpu.load_nd %0 : !xegpu.tensor_desc<8x16xf16> -> vector<8x16xf16>
       // CHECK: gpu.return
       gpu.return
@@ -148,9 +148,9 @@ module @gemm attributes {gpu.container_module} {
       //LSC: %[[c0_i8:.*]] = arith.constant 0 : i8
       //LSC: %[[r9:.*]] = vector.from_elements %c0_i8, %c0_i8 : vector<2xi8>
       //LSC: %[[c1_i8:.*]] = arith.constant 1 : i8
-      //LSC: %[[c16_i8:.*]] = arith.constant 16 : i8
-      //LSC: %[[c8_i8:.*]] = arith.constant 8 : i8
-      //LSC: %[[r10:.*]] = func.call @llvm.genx.lsc.load.2d.ugm.desc.v128f16.v2i8(%[[true]], %[[r9]], %[[c1_i8]], %[[c16_i8]], %[[c8_i8]], %[[r8]], %[[c0_i32]], %[[c0_i32]], %[[cst_0]]) : (i1, vector<2xi8>, i8, i8, i8, vector<16xi32>, i32, i32, vector<128xf16>) -> vector<128xf16>
+      //LSC: %[[c16_i16:.*]] = arith.constant 16 : i16
+      //LSC: %[[c8_i16:.*]] = arith.constant 8 : i16
+      //LSC: %[[r10:.*]] = func.call @llvm.genx.lsc.load.2d.ugm.desc.v128f16.v2i8(%[[true]], %[[r9]], %[[c1_i8]], %[[c16_i16]], %[[c8_i16]], %[[r8]], %[[c0_i32]], %[[c0_i32]], %[[cst_0]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, vector<128xf16>) -> vector<128xf16>
       %load_2d = xegpu.load_nd %tdesc_2d : !xegpu.tensor_desc<8x16xf16> -> vector<8x16xf16>
       gpu.return
     }

--- a/test/Conversion/XeGPUToVC/prefetchnd.mlir
+++ b/test/Conversion/XeGPUToVC/prefetchnd.mlir
@@ -28,7 +28,7 @@ module @gemm attributes {gpu.container_module} {
       //CHECK: %[[r8:.*]] = vector.insert %[[c1807_i32]], %[[r7]] [7] : i32 into vector<16xi32>
       %0 = xegpu.create_nd_tdesc %arg0[0, 0] : memref<8x16xf16> -> !xegpu.tensor_desc<8x16xf16>
 
-      //CHECK: %[[intptr_0:.*]] = memref.extract_aligned_pointer_as_index %arg1 : memref<16x16xf16> -> index
+      //CHECK: %[[intptr_0:.*]] = memref.extract_aligned_pointer_as_index %{{.*}} : memref<16x16xf16> -> index
       //CHECK: %[[r9:.*]] = arith.index_castui %[[intptr_0]] : index to i64
       //CHECK: %[[r10:.*]] = vector.insert %[[r9]], %[[cst]] [0] : i64 into vector<8xi64>
       //CHECK: %[[r11:.*]] = vector.bitcast %[[r10]] : vector<8xi64> to vector<16xi32>
@@ -60,19 +60,19 @@ module @gemm attributes {gpu.container_module} {
       //LSC: %[[c0_i8:.*]] = arith.constant 0 : i8
       //LSC: %[[r27:.*]] = vector.from_elements %[[c0_i8]], %[[c0_i8]] : vector<2xi8>
       //LSC: %[[c1_i8:.*]] = arith.constant 1 : i8
-      //LSC: %[[c16_i8:.*]] = arith.constant 16 : i8
-      //LSC: %[[c8_i8:.*]] = arith.constant 8 : i8
-      //LSC: func.call @llvm.genx.lsc.prefetch.2d.ugm.desc.v2i8(%[[true]], %[[r27]], %[[c1_i8]], %[[c16_i8]], %[[c8_i8]], %[[r8]], %[[c0_i32]], %[[c0_i32]], %[[cst_2]]) : (i1, vector<2xi8>, i8, i8, i8, vector<16xi32>, i32, i32, f16) -> ()
-      //LSC: func.call @llvm.genx.lsc.prefetch.2d.ugm.desc.v2i8(%[[true]], %[[r27]], %[[c1_i8]], %[[c16_i8]], %[[c16_i8]], %[[r17]], %[[c0_i32]], %[[c0_i32]], %[[cst_2]]) : (i1, vector<2xi8>, i8, i8, i8, vector<16xi32>, i32, i32, f16) -> ()
+      //LSC: %[[c16_i16:.*]] = arith.constant 16 : i16
+      //LSC: %[[c8_i16:.*]] = arith.constant 8 : i16
+      //LSC: func.call @llvm.genx.lsc.prefetch.2d.ugm.desc.v2i8(%[[true]], %[[r27]], %[[c1_i8]], %[[c16_i16]], %[[c8_i16]], %[[r8]], %[[c0_i32]], %[[c0_i32]], %[[cst_2]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, f16) -> ()
+      //LSC: func.call @llvm.genx.lsc.prefetch.2d.ugm.desc.v2i8(%[[true]], %[[r27]], %[[c1_i8]], %[[c16_i16]], %[[c16_i16]], %[[r17]], %[[c0_i32]], %[[c0_i32]], %[[cst_2]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, f16) -> ()
       xegpu.prefetch_nd %0 : !xegpu.tensor_desc<8x16xf16>
       xegpu.prefetch_nd %1 : !xegpu.tensor_desc<16x16xf16>
 
       //LSC: %[[cst_3:.*]] = arith.constant dense<0.000000e+00> : vector<128xf16>
-      //LSC: %[[A:.*]] = func.call @llvm.genx.lsc.load.2d.ugm.desc.v128f16.v2i8(%[[true]], %[[r27]], %[[c1_i8]], %[[c16_i8]], %[[c8_i8]], %[[r8]], %[[c0_i32]], %[[c0_i32]], %[[cst_3]]) : (i1, vector<2xi8>, i8, i8, i8, vector<16xi32>, i32, i32, vector<128xf16>) -> vector<128xf16>
+      //LSC: %[[A:.*]] = func.call @llvm.genx.lsc.load.2d.ugm.desc.v128f16.v2i8(%[[true]], %[[r27]], %[[c1_i8]], %[[c16_i16]], %[[c8_i16]], %[[r8]], %[[c0_i32]], %[[c0_i32]], %[[cst_3]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, vector<128xf16>) -> vector<128xf16>
       %3 = xegpu.load_nd %0 : !xegpu.tensor_desc<8x16xf16> -> vector<8x16xf16>
 
       //LSC: %[[cst_4:.*]] = arith.constant dense<0.000000e+00> : vector<256xf16>
-      //LSC: %[[B:.*]] = func.call @llvm.genx.lsc.load.2d.ugm.desc.vnni.v256f16.v2i8(%[[true]], %[[r27]], %[[c1_i8]], %[[c16_i8]], %[[c16_i8]], %[[r17]], %[[c0_i32]], %[[c0_i32]], %[[cst_4]]) : (i1, vector<2xi8>, i8, i8, i8, vector<16xi32>, i32, i32, vector<256xf16>) -> vector<256xf16>
+      //LSC: %[[B:.*]] = func.call @llvm.genx.lsc.load.2d.ugm.desc.vnni.v256f16.v2i8(%[[true]], %[[r27]], %[[c1_i8]], %[[c16_i16]], %[[c16_i16]], %[[r17]], %[[c0_i32]], %[[c0_i32]], %[[cst_4]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, vector<256xf16>) -> vector<256xf16>
       %4 = xegpu.load_nd %1 {packed} : !xegpu.tensor_desc<16x16xf16> -> vector<8x16x2xf16>
 
       //CHECK: %[[c134744586_i32:.*]] = arith.constant 134744586 : i32
@@ -81,7 +81,7 @@ module @gemm attributes {gpu.container_module} {
       //CHECK: %[[DPAS:.*]] = func.call @llvm.genx.dpas.nosrc0.v128f32.v128i32.v64i32(%[[r32]], %[[r31]], %[[c134744586_i32]]) : (vector<128xi32>, vector<64xi32>, i32) -> vector<128xf32>
       %5 = xegpu.dpas %3, %4 : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
 
-      //LSC: func.call @llvm.genx.lsc.store.2d.ugm.desc.v2i8.v128f32(%[[true]], %[[r27]], %[[c1_i8]], %[[c16_i8]], %[[c8_i8]], %[[r26]], %[[c0_i32]], %[[c0_i32]], %[[DPAS]]) : (i1, vector<2xi8>, i8, i8, i8, vector<16xi32>, i32, i32, vector<128xf32>) -> ()
+      //LSC: func.call @llvm.genx.lsc.store.2d.ugm.desc.v2i8.v128f32(%[[true]], %[[r27]], %[[c1_i8]], %[[c16_i16]], %[[c8_i16]], %[[r26]], %[[c0_i32]], %[[c0_i32]], %[[DPAS]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, vector<128xf32>) -> ()
       xegpu.store_nd %5, %2 : vector<8x16xf32>, !xegpu.tensor_desc<8x16xf32>
       //CHECK: gpu.return
       gpu.return

--- a/test/Conversion/XeGPUToVC/store_nd.mlir
+++ b/test/Conversion/XeGPUToVC/store_nd.mlir
@@ -28,9 +28,9 @@ module @gemm attributes {gpu.container_module} {
       //LSC: %[[c0_i8:.*]] = arith.constant 0 : i8
       //LSC: %[[r9:.*]] = vector.from_elements %c0_i8, %c0_i8 : vector<2xi8>
       //LSC: %[[c1_i8:.*]] = arith.constant 1 : i8
-      //LSC: %[[c16_i8:.*]] = arith.constant 16 : i8
-      //LSC: %[[c8_i8:.*]] = arith.constant 8 : i8
-      //LSC: func.call @llvm.genx.lsc.store.2d.ugm.desc.v2i8.v128f16(%[[true]], %[[r9]], %[[c1_i8]], %[[c16_i8]], %[[c8_i8]], %[[r8]], %[[c0_i32]], %[[c0_i32]], %[[data]]) : (i1, vector<2xi8>, i8, i8, i8, vector<16xi32>, i32, i32, vector<8x16xf16>) -> ()
+      //LSC: %[[c16_i16:.*]] = arith.constant 16 : i16
+      //LSC: %[[c8_i16:.*]] = arith.constant 8 : i16
+      //LSC: func.call @llvm.genx.lsc.store.2d.ugm.desc.v2i8.v128f16(%[[true]], %[[r9]], %[[c1_i8]], %[[c16_i16]], %[[c8_i16]], %[[r8]], %[[c0_i32]], %[[c0_i32]], %[[data]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, vector<8x16xf16>) -> ()
       xegpu.store_nd %c, %0 : vector<8x16xf16>, !xegpu.tensor_desc<8x16xf16>
       // CHECK: gpu.return
       gpu.return
@@ -87,9 +87,9 @@ module @gemm attributes {gpu.container_module} {
       //LSC: %c0_i8 = arith.constant 0 : i8
       //LSC: %9 = vector.from_elements %c0_i8, %c0_i8 : vector<2xi8>
       //LSC: %c1_i8 = arith.constant 1 : i8
-      //LSC: %c16_i8 = arith.constant 16 : i8
-      //LSC: %c8_i8 = arith.constant 8 : i8
-      //LSC: func.call @llvm.genx.lsc.store.2d.ugm.desc.v2i8.v128f16(%true, %9, %c1_i8, %c16_i8, %c8_i8, %8, %c0_i32, %c0_i32, %cst) : (i1, vector<2xi8>, i8, i8, i8, vector<16xi32>, i32, i32, vector<8x16xf16>) -> ()
+      //LSC: %c16_i16 = arith.constant 16 : i16
+      //LSC: %c8_i16 = arith.constant 8 : i16
+      //LSC: func.call @llvm.genx.lsc.store.2d.ugm.desc.v2i8.v128f16(%true, %9, %c1_i8, %c16_i16, %c8_i16, %8, %c0_i32, %c0_i32, %cst) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, vector<8x16xf16>) -> ()
       xegpu.store_nd %c2, %tdesc_2d : vector<8x16xf16>, !xegpu.tensor_desc<8x16xf16>
       gpu.return
     }


### PR DESCRIPTION
As described by the tile, replacing i8 with i16 for width and height parameters of 2d.ugm instrinsics

Please review these guidelines to help with the review process:
- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [ ] Have you organized your commits logically and ensured each can be built by itself?
