### PR TITLE
[XeGPUToVC] Fix 'offset' computation for 'base address + offset' calc…

### DIFF
--- a/include/imex/Utils/VCUtils.h
+++ b/include/imex/Utils/VCUtils.h
@@ -15,6 +15,7 @@
 #ifndef VC_UTILS_H
 #define VC_UTILS_H
 
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -64,6 +65,11 @@ using namespace mlir;
 #define dense_vector_val(attr, vecTy)                                          \
   rewriter.create<arith::ConstantOp>(loc, DenseElementsAttr::get(vecTy, attr))
 
+#define divi(a, b) rewriter.createOrFold<arith::DivSIOp>(loc, a, b)
+#define muli(a, b) rewriter.createOrFold<arith::MulIOp>(loc, a, b)
+#define addi(a, b) rewriter.createOrFold<arith::AddIOp>(loc, a, b)
+#define subi(a, b) rewriter.createOrFold<arith::SubIOp>(loc, a, b)
+
 /// This function adds necessary Func Declaration for Imported VC-intrinsics
 /// functions and sets linkage attributes to those declaration
 /// to support SPIRV compilation
@@ -78,4 +84,10 @@ func::CallOp createFuncCall(PatternRewriter &rewriter, Location loc,
                             StringRef funcName, TypeRange resultType,
                             ValueRange operands, bool emitCInterface);
 
+Value getOffsetInUnitOfBytes(PatternRewriter &rewriter, Location loc,
+                             Type addrTy, Value offset, unsigned eTyBitWidth);
+
+Value getVecOffsetInUnitOfBytes(PatternRewriter &rewriter, Location loc,
+                                unsigned vecSize, Type addrTy, Value offset,
+                                unsigned eTyBitWidth);
 #endif // XEGPU_VC_UTILS_H

--- a/lib/Conversion/XeGPUToVC/LSCPatterns.cpp
+++ b/lib/Conversion/XeGPUToVC/LSCPatterns.cpp
@@ -727,9 +727,8 @@ auto getElemBitWidth = [](TensorDescType tdescTy) -> unsigned {
 };
 
 auto isLowPrecision = [](TensorDescType tdescTy) -> bool {
-  // Note: Handling for sub 8bit types is unclear so report as false
   auto width = getElemBitWidth(tdescTy);
-  return width < 32 && width >= 8;
+  return width < 32 && width >= 4;
 };
 
 auto getScaled1DTdesc =

--- a/lib/Utils/VCUtils.cpp
+++ b/lib/Utils/VCUtils.cpp
@@ -77,3 +77,30 @@ func::CallOp createFuncCall(PatternRewriter &rewriter, Location loc,
       true /*isVectorComputeFunctionINTEL=true*/, emitCInterface);
   return rewriter.create<func::CallOp>(loc, fn, resultType, operands);
 }
+
+Value getOffsetInUnitOfBytes(PatternRewriter &rewriter, Location loc,
+                             Type addrTy, Value offset, unsigned eTyBitWidth) {
+  if (eTyBitWidth >= 8) {
+    unsigned eTyBytes = eTyBitWidth / 8;
+    Value factor = integer_val(eTyBytes, addrTy);
+    return muli(offset, factor);
+  } else {
+    Value eight = integer_val(8, addrTy);
+    Value bw = integer_val(eTyBitWidth, addrTy);
+    return divi(muli(offset, bw), eight);
+  }
+}
+
+Value getVecOffsetInUnitOfBytes(PatternRewriter &rewriter, Location loc,
+                                unsigned vecSize, Type addrTy, Value offset,
+                                unsigned eTyBitWidth) {
+  if (eTyBitWidth >= 8) {
+    unsigned eTyBytes = eTyBitWidth / 8;
+    Value factor = dense_vector_int_val(eTyBytes, addrTy, vecSize);
+    return muli(offset, factor);
+  } else {
+    Value eight = dense_vector_int_val(8, addrTy, vecSize);
+    Value bw = dense_vector_int_val(eTyBitWidth, addrTy, vecSize);
+    return divi(muli(offset, bw), eight);
+  }
+}


### PR DESCRIPTION
…ulation

Current implementation of computing 'offset' fails for sub-byte types. This patch generalizes the implementation of 'offset' computation so that it works even for sub-byte types.

Please review these guidelines to help with the review process:
- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [ ] Have you organized your commits logically and ensured each can be built by itself?
