### PR TITLE
[XeGPUToVC] Add target based legality check for MathToVC patterns ear…

### DIFF
--- a/lib/Conversion/XeGPUToVC/CMakeLists.txt
+++ b/lib/Conversion/XeGPUToVC/CMakeLists.txt
@@ -11,6 +11,7 @@ add_imex_conversion_library(IMEXXeGPUToVC
   #LINK_COMPONENTS
 
   LINK_LIBS PUBLIC
+  IMEXMathToVC
   MLIRIR
   MLIRSupport
   # MLIRTransforms

--- a/lib/Conversion/XeGPUToVC/XeGPUToVC.cpp
+++ b/lib/Conversion/XeGPUToVC/XeGPUToVC.cpp
@@ -865,6 +865,9 @@ struct XeGPUToVCPass : public imex::impl::ConvertXeGPUToVCBase<XeGPUToVCPass> {
     RewritePatternSet patterns(&getContext());
     ConversionTarget target(getContext());
 
+    // Configure the legality of the conversion target for MathToVC patterns.
+    configureMathToVCConversionLegality(target);
+
     target.addLegalDialect<func::FuncDialect, arith::ArithDialect,
                            memref::MemRefDialect, vector::VectorDialect>();
     target.addIllegalDialect<xegpu::XeGPUDialect>();
@@ -959,8 +962,6 @@ struct XeGPUToVCPass : public imex::impl::ConvertXeGPUToVCBase<XeGPUToVCPass> {
     populateLoadStoreLSCPatterns(typeConverter, patterns);
 
     populateMathToVCPatterns(typeConverter, patterns);
-
-    configureMathToVCConversionLegality(target);
 
     if (failed(applyPartialConversion(m, target, std::move(patterns))))
       return signalPassFailure();


### PR DESCRIPTION
…ly in the pass.

Configuring the legality for MathToVC pass has to be done early. Since, XeGPUToVC makes some arith ops dynamically legal in the target environment. Making the whole dialect legal (needed for MathToVC) has to be done before conditionally making some ops legal.

Also add MathToVC as the link target for the XeGPUToVC pass.

Please review these guidelines to help with the review process:
- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [ ] Have you organized your commits logically and ensured each can be built by itself?
