### PR TITLE
[NDArray] Bugfix for "ndarray.permute_dims" by adding "bufferization.clone"

### DIFF
--- a/include/imex/Utils/PassUtils.h
+++ b/include/imex/Utils/PassUtils.h
@@ -280,7 +280,8 @@ extern void printValsAsMemRef(::mlir::Location loc, ::mlir::OpBuilder &builder,
 // If this memref has a different shape than mrTyp, also creates a memref.cast
 extern ::mlir::Value createToMemRef(::mlir::Location loc,
                                     ::mlir::OpBuilder &builder,
-                                    ::mlir::Value input, ::mlir::Type toTyp);
+                                    ::mlir::Value input, ::mlir::Type toTyp,
+                                    bool clone = false);
 
 // broadcast 2 shapes into one according to the array-API
 template <typename V1, typename V2>

--- a/lib/Conversion/NDArrayToLinalg/NDArrayToLinalg.cpp
+++ b/lib/Conversion/NDArrayToLinalg/NDArrayToLinalg.cpp
@@ -1242,7 +1242,7 @@ struct PermuteDimsOpLowering
     if (!srcArType)
       return mlir::failure();
     auto srcMRType = srcArType.getMemRefType(srcTnsr);
-    auto srcMR = createToMemRef(loc, rewriter, srcTnsr, srcMRType);
+    auto srcMR = createToMemRef(loc, rewriter, srcTnsr, srcMRType, true);
 
     auto perm = ::mlir::AffineMapAttr::get(::mlir::AffineMap::getPermutationMap(
         adaptor.getAxes(), rewriter.getContext()));

--- a/test/Conversion/NDArrayToLinalg/NDArrayToLinalg.mlir
+++ b/test/Conversion/NDArrayToLinalg/NDArrayToLinalg.mlir
@@ -477,5 +477,6 @@ func.func @test_permute_dims(%arg0: !ndarray.ndarray<5x3x2xi32>) -> !ndarray.nda
 // CHECK-LABEL: @test_permute_dims
 // CHECK: [[V0:%.*]] = bufferization.to_tensor
 // CHECK: [[V1:%.*]] = bufferization.to_memref [[V0]]
-// CHECK: [[V2:%.*]] = memref.transpose [[V1]] (d0, d1, d2) -> (d2, d1, d0)
-// CHECK-NEXT: return [[V2]] : memref<2x3x5xi32, strided<[?, ?, ?], offset: ?>>
+// CHECK: [[V2:%.*]] = bufferization.clone [[V1]]
+// CHECK: [[V3:%.*]] = memref.transpose [[V2]] (d0, d1, d2) -> (d2, d1, d0)
+// CHECK-NEXT: return [[V3]] : memref<2x3x5xi32, strided<[?, ?, ?], offset: ?>>

--- a/test/imex-runner/ndarray-gpu.pp
+++ b/test/imex-runner/ndarray-gpu.pp
@@ -12,6 +12,7 @@ builtin.module(
     func.func(empty-tensor-to-alloc-tensor)
     one-shot-bufferize{bufferize-function-boundaries}
     imex-remove-temporaries
+    convert-bufferization-to-memref
     func.func(convert-linalg-to-parallel-loops)
     func.func(scf-parallel-loop-fusion)
 // GPU

--- a/test/imex-runner/ndarray.pp
+++ b/test/imex-runner/ndarray.pp
@@ -11,6 +11,7 @@ builtin.module(
     func.func(empty-tensor-to-alloc-tensor)
     one-shot-bufferize{bufferize-function-boundaries}
     imex-remove-temporaries
+    convert-bufferization-to-memref
     func.func(convert-linalg-to-parallel-loops)
     func.func(scf-parallel-loop-fusion)
     drop-regions


### PR DESCRIPTION
Since "ndarray.permute_dims" always returns a new ndarray, I added "bufferization.clone" after converting to memref.