### PR TITLE
[XeTile][WgToSG] Improve the implementation for data distribution. 

### DIFF
--- a/include/imex/Dialect/XeTile/IR/XeTileOps.td
+++ b/include/imex/Dialect/XeTile/IR/XeTileOps.td
@@ -362,6 +362,8 @@ def XeTile_StoreTileOp : XeTile_Op<"store_tile", [
     let assemblyFormat = [{
         $value`,`` `$tile attr-dict `:` qualified(type($value)) `,` qualified(type($tile))
     }];
+
+    let hasVerifier = 1;
 }
 
 def XeTile_PrefetchTileOp : XeTile_Op<"prefetch_tile", []> {
@@ -569,6 +571,8 @@ def XeTile_ConvertLayoutOp: XeTile_Op<"convert_layout", [AllTypesMatch<["source"
     let assemblyFormat = [{
         $source attr-dict `:` type($source)
     }];
+
+    let hasVerifier = 1;
 }
 
 def XeTile_LoadGatherOp: XeTile_Op<"load", [AllElementTypesMatch<["tile", "value"]>,

--- a/lib/Dialect/XeTile/Transforms/WgToSg.cpp
+++ b/lib/Dialect/XeTile/Transforms/WgToSg.cpp
@@ -787,10 +787,14 @@ class WGToSGXeTileConvertLayout
     auto dstMapDimY = createIndexConstant(indexType, dstSgLayout[1]);
     auto loadSgIdX = rewriter.create<mlir::index::DivUOp>(loc, sgId, dstMapDimY);
     auto loadSgIdY =  rewriter.create<mlir::index::RemUOp>(loc, sgId, dstMapDimY);
-    auto loadOffsetX = rewriter.createOrFold<mlir::index::MulOp>(
+    mlir::Value loadOffsetX = rewriter.createOrFold<mlir::index::MulOp>(
                 loc, loadSgIdX, createIndexConstant(indexType, dstMapSgData[0]));
-    auto loadOffsetY = rewriter.createOrFold<mlir::index::MulOp>(
+    mlir::Value loadOffsetY = rewriter.createOrFold<mlir::index::MulOp>(
                 loc, loadSgIdY, createIndexConstant(indexType, dstMapSgData[1]));
+    loadOffsetX = rewriter.createOrFold<mlir::index::RemUOp>(
+                loc, loadOffsetX, createIndexConstant(indexType, resShape[0]));
+    loadOffsetY = rewriter.createOrFold<mlir::index::RemUOp>(
+                loc, loadOffsetY, createIndexConstant(indexType, resShape[1]));
     auto loadInitTileOp = rewriter.create<xetile::InitTileOp>(
           loc, dstTileTy, viewOp, llvm::ArrayRef<mlir::OpFoldResult>({loadOffsetX, loadOffsetY}));
     //TODO: Set up cache attributes

--- a/test/Dialect/XeTile/IR/ops.mlir
+++ b/test/Dialect/XeTile/IR/ops.mlir
@@ -9,6 +9,10 @@
 #tile_attr = #xetile.tile_attr<wg_map = #wg_map, sg_map = #sg_map>
 #tile_attr_w_order = #xetile.tile_attr<order = [0, 1]>
 
+#st_sg_map = #xetile.sg_map<wi_layout = [2, 8], wi_data = [1, 2]>
+#st_wg_map = #xetile.wg_map<sg_layout = [4, 1], sg_data = [32, 128]>
+#st_tile_attr = #xetile.tile_attr<wg_map = #st_wg_map, sg_map = #st_sg_map>
+
 
 #wg_map_mma_a = #xetile.wg_map<sg_layout = [8, 4], sg_data = [32, 32]>
 #wg_map_mma_b = #xetile.wg_map<sg_layout = [8, 4], sg_data = [32, 64]>
@@ -185,7 +189,7 @@ func.func @test_load_tile(%src: !xetile.tile<64x32xf16>, %src1 : !xetile.tile<12
 // CHECK-LABEL: func @test_store_tile({{.*}}) {
 func.func @test_store_tile(%value1 : vector<64x32xf16>,
   %value2 : vector<8x4x8x16xf16>, %value3 : vector<128x128xf16>, %dst: !xetile.tile<64x32xf16>,
-  %dst1 : !xetile.tile<128x128xf16, #tile_attr>,
+  %dst1 : !xetile.tile<128x128xf16, #st_tile_attr>,
   %dst2 : !xetile.tile<64x32xf16, #tile_attr_w_order>) {
 
   // CHECK: xetile.store_tile
@@ -194,8 +198,8 @@ func.func @test_store_tile(%value1 : vector<64x32xf16>,
 
   // CHECK: xetile.store_tile
   // CHECK-SAME: vector<128x128xf16>, !xetile.tile<128x128xf16, #xetile.tile_attr<sg_map =
-  // CHECK-SAME: <wi_layout = [2, 8], wi_data = [1, 2]>, wg_map = <sg_layout = [2, 2], sg_data = [32, 128]>>>
-  xetile.store_tile %value3, %dst1 : vector<128x128xf16>, !xetile.tile<128x128xf16, #tile_attr>
+  // CHECK-SAME: <wi_layout = [2, 8], wi_data = [1, 2]>, wg_map = <sg_layout = [4, 1], sg_data = [32, 128]>>>
+  xetile.store_tile %value3, %dst1 : vector<128x128xf16>, !xetile.tile<128x128xf16, #st_tile_attr>
 
   // CHECK: xetile.store_tile
   // CHECK-SAME: vector<64x32xf16>, !xetile.tile<64x32xf16, #xetile.tile_attr<order = [0, 1]>>

--- a/test/Dialect/XeTile/IR/simple_gemm.mlir
+++ b/test/Dialect/XeTile/IR/simple_gemm.mlir
@@ -13,7 +13,7 @@
 #tile_attr_b = #xetile.tile_attr<wg_map = #wg_map_b, sg_map = #sg_map_b>
 
 #sg_map_c = #xetile.sg_map< wi_layout = [1, 16], wi_data = [1, 1]>
-#wg_map_c = #xetile.wg_map<sg_layout = [2, 2], sg_data = [32, 32]>
+#wg_map_c = #xetile.wg_map<sg_layout = [4, 4], sg_data = [32, 32]>
 #tile_attr_c = #xetile.tile_attr<wg_map = #wg_map_c, sg_map = #sg_map_c>
 
 // CHECK-LABEL: func @test_gemm({{.*}}) {
@@ -31,11 +31,11 @@ func.func @test_gemm(%A: memref<1024x1024xf16>, %B: memref<1024x1024xf16>, %C: m
   // intialize C tile and load it
   // CHECK: xetile.init_tile
   // CHECK-SAME: memref<1024x1024xf32> -> !xetile.tile<128x128xf32, #xetile.tile_attr<sg_map = <wi_layout = [1, 16],
-  // CHECK-SAME: wi_data = [1, 1]>, wg_map = <sg_layout = [2, 2], sg_data = [32, 32]>>>
+  // CHECK-SAME: wi_data = [1, 1]>, wg_map = <sg_layout = [4, 4], sg_data = [32, 32]>>>
   %c_init_tile = xetile.init_tile %C[%m, %n] : memref<1024x1024xf32> -> !xetile.tile<128x128xf32, #tile_attr_c>
   // CHECK:  xetile.load_tile
   // CHECK-SAME: : !xetile.tile<128x128xf32, #xetile.tile_attr<sg_map =
-  // CHECK-SAME: <wi_layout = [1, 16], wi_data = [1, 1]>, wg_map = <sg_layout = [2, 2], sg_data = [32, 32]>>> -> vector<128x128xf32>
+  // CHECK-SAME: <wi_layout = [1, 16], wi_data = [1, 1]>, wg_map = <sg_layout = [4, 4], sg_data = [32, 32]>>> -> vector<128x128xf32>
   %c_init_value = xetile.load_tile %c_init_tile : !xetile.tile<128x128xf32, #tile_attr_c> -> vector<128x128xf32>
   // initalize A and B tiles
   // CHECK: xetile.init_tile
@@ -80,7 +80,7 @@ func.func @test_gemm(%A: memref<1024x1024xf16>, %B: memref<1024x1024xf16>, %C: m
   // store the final accumulated C tile result back to memory
   // CHECK: xetile.store_tile
   // CHECK-SAME: vector<128x128xf32>, !xetile.tile<128x128xf32, #xetile.tile_attr<sg_map = <wi_layout = [1, 16],
-  // CHECK-SAME: wi_data = [1, 1]>, wg_map = <sg_layout = [2, 2], sg_data = [32, 32]>>>
+  // CHECK-SAME: wi_data = [1, 1]>, wg_map = <sg_layout = [4, 4], sg_data = [32, 32]>>>
   xetile.store_tile %out#2, %c_init_tile : vector<128x128xf32>, !xetile.tile<128x128xf32, #tile_attr_c>
   return
 }

--- a/test/Dialect/XeTile/Transforms/WgToSg/convert_layout.mlir
+++ b/test/Dialect/XeTile/Transforms/WgToSg/convert_layout.mlir
@@ -26,7 +26,9 @@ gpu.module @test_convert_layout{
     //CHECK: %[[R7:.*]] = index.mul %[[R5]], %[[c8]]
     //CHECK: %[[c256:.*]] = arith.constant 256 : index
     //CHECK: %[[R8:.*]] = index.mul %[[R6]], %[[c256]]
-    //CHECK: %[[INITTILEDSTMAP:.*]] = xetile.init_tile %[[SLMVIEW]][%[[R7]], %[[R8]]] : memref<256x256xf32, 3> -> !xetile.tile<8x256xf32, #xetile.tile_attr<memory_space = 3 : i32>>
+    //CHECK: %[[R9:.*]] = index.remu %[[R7]], %c256
+    //CHECK: %[[R10:.*]] = index.remu %[[R8]], %c256
+    //CHECK: %[[INITTILEDSTMAP:.*]] = xetile.init_tile %[[SLMVIEW]][%[[R9]], %[[R10]]] : memref<256x256xf32, 3> -> !xetile.tile<8x256xf32, #xetile.tile_attr<memory_space = 3 : i32>>
     //CHECK: %[[LOADTILE:.*]] = xetile.load_tile %[[INITTILEDSTMAP]] : !xetile.tile<8x256xf32, #xetile.tile_attr<memory_space = 3 : i32>> -> vector<8x256xf32>
 
     %cst = arith.constant {map = #xetile.wg_map<sg_layout = [8, 4], sg_data = [32, 64]>} dense<0.000000e+00> : vector<256x256xf32>

--- a/test/Dialect/XeTile/Transforms/WgToSg/round_robin.mlir
+++ b/test/Dialect/XeTile/Transforms/WgToSg/round_robin.mlir
@@ -1,12 +1,12 @@
 // RUN: imex-opt --split-input-file --xetile-wg-to-sg --cse %s -verify-diagnostics | FileCheck %s
 
-#wg_map_a = #xetile.wg_map<sg_layout = [2, 2], sg_data = [32, 128]>
+#wg_map_a = #xetile.wg_map<sg_layout = [4, 4], sg_data = [32, 128]>
 #tile_attr_a = #xetile.tile_attr<wg_map = #wg_map_a>
 
-#wg_map_b = #xetile.wg_map<sg_layout = [2, 2], sg_data = [128, 32]>
+#wg_map_b = #xetile.wg_map<sg_layout = [4, 4], sg_data = [128, 32]>
 #tile_attr_b = #xetile.tile_attr<wg_map = #wg_map_b>
 
-#wg_map_c = #xetile.wg_map<sg_layout = [2, 2], sg_data = [32, 32]>
+#wg_map_c = #xetile.wg_map<sg_layout = [4, 4], sg_data = [32, 32]>
 #tile_attr_c = #xetile.tile_attr<wg_map = #wg_map_c>
 
 
@@ -16,37 +16,28 @@ gpu.module @test_wg_to_sg_rr  {
         //CHECK: %[[c0:.*]] = arith.constant 0 : index
         //CHECK: %[[c128:.*]] = arith.constant 128 : index
         //CHECK: %[[c1024:.*]] = arith.constant 1024 : index
-        //CHECK: %[[R0:.*]] = gpu.block_id  x
-        //CHECK: %[[R1:.*]] = gpu.block_id  y
+        //CHECK: %[[block_id_x:.*]] = gpu.block_id  x
+        //CHECK: %[[block_id_y:.*]] = gpu.block_id  y
         %c0 = arith.constant 0 : index
         %c1 = arith.constant 1 : index
         %c128 = arith.constant 128 : index
         %c1024 = arith.constant 1024 : index
 
-        //CHECK: %[[R2:.*]] = arith.muli %[[R0]], %[[c128]] : index
-        //CHECK: %[[R3:.*]] = arith.muli %[[R1]], %[[c128]] : index
-        //CHECK: %[[R4:.*]] = gpu.subgroup_id : index
-        //CHECK: %[[c2:.*]] = arith.constant 2 : index
-        //CHECK: %[[c32:.*]] = arith.constant 32 : index
-        //CHECK: %[[R5:.*]] = index.divu %[[R4]], %[[c2]]
-        //CHECK: %[[R6:.*]] = index.remu %[[R4]], %[[c2]]
-        //CHECK: %[[R7:.*]] = index.add %[[R5]], %[[c0]]
+        //CHECK: %[[R0:.*]] = arith.muli %[[block_id_x]], %[[c128]] : index
+        //CHECK: %[[R1:.*]] = arith.muli %[[block_id_y]], %[[c128]] : index
+        //CHECK: %[[R2:.*]] = gpu.subgroup_id : index
         //CHECK: %[[c4:.*]] = arith.constant 4 : index
-        //CHECK: %[[R8:.*]] = index.remu %[[R7]], %[[c4]]
-        //CHECK: %[[R9:.*]] = index.mul %[[R8]], %[[c32]]
-        //CHECK: %[[R10:.*]] = index.add %[[R2]], %[[R9]]
-        //CHECK: %[[R11:.*]] = index.add %[[R5]], %[[c2]]
-        //CHECK: %[[R12:.*]] = index.remu %[[R11]], %[[c4]]
-        //CHECK: %[[R13:.*]] = index.mul %[[R12]], %[[c32]]
-        //CHECK: %[[R14:.*]] = index.add %[[R2]], %[[R13]]
-        //CHECK: %[[R15:.*]] = index.add %[[R6]], %[[c0]]
-        //CHECK: %[[R16:.*]] = index.remu %[[R15]], %[[c4]]
-        //CHECK: %[[R17:.*]] = index.mul %[[R16]], %[[c32]]
-        //CHECK: %[[R18:.*]] = index.add %[[R3]], %[[R17]]
-        //CHECK: %[[R19:.*]] = index.add %[[R6]], %[[c2]]
-        //CHECK: %[[R20:.*]] = index.remu %[[R19]], %[[c4]]
-        //CHECK: %[[R21:.*]] = index.mul %[[R20]], %[[c32]]
-        //CHECK: %[[R22:.*]] = index.add %[[R3]], %[[R21]]
+        //CHECK: %[[c32:.*]] = arith.constant 32 : index
+        //CHECK: %[[R3:.*]] = index.divu %[[R2]], %[[c4]]
+        //CHECK: %[[R4:.*]] = index.remu %[[R2]], %[[c4]]
+        //CHECK: %[[R5:.*]] = index.add %[[R3]], %[[c0]]
+        //CHECK: %[[R6:.*]] = index.remu %[[R5]], %[[c4]]
+        //CHECK: %[[R7:.*]] = index.mul %[[R6]], %[[c32]]
+        //CHECK: %[[R8:.*]] = index.add %[[R0]], %[[R7]]
+        //CHECK: %[[R9:.*]] = index.add %[[R4]], %[[c0]]
+        //CHECK: %[[R10:.*]] = index.remu %[[R9]], %[[c4]]
+        //CHECK: %[[R11:.*]] = index.mul %[[R10]], %[[c32]]
+        //CHECK: %[[R12:.*]] = index.add %[[R1]], %[[R11]]
 
         %block_id_x = gpu.block_id x
         %block_id_y = gpu.block_id y
@@ -54,86 +45,57 @@ gpu.module @test_wg_to_sg_rr  {
         %n = arith.muli %block_id_y, %c128 : index
 
 
-        //CHECK: %[[R23:.*]] = xetile.init_tile %[[arg2]][%[[R10]], %[[R18]]] : memref<1024x1024xf32> -> !xetile.tile<32x32xf32>
-        //CHECK: %[[R24:.*]] = xetile.init_tile %[[arg2]][%[[R10]], %[[R22]]] : memref<1024x1024xf32> -> !xetile.tile<32x32xf32>
-        //CHECK: %[[R25:.*]] = xetile.init_tile %[[arg2]][%[[R14]], %[[R18]]] : memref<1024x1024xf32> -> !xetile.tile<32x32xf32>
-        //CHECK: %[[R26:.*]] = xetile.init_tile %[[arg2]][%[[R14]], %[[R22]]] : memref<1024x1024xf32> -> !xetile.tile<32x32xf32>
+        //CHECK: %[[R13:.*]] = xetile.init_tile %[[arg2]][%[[R8]], %[[R12]]] : memref<1024x1024xf32> -> !xetile.tile<32x32xf32>
         %c_init_tile = xetile.init_tile %C[%m, %n] : memref<1024x1024xf32>
           -> !xetile.tile<128x128xf32, #tile_attr_c>
 
-        //CHECK: %[[R27:.*]] =  xetile.load_tile %[[R23]] : !xetile.tile<32x32xf32> -> vector<32x32xf32>
-        //CHECK: %[[R28:.*]] =  xetile.load_tile %[[R24]] : !xetile.tile<32x32xf32> -> vector<32x32xf32>
-        //CHECK: %[[R29:.*]] =  xetile.load_tile %[[R25]] : !xetile.tile<32x32xf32> -> vector<32x32xf32>
-        //CHECK: %[[R30:.*]] =  xetile.load_tile %[[R26]] : !xetile.tile<32x32xf32> -> vector<32x32xf32>
+        //CHECK: %[[R14:.*]] = xetile.load_tile %[[R13]] : !xetile.tile<32x32xf32> -> vector<32x32xf32>
         %c_init_value = xetile.load_tile %c_init_tile : !xetile.tile<128x128xf32, #tile_attr_c>
           -> vector<128x128xf32>
 
 
         //CHECK: %[[c1:.*]] = arith.constant 1 : index
-        //CHECK: %[[R31:.*]] = index.remu %[[R15]], %[[c1]]
-        //CHECK: %[[R32:.*]] = index.mul %[[R31]], %[[c128]]
-        //CHECK: %[[R33:.*]] = index.add %[[R32]], %[[c0]]
-        //CHECK: %[[R34:.*]] = xetile.init_tile %[[arg0]][%[[R10]], %[[R33]]] : memref<1024x1024xf16> -> !xetile.tile<32x128xf16>
-        //CHECK: %[[R35:.*]] = xetile.init_tile %[[arg0]][%[[R14]], %[[R33]]] : memref<1024x1024xf16> -> !xetile.tile<32x128xf16>
+        //CHECK: %[[R15:.*]] = index.remu %[[R9]], %[[c1]]
+        //CHECK: %[[R16:.*]] = index.mul %[[R15]], %[[c128]]
+        //CHECK: %[[R17:.*]] = index.add %[[R16]], %[[c0]]
+        //CHECK: %[[R18:.*]] = xetile.init_tile %[[arg0]][%[[R8]], %[[R17]]] : memref<1024x1024xf16> -> !xetile.tile<32x128xf16>
         %a_init_tile = xetile.init_tile %A[%m, %c0] : memref<1024x1024xf16>
           -> !xetile.tile<128x128xf16, #tile_attr_a>
 
-        //CHECK: %[[R36:.*]] = index.remu %[[R7]], %[[c1]]
-        //CHECK: %[[R37:.*]] = index.mul %[[R36]], %[[c128]]
-        //CHECK: %[[R38:.*]] = index.add %[[R37]], %[[c0]]
-        //CHECK: %[[R39:.*]] = xetile.init_tile %[[arg1]][%[[R38]], %[[R18]]] : memref<1024x1024xf16> -> !xetile.tile<128x32xf16>
-        //CHECK: %[[R40:.*]] = xetile.init_tile %[[arg1]][%[[R38]], %[[R22]]] : memref<1024x1024xf16> -> !xetile.tile<128x32xf16>
+        //CHECK: %[[R19:.*]] = index.remu %[[R5:.*]], %[[c1]]
+        //CHECK: %[[R20:.*]] = index.mul %[[R19:.*]], %[[c128:.*]]
+        //CHECK: %[[R21:.*]] = index.add %[[R20:.*]], %[[c0]]
+        //CHECK: %[[R22:.*]] = xetile.init_tile %[[arg1]][%[[R21]], %[[R12]]] : memref<1024x1024xf16> -> !xetile.tile<128x32xf16>
         %b_init_tile = xetile.init_tile %B[%c0, %n] : memref<1024x1024xf16>
           -> !xetile.tile<128x128xf16, #tile_attr_b>
 
-
-        //CHECK: %[[R41:.*]]:8 = scf.for %[[arg3:.*]] = %[[c0]] to %[[c1024]] step %[[c128]]
-        //CHECK-SAME: iter_args(%[[arg4:.*]] = %[[R34]], %[[arg5:.*]] = %[[R35]], %[[arg6:.*]] = %[[R39]],  %[[arg7:.*]] = %[[R40]], %[[arg8:.*]] = %[[R27]], %[[arg9:.*]] = %[[R28]], %[[arg10:.*]] = %[[R29]], %[[arg11:.*]] = %[[R30]])
-        //CHECK-SAME: -> (!xetile.tile<32x128xf16>, !xetile.tile<32x128xf16>, !xetile.tile<128x32xf16>, !xetile.tile<128x32xf16>, vector<32x32xf32>, vector<32x32xf32>, vector<32x32xf32>, vector<32x32xf32>)
+        //CHECK: %[[R23:.*]]:3 = scf.for %[[arg3:.*]] = %[[c0]] to %[[c1024]] step %[[c128]]
+        //CHECK-SAME: iter_args(%[[arg4:.*]] = %[[R18]], %[[arg5:.*]] = %[[R22]], %[[arg6:.*]] = %[[R14]])
+        //CHECK-SAME: -> (!xetile.tile<32x128xf16>, !xetile.tile<128x32xf16>, vector<32x32xf32>) {
         %out:3 = scf.for %k = %c0 to %c1024 step %c128
           iter_args(%a_tile = %a_init_tile, %b_tile = %b_init_tile, %c_value = %c_init_value)
           -> (!xetile.tile<128x128xf16, #tile_attr_a>,
               !xetile.tile<128x128xf16, #tile_attr_b>,
               vector<128x128xf32>) {
 
-          //CHECK: %[[R42:.*]] =  xetile.load_tile %[[arg4]] : !xetile.tile<32x128xf16> -> vector<32x128xf16>
-          //CHECK: %[[R43:.*]] =  xetile.load_tile %[[arg5]] : !xetile.tile<32x128xf16> -> vector<32x128xf16>
-          %a_value = xetile.load_tile %a_tile  : !xetile.tile<128x128xf16, #tile_attr_a>
-            -> vector<128x128xf16>
+          //CHECK: %[[R24:.*]] = xetile.load_tile %[[arg4]] : !xetile.tile<32x128xf16> -> vector<32x128xf16>
+          //CHECK: %[[R25:.*]] = xetile.load_tile %[[arg5]] : !xetile.tile<128x32xf16> -> vector<128x32xf16>
+          //CHECK: %[[R26:.*]] = xetile.tile_mma %[[R24]], %[[R25]], %[[arg6]] : vector<32x128xf16>, vector<128x32xf16>, vector<32x32xf32> -> vector<32x32xf32>
+          //CHECK: %[[R27:.*]] = xetile.update_tile_offset %[[arg4]], [%[[c0]], %[[c128]]] : !xetile.tile<32x128xf16>
+          //CHECK: %[[R28:.*]] = xetile.update_tile_offset %[[arg5]], [%[[c128]], %[[c0]]] : !xetile.tile<128x32xf16>
+          //CHECK: scf.yield %[[R27]], %[[R28]], %[[R26]] : !xetile.tile<32x128xf16>, !xetile.tile<128x32xf16>, vector<32x32xf32>
 
-          //CHECK: %[[R44:.*]] =  xetile.load_tile %[[arg6]] : !xetile.tile<128x32xf16> -> vector<128x32xf16>
-          //CHECK: %[[R45:.*]] =  xetile.load_tile %[[arg7]] : !xetile.tile<128x32xf16> -> vector<128x32xf16>
-          %b_value = xetile.load_tile %b_tile : !xetile.tile<128x128xf16, #tile_attr_b>
-            -> vector<128x128xf16>
-
-          //CHECK: %[[R46:.*]] = xetile.tile_mma %[[R42]], %[[R44]],  %[[arg8]] : vector<32x128xf16>, vector<128x32xf16>, vector<32x32xf32> -> vector<32x32xf32>
-          //CHECK: %[[R47:.*]] = xetile.tile_mma %[[R42]], %[[R45]],  %[[arg9]] : vector<32x128xf16>, vector<128x32xf16>, vector<32x32xf32> -> vector<32x32xf32>
-          //CHECK: %[[R48:.*]] = xetile.tile_mma %[[R43]], %[[R44]],  %[[arg10]] : vector<32x128xf16>, vector<128x32xf16>, vector<32x32xf32> -> vector<32x32xf32>
-          //CHECK: %[[R49:.*]] = xetile.tile_mma %[[R43]], %[[R45]],  %[[arg11]] : vector<32x128xf16>, vector<128x32xf16>, vector<32x32xf32> -> vector<32x32xf32>
+          %a_value = xetile.load_tile %a_tile  : !xetile.tile<128x128xf16, #tile_attr_a> -> vector<128x128xf16>
+          %b_value = xetile.load_tile %b_tile : !xetile.tile<128x128xf16, #tile_attr_b> -> vector<128x128xf16>
           %c_new_value = xetile.tile_mma %a_value, %b_value, %c_value {wg_map_a = #wg_map_a, wg_map_b = #wg_map_b, wg_map_c = #wg_map_c}
             : vector<128x128xf16>, vector<128x128xf16>, vector<128x128xf32> -> vector<128x128xf32>
-
-          //CHECK: %[[R50:.*]] = xetile.update_tile_offset %[[arg4]], [%[[c0]],  %[[c128]]] : !xetile.tile<32x128xf16>
-          //CHECK: %[[R51:.*]] = xetile.update_tile_offset %[[arg5]], [%[[c0]],  %[[c128]]] : !xetile.tile<32x128xf16>
           %a_next_tile = xetile.update_tile_offset %a_tile, [%c0, %c128] : !xetile.tile<128x128xf16, #tile_attr_a>
-
-          //CHECK: %[[R52:.*]] = xetile.update_tile_offset %[[arg6]], [%[[c128]],  %[[c0]]] : !xetile.tile<128x32xf16>
-          //CHECK: %[[R53:.*]] = xetile.update_tile_offset %[[arg7]], [%[[c128]],  %[[c0]]] : !xetile.tile<128x32xf16>
           %b_next_tile = xetile.update_tile_offset %b_tile, [%c128, %c0] : !xetile.tile<128x128xf16, #tile_attr_b>
-
-          //CHECK: scf.yield %[[R50]], %[[R51]], %[[R52]], %[[R53]], %[[R46]], %[[R47]], %[[R48]], %[[R49]]
-          //CHECK-SAME: !xetile.tile<32x128xf16>, !xetile.tile<32x128xf16>, !xetile.tile<128x32xf16>, !xetile.tile<128x32xf16>, vector<32x32xf32>, vector<32x32xf32>, vector<32x32xf32>, vector<32x32xf32>
-          scf.yield %a_next_tile, %b_next_tile, %c_new_value
-            : !xetile.tile<128x128xf16, #tile_attr_a>,
-            !xetile.tile<128x128xf16, #tile_attr_b>, vector<128x128xf32>
+          scf.yield %a_next_tile, %b_next_tile, %c_new_value : !xetile.tile<128x128xf16, #tile_attr_a>, !xetile.tile<128x128xf16, #tile_attr_b>, vector<128x128xf32>
         }
 
-        //CHECK: xetile.store_tile %[[R41]]#4,  %[[R23]] : vector<32x32xf32>, !xetile.tile<32x32xf32>
-        //CHECK: xetile.store_tile %[[R41]]#5,  %[[R24]] : vector<32x32xf32>, !xetile.tile<32x32xf32>
-        //CHECK: xetile.store_tile %[[R41]]#6,  %[[R25]] : vector<32x32xf32>, !xetile.tile<32x32xf32>
-        //CHECK: xetile.store_tile %[[R41]]#7,  %[[R26]] : vector<32x32xf32>, !xetile.tile<32x32xf32>
-        xetile.store_tile %out#2, %c_init_tile : vector<128x128xf32>,
-          !xetile.tile<128x128xf32, #tile_attr_c>
+        //CHECK: xetile.store_tile %[[R23]]#2,  %[[R13]] : vector<32x32xf32>, !xetile.tile<32x32xf32>
+        xetile.store_tile %out#2, %c_init_tile : vector<128x128xf32>, !xetile.tile<128x128xf32, #tile_attr_c>
         %cst = arith.constant {map = #wg_map_c} dense<0.000000e+00> : vector<128x128xf32>
         %result_post_op = arith.addf %out#2, %cst {map = #wg_map_c} : vector<128x128xf32>
         //CHECK: gpu.return


### PR DESCRIPTION
As indicated in the title, the PR makes the following changes
1. add verification for WgMapAttr for store_tile and convert_layout (source part), ensuring the data is evenly distributed across subgroups, since different threads writing to same region will cause data race. 
2. add round-robin support for load part of code generated for ConverLayoutOp. 

Please review these guidelines to help with the review process:
- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [ ] Have you organized your commits logically and ensured each can be built by itself?
