### PR TITLE
[Pipeline][XeGPUToVC][MathToVC][ArithToVC][VectorLinearize] Move XeGPUToVC forward

### DIFF
--- a/include/imex/Conversion/ArithToVC/ArithToVC.h
+++ b/include/imex/Conversion/ArithToVC/ArithToVC.h
@@ -40,8 +40,7 @@ namespace imex {
 #include "imex/Conversion/Passes.h.inc"
 
 void populateArithToVCPatterns(
-    ::mlir::LLVMTypeConverter &typeConverter,
-    ::mlir::RewritePatternSet &patterns,
+    ::mlir::TypeConverter &typeConverter, ::mlir::RewritePatternSet &patterns,
     bool enableHighPrecisionInterimCalculation = false);
 void configureArithToVCConversionLegality(::mlir::ConversionTarget &target);
 std::unique_ptr<::mlir::OperationPass<::mlir::gpu::GPUModuleOp>>

--- a/include/imex/Conversion/MathToVC/MathToVC.h
+++ b/include/imex/Conversion/MathToVC/MathToVC.h
@@ -40,8 +40,7 @@ namespace imex {
 #include "imex/Conversion/Passes.h.inc"
 
 void populateMathToVCPatterns(
-    ::mlir::LLVMTypeConverter &typeConverter,
-    ::mlir::RewritePatternSet &patterns,
+    ::mlir::TypeConverter &typeConverter, ::mlir::RewritePatternSet &patterns,
     bool enableHighPrecisionInterimCalculation = false);
 void configureMathToVCConversionLegality(::mlir::ConversionTarget &target);
 std::unique_ptr<::mlir::OperationPass<::mlir::gpu::GPUModuleOp>>

--- a/lib/Conversion/XeGPUToVC/LSCPatterns.cpp
+++ b/lib/Conversion/XeGPUToVC/LSCPatterns.cpp
@@ -911,7 +911,6 @@ class LoadNdPattern : public OpConversionPattern<LoadNdOp> {
         auto targetTy = convertVectorType(op.getType()).second;
         callOp = rewriter.create<vector::BitCastOp>(loc, targetTy, callOp);
       }
-
       rewriter.replaceOp(op, callOp);
       return success();
     }
@@ -1304,11 +1303,8 @@ void populateAtomicAndFenceLSCPatterns(TypeConverter &converter,
 
 void populateLoadStoreLSCPatterns(TypeConverter &converter,
                                   RewritePatternSet &patterns) {
-  // TODO: why some patterns need typconverter and some not?
-  patterns.add<LSC::LoadNdPattern, LSC::StoreNdPattern, LSC::PrefetchNdPattern>(
-      patterns.getContext());
-
-  patterns.add<LSC::LoadGatherPattern, LSC::StoreScatterPattern,
+  patterns.add<LSC::LoadNdPattern, LSC::StoreNdPattern, LSC::PrefetchNdPattern,
+               LSC::LoadGatherPattern, LSC::StoreScatterPattern,
                LSC::PrefetchPattern>(converter, patterns.getContext());
 }
 

--- a/lib/Conversion/XeGPUToVC/LscIntrinsicEnums.h
+++ b/lib/Conversion/XeGPUToVC/LscIntrinsicEnums.h
@@ -109,4 +109,22 @@ enum LSC_OP {
   LSC_INVALID = 0xFFFFFFFF,
 };
 
+enum class GenPrecision : unsigned char {
+  INVALID = 0,
+
+  U1 = 1,
+  S1 = 2,
+  U2 = 3,
+  S2 = 4,
+  U4 = 5,
+  S4 = 6,
+  U8 = 7,
+  S8 = 8,
+  BF16 = 9,  // bfloat16 (s:1, e:8, m:7)
+  FP16 = 10, // half (1, 5, 10)
+  BF8 = 11,  // bfloat8 (1, 5, 2)
+  TF32 = 12, // TensorFloat (1, 8, 10), 19 bits
+  TOTAL_NUM
+};
+
 #endif // LSC_INTRINSIC_ENUMS_H

--- a/test/Conversion/XeGPUToVC/prefetchnd.mlir
+++ b/test/Conversion/XeGPUToVC/prefetchnd.mlir
@@ -1,4 +1,4 @@
-// RUN: imex-opt --split-input-file -convert-xegpu-to-vc --cse %s | FileCheck %s --check-prefixes=CHECK,LSC
+// RUN: imex-opt --split-input-file -convert-xegpu-to-vc --cse %s | FileCheck %s
 
 // -----
 module @gemm attributes {gpu.container_module} {
@@ -51,24 +51,24 @@ module @gemm attributes {gpu.container_module} {
       //CHECK: %[[r26:.*]] = vector.insert %[[c1807_i32]], %[[r25]] [7] : i32 into vector<16xi32>
       %2 = xegpu.create_nd_tdesc %arg2[0, 0] : memref<8x16xf32> -> !xegpu.tensor_desc<8x16xf32>
 
-      //LSC: %[[cst_2:.*]] = arith.constant 0.000000e+00 : f16
-      //LSC: %[[true:.*]] = arith.constant true
-      //LSC: %[[c0_i8:.*]] = arith.constant 0 : i8
-      //LSC: %[[r27:.*]] = vector.from_elements %[[c0_i8]], %[[c0_i8]] : vector<2xi8>
-      //LSC: %[[c1_i8:.*]] = arith.constant 1 : i8
-      //LSC: %[[c16_i16:.*]] = arith.constant 16 : i16
-      //LSC: %[[c8_i16:.*]] = arith.constant 8 : i16
-      //LSC: func.call @llvm.genx.lsc.prefetch.2d.ugm.desc.v2i8.f16(%[[true]], %[[r27]], %[[c1_i8]], %[[c16_i16]], %[[c8_i16]], %[[r8]], %[[c0_i32]], %[[c0_i32]], %[[cst_2]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, f16) -> ()
-      //LSC: func.call @llvm.genx.lsc.prefetch.2d.ugm.desc.v2i8.f16(%[[true]], %[[r27]], %[[c1_i8]], %[[c16_i16]], %[[c16_i16]], %[[r17]], %[[c0_i32]], %[[c0_i32]], %[[cst_2]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, f16) -> ()
+      //CHECK: %[[cst_2:.*]] = arith.constant 0.000000e+00 : f16
+      //CHECK: %[[true:.*]] = arith.constant true
+      //CHECK: %[[c0_i8:.*]] = arith.constant 0 : i8
+      //CHECK: %[[r27:.*]] = vector.from_elements %[[c0_i8]], %[[c0_i8]] : vector<2xi8>
+      //CHECK: %[[c1_i8:.*]] = arith.constant 1 : i8
+      //CHECK: %[[c16_i16:.*]] = arith.constant 16 : i16
+      //CHECK: %[[c8_i16:.*]] = arith.constant 8 : i16
+      //CHECK: func.call @llvm.genx.lsc.prefetch.2d.ugm.desc.v2i8.f16(%[[true]], %[[r27]], %[[c1_i8]], %[[c16_i16]], %[[c8_i16]], %[[r8]], %[[c0_i32]], %[[c0_i32]], %[[cst_2]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, f16) -> ()
+      //CHECK: func.call @llvm.genx.lsc.prefetch.2d.ugm.desc.v2i8.f16(%[[true]], %[[r27]], %[[c1_i8]], %[[c16_i16]], %[[c16_i16]], %[[r17]], %[[c0_i32]], %[[c0_i32]], %[[cst_2]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, f16) -> ()
       xegpu.prefetch_nd %0 : !xegpu.tensor_desc<8x16xf16>
       xegpu.prefetch_nd %1 : !xegpu.tensor_desc<16x16xf16>
 
-      //LSC: %[[cst_3:.*]] = arith.constant dense<0.000000e+00> : vector<128xf16>
-      //LSC: %[[A:.*]] = func.call @llvm.genx.lsc.load.2d.ugm.desc.v128f16.v2i8(%[[true]], %[[r27]], %[[c1_i8]], %[[c16_i16]], %[[c8_i16]], %[[r8]], %[[c0_i32]], %[[c0_i32]], %[[cst_3]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, vector<128xf16>) -> vector<128xf16>
+      //CHECK: %[[cst_3:.*]] = arith.constant dense<0.000000e+00> : vector<128xf16>
+      //CHECK: %[[A:.*]] = func.call @llvm.genx.lsc.load.2d.ugm.desc.v128f16.v2i8(%[[true]], %[[r27]], %[[c1_i8]], %[[c16_i16]], %[[c8_i16]], %[[r8]], %[[c0_i32]], %[[c0_i32]], %[[cst_3]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, vector<128xf16>) -> vector<128xf16>
       %3 = xegpu.load_nd %0 : !xegpu.tensor_desc<8x16xf16> -> vector<8x16xf16>
 
-      //LSC: %[[cst_4:.*]] = arith.constant dense<0.000000e+00> : vector<256xf16>
-      //LSC: %[[B:.*]] = func.call @llvm.genx.lsc.load.2d.ugm.desc.vnni.v256f16.v2i8(%[[true]], %[[r27]], %[[c1_i8]], %[[c16_i16]], %[[c16_i16]], %[[r17]], %[[c0_i32]], %[[c0_i32]], %[[cst_4]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, vector<256xf16>) -> vector<256xf16>
+      //CHECK: %[[cst_4:.*]] = arith.constant dense<0.000000e+00> : vector<256xf16>
+      //CHECK: %[[B:.*]] = func.call @llvm.genx.lsc.load.2d.ugm.desc.vnni.v256f16.v2i8(%[[true]], %[[r27]], %[[c1_i8]], %[[c16_i16]], %[[c16_i16]], %[[r17]], %[[c0_i32]], %[[c0_i32]], %[[cst_4]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, vector<256xf16>) -> vector<256xf16>
       %4 = xegpu.load_nd %1 {packed} : !xegpu.tensor_desc<16x16xf16> -> vector<8x16x2xf16>
 
       //CHECK: %[[c134744586_i32:.*]] = arith.constant 134744586 : i32
@@ -77,7 +77,7 @@ module @gemm attributes {gpu.container_module} {
       //CHECK: %[[DPAS:.*]] = func.call @llvm.genx.dpas.nosrc0.v128f32.v128i32.v64i32(%[[r32]], %[[r31]], %[[c134744586_i32]]) : (vector<128xi32>, vector<64xi32>, i32) -> vector<128xf32>
       %5 = xegpu.dpas %3, %4 : vector<8x16xf16>, vector<8x16x2xf16> -> vector<8x16xf32>
 
-      //LSC: func.call @llvm.genx.lsc.store.2d.ugm.desc.v2i8.v128f32(%[[true]], %[[r27]], %[[c1_i8]], %[[c16_i16]], %[[c8_i16]], %[[r26]], %[[c0_i32]], %[[c0_i32]], %[[DPAS]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, vector<128xf32>) -> ()
+      //CHECK: func.call @llvm.genx.lsc.store.2d.ugm.desc.v2i8.v128f32(%[[true]], %[[r27]], %[[c1_i8]], %[[c16_i16]], %[[c8_i16]], %[[r26]], %[[c0_i32]], %[[c0_i32]], %[[DPAS]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, vector<128xf32>) -> ()
       xegpu.store_nd %5, %2 : vector<8x16xf32>, !xegpu.tensor_desc<8x16xf32>
       //CHECK: gpu.return
       gpu.return
@@ -88,24 +88,23 @@ module @gemm attributes {gpu.container_module} {
 
 // -----
 module @two_type attributes {gpu.container_module} {
-
   gpu.module @test_kernel {
     gpu.func @test_prefetch(%arg0: memref<8x16xf16>, %arg1: memref<8x16xf32>, %arg2: memref<8x16xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
       %0 = xegpu.create_nd_tdesc %arg0[0, 0] : memref<8x16xf16> -> !xegpu.tensor_desc<8x16xf16>
       %1 = xegpu.create_nd_tdesc %arg1[0, 0] : memref<8x16xf32> -> !xegpu.tensor_desc<8x16xf32>
       %2 = xegpu.create_nd_tdesc %arg2[0, 0] : memref<8x16xf32> -> !xegpu.tensor_desc<8x16xf32>
 
-      //LSC: %[[c0_i32:.*]] = arith.constant 0 : i32
-      //LSC: %[[c0_f16:.*]] = arith.constant 0.000000e+00 : f16
-      //LSC: %[[true:.*]] = arith.constant true
-      //LSC: %[[c0_i8:.*]] = arith.constant 0 : i8
-      //LSC: %[[r27:.*]] = vector.from_elements %[[c0_i8]], %[[c0_i8]] : vector<2xi8>
-      //LSC: %[[c1_i8:.*]] = arith.constant 1 : i8
-      //LSC: %[[c16_i16:.*]] = arith.constant 16 : i16
-      //LSC: %[[c8_i16:.*]] = arith.constant 8 : i16
-      //LSC: func.call @llvm.genx.lsc.prefetch.2d.ugm.desc.v2i8.f16(%[[true]], %[[r27]], %[[c1_i8]], %[[c16_i16]], %[[c8_i16]], %[[r8]], %[[c0_i32]], %[[c0_i32]], %[[c0_f16]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, f16) -> ()
-      //LSC: %[[c0_f32:.*]] = arith.constant 0.000000e+00 : f32
-      //LSC: func.call @llvm.genx.lsc.prefetch.2d.ugm.desc.v2i8.f32(%[[true]], %[[r27]], %[[c1_i8]], %[[c16_i16]], %[[c8_i16]], %[[r17]], %[[c0_i32]], %[[c0_i32]], %[[c0_f32]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, f32) -> ()
+      //CHECK: %[[c0_i32:.*]] = arith.constant 0 : i32
+      //CHECK: %[[c0_f16:.*]] = arith.constant 0.000000e+00 : f16
+      //CHECK: %[[true:.*]] = arith.constant true
+      //CHECK: %[[c0_i8:.*]] = arith.constant 0 : i8
+      //CHECK: %[[r27:.*]] = vector.from_elements %[[c0_i8]], %[[c0_i8]] : vector<2xi8>
+      //CHECK: %[[c1_i8:.*]] = arith.constant 1 : i8
+      //CHECK: %[[c16_i16:.*]] = arith.constant 16 : i16
+      //CHECK: %[[c8_i16:.*]] = arith.constant 8 : i16
+      //CHECK: func.call @llvm.genx.lsc.prefetch.2d.ugm.desc.v2i8.f16(%[[true]], %[[r27]], %[[c1_i8]], %[[c16_i16]], %[[c8_i16]], %[[r8]], %[[c0_i32]], %[[c0_i32]], %[[c0_f16]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, f16) -> ()
+      //CHECK: %[[c0_f32:.*]] = arith.constant 0.000000e+00 : f32
+      //CHECK: func.call @llvm.genx.lsc.prefetch.2d.ugm.desc.v2i8.f32(%[[true]], %[[r27]], %[[c1_i8]], %[[c16_i16]], %[[c8_i16]], %[[r17]], %[[c0_i32]], %[[c0_i32]], %[[c0_f32]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, f32) -> ()
       xegpu.prefetch_nd %0 : !xegpu.tensor_desc<8x16xf16>
       xegpu.prefetch_nd %1 : !xegpu.tensor_desc<8x16xf32>
 
@@ -115,6 +114,5 @@ module @two_type attributes {gpu.container_module} {
       xegpu.store_nd %4, %2 : vector<8x16xf32>, !xegpu.tensor_desc<8x16xf32>
       gpu.return
     }
-
- }
+  }
 }

--- a/test/Conversion/XeGPUToVC/store_nd.mlir
+++ b/test/Conversion/XeGPUToVC/store_nd.mlir
@@ -1,10 +1,12 @@
-// RUN: imex-opt -convert-xegpu-to-vc -cse  %s | FileCheck %s --check-prefixes=CHECK,LSC
+// RUN: imex-opt -convert-xegpu-to-vc -cse  %s | FileCheck %s
 module @gemm attributes {gpu.container_module} {
   gpu.module @test_kernel {
 
     // CHECK: gpu.func @test_store_nd(%[[arg0:.*]]: memref<8x16xf16>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
     gpu.func @test_store_nd(%arg0: memref<8x16xf16>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>}{
-      // CHECK: %[[data:.*]] = arith.constant dense<1.000000e+00> : vector<8x16xf16>
+      // CHECK: %[[cst:.*]] = arith.constant dense<1.000000e+00> : vector<8x16xf16>
+      // CHECK: %[[data:.*]] = vector.shape_cast %[[cst]] : vector<8x16xf16> to vector<128xf16>
+
       %c = arith.constant dense<1.0> : vector<8x16xf16>
 
       //CHECK: %[[intptr:.*]] = memref.extract_aligned_pointer_as_index %{{.*}} : memref<8x16xf16> -> index
@@ -14,9 +16,9 @@ module @gemm attributes {gpu.container_module} {
       //CHECK: %[[r2:.*]] = vector.bitcast %[[r1]] : vector<8xi64> to vector<16xi32>
       //CHECK: %[[c31_i32:.*]] = arith.constant 31 : i32
       //CHECK: %[[c7_i32:.*]] = arith.constant 7 : i32
-      //CHECK: %[[r3:.*]] = vector.insert %[[c31_i32:.*]], %2 [2] : i32 into vector<16xi32>
-      //CHECK: %[[r4:.*]] = vector.insert %[[c7_i32:.*]], %3 [3] : i32 into vector<16xi32>
-      //CHECK: %[[r5:.*]] = vector.insert %[[c31_i32:.*]], %4 [4] : i32 into vector<16xi32>
+      //CHECK: %[[r3:.*]] = vector.insert %[[c31_i32:.*]], %[[r2]] [2] : i32 into vector<16xi32>
+      //CHECK: %[[r4:.*]] = vector.insert %[[c7_i32:.*]], %[[r3]] [3] : i32 into vector<16xi32>
+      //CHECK: %[[r5:.*]] = vector.insert %[[c31_i32:.*]], %[[r4]] [4] : i32 into vector<16xi32>
       //CHECK: %[[c0_i32:.*]] = arith.constant 0 : i32
       //CHECK: %[[r6:.*]] = vector.insert %[[c0_i32]], %[[r5]] [5] : i32 into vector<16xi32>
       //CHECK: %[[r7:.*]] = vector.insert %[[c0_i32]], %[[r6]] [6] : i32 into vector<16xi32>
@@ -24,13 +26,13 @@ module @gemm attributes {gpu.container_module} {
       //CHECK: %[[r8:.*]] = vector.insert %[[c1807_i32]], %[[r7]] [7] : i32 into vector<16xi32>
       %0 = xegpu.create_nd_tdesc %arg0[0, 0] : memref<8x16xf16> -> !xegpu.tensor_desc<8x16xf16>
 
-      //LSC: %[[true:.*]] = arith.constant true
-      //LSC: %[[c0_i8:.*]] = arith.constant 0 : i8
-      //LSC: %[[r9:.*]] = vector.from_elements %c0_i8, %c0_i8 : vector<2xi8>
-      //LSC: %[[c1_i8:.*]] = arith.constant 1 : i8
-      //LSC: %[[c16_i16:.*]] = arith.constant 16 : i16
-      //LSC: %[[c8_i16:.*]] = arith.constant 8 : i16
-      //LSC: func.call @llvm.genx.lsc.store.2d.ugm.desc.v2i8.v128f16(%[[true]], %[[r9]], %[[c1_i8]], %[[c16_i16]], %[[c8_i16]], %[[r8]], %[[c0_i32]], %[[c0_i32]], %[[data]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, vector<8x16xf16>) -> ()
+      //CHECK: %[[true:.*]] = arith.constant true
+      //CHECK: %[[c0_i8:.*]] = arith.constant 0 : i8
+      //CHECK: %[[r9:.*]] = vector.from_elements %[[c0_i8]], %[[c0_i8]] : vector<2xi8>
+      //CHECK: %[[c1_i8:.*]] = arith.constant 1 : i8
+      //CHECK: %[[c16_i16:.*]] = arith.constant 16 : i16
+      //CHECK: %[[c8_i16:.*]] = arith.constant 8 : i16
+      //CHECK: func.call @llvm.genx.lsc.store.2d.ugm.desc.v2i8.v128f16(%[[true]], %[[r9]], %[[c1_i8]], %[[c16_i16]], %[[c8_i16]], %[[r8]], %[[c0_i32]], %[[c0_i32]], %[[data]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, vector<128xf16>) -> ()
       xegpu.store_nd %c, %0 : vector<8x16xf16>, !xegpu.tensor_desc<8x16xf16>
       // CHECK: gpu.return
       gpu.return
@@ -39,57 +41,57 @@ module @gemm attributes {gpu.container_module} {
     // CHECK: gpu.func @test_store_nd_1d_strided_memref(%[[arg0:.*]]: memref<32x32xf32, strided<[64, 1]>>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
     gpu.func @test_store_nd_1d_strided_memref(%arg0: memref<32x32xf32, strided<[64,1], offset: 0>>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>}{
 
-      //CHECK: %cst = arith.constant dense<1.000000e+00> : vector<16xf32>
+      //CHECK: %[[cst:.*]] = arith.constant dense<1.000000e+00> : vector<16xf32>
       %c1 = arith.constant dense<1.0> : vector<16xf32>
 
-      //CHECK: %intptr = memref.extract_aligned_pointer_as_index %arg0 : memref<32x32xf32, strided<[64, 1]>> -> index
-      //CHECK: %0 = arith.index_castui %intptr : index to i64
-      //CHECK: %1 = vector.broadcast %0 : i64 to vector<1xi64>
+      //CHECK: %[[intptr:.*]] = memref.extract_aligned_pointer_as_index %[[arg0]] : memref<32x32xf32, strided<[64, 1]>> -> index
+      //CHECK: %[[R0:.*]] = arith.index_castui %[[intptr]] : index to i64
+      //CHECK: %[[R1:.*]] = vector.broadcast %[[R0]] : i64 to vector<1xi64>
       %tdesc_1d = xegpu.create_nd_tdesc %arg0[0, 0] : memref<32x32xf32, strided<[64,1], offset: 0>> -> !xegpu.tensor_desc<16xf32>
 
-      //LSC: %cst_0 = arith.constant dense<true> : vector<1xi1>
-      //LSC: %c4_i8 = arith.constant 4 : i8
-      //LSC: %c0_i8 = arith.constant 0 : i8
-      //LSC: %c1_i16 = arith.constant 1 : i16
-      //LSC: %c0_i32 = arith.constant 0 : i32
-      //LSC: %c3_i8 = arith.constant 3 : i8
-      //LSC: %c6_i8 = arith.constant 6 : i8
-      //LSC: %c1_i8 = arith.constant 1 : i8
-      //LSC: func.call @llvm.genx.lsc.store.stateless.v1i1.v1i64.v16f32(%cst_0, %c4_i8, %c0_i8, %c0_i8, %c1_i16, %c0_i32, %c3_i8, %c6_i8, %c1_i8, %c0_i8, %1, %cst, %c0_i32) : (vector<1xi1>, i8, i8, i8, i16, i32, i8, i8, i8, i8, vector<1xi64>, vector<16xf32>, i32) -> ()
+      //CHECK: %[[cst_0:.*]] = arith.constant dense<true> : vector<1xi1>
+      //CHECK: %[[c4_i8:.*]] = arith.constant 4 : i8
+      //CHECK: %[[c0_i8:.*]] = arith.constant 0 : i8
+      //CHECK: %[[c1_i16:.*]] = arith.constant 1 : i16
+      //CHECK: %[[c0_i32:.*]] = arith.constant 0 : i32
+      //CHECK: %[[c3_i8:.*]] = arith.constant 3 : i8
+      //CHECK: %[[c6_i8:.*]] = arith.constant 6 : i8
+      //CHECK: %[[c1_i8:.*]] = arith.constant 1 : i8
+      //CHECK: func.call @llvm.genx.lsc.store.stateless.v1i1.v1i64.v16f32(%[[cst_0]], %[[c4_i8]], %[[c0_i8]], %[[c0_i8]], %[[c1_i16]], %[[c0_i32]], %[[c3_i8]], %[[c6_i8]], %[[c1_i8]], %[[c0_i8]], %[[R1]], %[[cst]], %[[c0_i32]]) : (vector<1xi1>, i8, i8, i8, i16, i32, i8, i8, i8, i8, vector<1xi64>, vector<16xf32>, i32) -> ()
       xegpu.store_nd %c1, %tdesc_1d : vector<16xf32>, !xegpu.tensor_desc<16xf32>
       gpu.return
     }
 
     // CHECK: gpu.func @test_store_nd_2d_strided_memref(%[[arg0:.*]]: memref<32x32xf16, strided<[64, 1]>>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
     gpu.func @test_store_nd_2d_strided_memref(%arg0: memref<32x32xf16, strided<[64,1], offset: 0>>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>}{
-      //CHECK: %cst = arith.constant dense<1.000000e+00> : vector<8x16xf16>
+
+      //CHECK: %[[cst:.*]] = arith.constant dense<1.000000e+00> : vector<8x16xf16>
+      //CHECK: %[[R0:.*]] = vector.shape_cast %[[cst]] : vector<8x16xf16> to vector<128xf16>
+      //CHECK: %[[intptr:.*]] = memref.extract_aligned_pointer_as_index %[[arg0]] : memref<32x32xf16, strided<[64, 1]>> -> index
+      //CHECK: %[[R1:.*]] = arith.index_castui %[[intptr]] : index to i64
+      //CHECK: %[[cst_0:.*]] = arith.constant dense<0> : vector<8xi64>
+      //CHECK: %[[R2:.*]] = vector.insert %[[R1]], %[[cst_0]] [0] : i64 into vector<8xi64>
+      //CHECK: %[[R3:.*]] = vector.bitcast %[[R2]] : vector<8xi64> to vector<16xi32>
+      //CHECK: %[[c63_i32:.*]] = arith.constant 63 : i32
+      //CHECK: %[[c31_i32:.*]] = arith.constant 31 : i32
+      //CHECK: %[[c127_i32:.*]] = arith.constant 127 : i32
+      //CHECK: %[[R4:.*]] = vector.insert %[[c63_i32]], %[[R3]] [2] : i32 into vector<16xi32>
+      //CHECK: %[[R5:.*]] = vector.insert %[[c31_i32]], %[[R4]] [3] : i32 into vector<16xi32>
+      //CHECK: %[[R6:.*]] = vector.insert %[[c127_i32]], %[[R5]] [4] : i32 into vector<16xi32>
+      //CHECK: %[[c0_i32:.*]] = arith.constant 0 : i32
+      //CHECK: %[[R7:.*]] = vector.insert %[[c0_i32]], %[[R6]] [5] : i32 into vector<16xi32>
+      //CHECK: %[[R8:.*]] = vector.insert %[[c0_i32]], %[[R7]] [6] : i32 into vector<16xi32>
+      //CHECK: %[[c1807_i32:.*]] = arith.constant 1807 : i32
+      //CHECK: %[[R9:.*]] = vector.insert %[[c1807_i32]], %[[R8]] [7] : i32 into vector<16xi32>
+      //CHECK: %[[true:.*]] = arith.constant true
+      //CHECK: %[[c0_i8:.*]] = arith.constant 0 : i8
+      //CHECK: %[[R10:.*]] = vector.from_elements %[[c0_i8]], %[[c0_i8]] : vector<2xi8>
+      //CHECK: %[[c1_i8:.*]] = arith.constant 1 : i8
+      //CHECK: %[[c16_i16:.*]] = arith.constant 16 : i16
+      //CHECK: %[[c8_i16:.*]] = arith.constant 8 : i16
+      //CHECK: func.call @llvm.genx.lsc.store.2d.ugm.desc.v2i8.v128f16(%[[true]], %[[R10]], %[[c1_i8]], %[[c16_i16]], %[[c8_i16]], %[[R9]], %[[c0_i32]], %[[c0_i32]], %[[R0]]) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, vector<128xf16>) -> ()
       %c2 = arith.constant dense<1.0> : vector<8x16xf16>
-
-      //CHECK: %intptr = memref.extract_aligned_pointer_as_index %arg0 : memref<32x32xf16, strided<[64, 1]>> -> index
-      //CHECK: %0 = arith.index_castui %intptr : index to i64
-      //CHECK: %cst_0 = arith.constant dense<0> : vector<8xi64>
-      //CHECK: %1 = vector.insert %0, %cst_0 [0] : i64 into vector<8xi64>
-      //CHECK: %2 = vector.bitcast %1 : vector<8xi64> to vector<16xi32>
-      //CHECK: %c63_i32 = arith.constant 63 : i32
-      //CHECK: %c31_i32 = arith.constant 31 : i32
-      //CHECK: %c127_i32 = arith.constant 127 : i32
-      //CHECK: %3 = vector.insert %c63_i32, %2 [2] : i32 into vector<16xi32>
-      //CHECK: %4 = vector.insert %c31_i32, %3 [3] : i32 into vector<16xi32>
-      //CHECK: %5 = vector.insert %c127_i32, %4 [4] : i32 into vector<16xi32>
-      //CHECK: %c0_i32 = arith.constant 0 : i32
-      //CHECK: %6 = vector.insert %c0_i32, %5 [5] : i32 into vector<16xi32>
-      //CHECK: %7 = vector.insert %c0_i32, %6 [6] : i32 into vector<16xi32>
-      //CHECK: %c1807_i32 = arith.constant 1807 : i32
-      //CHECK: %8 = vector.insert %c1807_i32, %7 [7] : i32 into vector<16xi32>
       %tdesc_2d = xegpu.create_nd_tdesc %arg0[0, 0] : memref<32x32xf16, strided<[64,1], offset: 0>> -> !xegpu.tensor_desc<8x16xf16>
-
-      //LSC: %true = arith.constant true
-      //LSC: %c0_i8 = arith.constant 0 : i8
-      //LSC: %9 = vector.from_elements %c0_i8, %c0_i8 : vector<2xi8>
-      //LSC: %c1_i8 = arith.constant 1 : i8
-      //LSC: %c16_i16 = arith.constant 16 : i16
-      //LSC: %c8_i16 = arith.constant 8 : i16
-      //LSC: func.call @llvm.genx.lsc.store.2d.ugm.desc.v2i8.v128f16(%true, %9, %c1_i8, %c16_i16, %c8_i16, %8, %c0_i32, %c0_i32, %cst) : (i1, vector<2xi8>, i8, i16, i16, vector<16xi32>, i32, i32, vector<8x16xf16>) -> ()
       xegpu.store_nd %c2, %tdesc_2d : vector<8x16xf16>, !xegpu.tensor_desc<8x16xf16>
       gpu.return
     }

--- a/test/Conversion/XeGPUToVC/unit_tests.mlir
+++ b/test/Conversion/XeGPUToVC/unit_tests.mlir
@@ -1,0 +1,19 @@
+// RUN: imex-opt -convert-xegpu-to-vc %s | FileCheck %s
+
+gpu.module @test_kernel {
+  gpu.func @test(%arg0: memref<4x16xf32>) -> vector<2x4xf32> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %1 = arith.constant dense<1.0> : vector<2x4xf32>
+    %tdesc = xegpu.create_nd_tdesc %arg0[%c0, %c0] : memref<4x16xf32> -> !xegpu.tensor_desc<2x4xf32>
+    //CHECK-NOT: builtin.unrealized_conversion_cast {{.*}}: vector<16xi32> -> !xegpu.tensor_desc<2x4xf32>
+    %r:2 = scf.for %i = %c0 to %c4 step %c1 iter_args(%arg1 = %tdesc, %arg2 = %1) -> (!xegpu.tensor_desc<2x4xf32>, vector<2x4xf32>) {
+      %data = xegpu.load_nd %arg1 : !xegpu.tensor_desc<2x4xf32> -> vector<2x4xf32>
+      %next = xegpu.update_nd_offset %arg1, [%c0, %c4] : !xegpu.tensor_desc<2x4xf32>
+      %2 = arith.addf %data, %arg2 : vector<2x4xf32>
+      scf.yield %next, %2 : !xegpu.tensor_desc<2x4xf32>, vector<2x4xf32>
+    }
+    gpu.return %r#1 : vector<2x4xf32>
+  }
+}

--- a/test/Integration/Dialect/XeGPU/exp_f32.vc.mlir
+++ b/test/Integration/Dialect/XeGPU/exp_f32.vc.mlir
@@ -20,7 +20,7 @@ module @gemm attributes {gpu.container_module} {
     return %memref_2, %memref_3 : memref<8x16xf32>, memref<8x16xf32>
   }
 
-    gpu.module @module0 attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
+  gpu.module @module0 attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float16, Float64, AtomicFloat32AddEXT, ExpectAssumeKHR, SubgroupDispatch, VectorComputeINTEL, VectorAnyINTEL], [SPV_EXT_shader_atomic_float_add, SPV_KHR_expect_assume, SPV_INTEL_vector_compute]>, api=OpenCL, #spirv.resource_limits<>>} {
     gpu.func @test_exp_larger_vec(%A: memref<8x16xf32>, %Out: memref<8x16xf32>) kernel attributes {VectorComputeFunctionINTEL, spirv.entry_point_abi = #spirv.entry_point_abi<>} {
       %c0 = arith.constant 0 : index
       %c16 = arith.constant 16 : index

--- a/test/Integration/Dialect/XeGPU/xegpu-to-func-vc.pp
+++ b/test/Integration/Dialect/XeGPU/xegpu-to-func-vc.pp
@@ -6,9 +6,12 @@ builtin.module(
     gpu.module(imex-xegpu-hoist-transpose,
         imex-xegpu-apply-vnni-transformation,
         imex-xegpu-optimize-transpose)
+    cse
+    gpu.module(convert-math-to-vc{enable-high-precision-interim-calculation=true}
+        convert-xegpu-to-vc)
+    cse
     imex-vector-linearize
-    gpu.module(convert-math-to-vc{enable-high-precision-interim-calculation=true})
-    gpu.module(convert-xegpu-to-vc)
+    canonicalize
     cse
     reconcile-unrealized-casts
     bf16-to-gpu

--- a/test/Integration/Dialect/XeTile/fallback/xetile-fallback-to-func-vc.pp
+++ b/test/Integration/Dialect/XeTile/fallback/xetile-fallback-to-func-vc.pp
@@ -9,14 +9,13 @@ builtin.module(
 	cse
         imex-xegpu-hoist-transpose
         imex-xegpu-apply-vnni-transformation
-        imex-xegpu-optimize-transpose)
+        imex-xegpu-optimize-transpose
+        cse
+        convert-xegpu-to-vc)
     cse
     imex-vector-linearize
-    cse
-    imex-remove-single-elem-vector
     canonicalize
     cse
-    gpu.module(convert-xegpu-to-vc)
     reconcile-unrealized-casts
     bf16-to-gpu
     cse

--- a/test/Integration/Dialect/XeTile/xetile-to-func-vc.pp
+++ b/test/Integration/Dialect/XeTile/xetile-to-func-vc.pp
@@ -8,13 +8,13 @@ builtin.module(
 	cse
         imex-xegpu-hoist-transpose
         imex-xegpu-apply-vnni-transformation
-        imex-xegpu-optimize-transpose)
+        imex-xegpu-optimize-transpose
+        cse
+        convert-xegpu-to-vc)
     cse
     imex-vector-linearize
+    canonicalize
     cse
-    imex-remove-single-elem-vector
-    cse
-    gpu.module(convert-xegpu-to-vc)
     reconcile-unrealized-casts
     bf16-to-gpu
     imex-convert-gpu-to-spirv

--- a/test/Integration/Dialect/XeTile/xetile-wg-to-func-vc.pp
+++ b/test/Integration/Dialect/XeTile/xetile-wg-to-func-vc.pp
@@ -11,13 +11,12 @@ builtin.module(
         cse
         imex-xegpu-hoist-transpose
         imex-xegpu-apply-vnni-transformation
-        imex-xegpu-optimize-transpose)
+        imex-xegpu-optimize-transpose
+        cse
+        convert-xegpu-to-vc)
     cse
     imex-vector-linearize
-    cse
-    imex-remove-single-elem-vector
-    cse
-    gpu.module(convert-xegpu-to-vc)
+    canonicalize
     reconcile-unrealized-casts
     bf16-to-gpu
     imex-convert-gpu-to-spirv

--- a/test/Transforms/VectorLinearize/unit_tests.mlir
+++ b/test/Transforms/VectorLinearize/unit_tests.mlir
@@ -9,3 +9,31 @@ func.func @test() -> vector<4x2xf16> {
   %2 = vector.bitcast %1 : vector<4x1xf32> to vector<4x2xf16>
   return %2 : vector<4x2xf16>
 }
+
+// -----
+// test the insert_strided_slice
+func.func @test() -> vector<2x4xf32> {
+  %src = arith.constant dense<1.0> : vector<1x2xf32>
+  %dst = arith.constant dense<1.0> : vector<2x4xf32>
+  //CHECK: vector.insert_strided_slice %{{.*}}, %{{.*}} {offsets = [0], strides = [1]} : vector<2xf32> into vector<8xf32>
+  %1 = vector.insert_strided_slice %src, %dst {offsets = [0, 0], strides = [1, 1]} : vector<1x2xf32> into vector<2x4xf32>
+  //CHECK: vector.insert_strided_slice %{{.*}}, %{{.*}} {offsets = [6], strides = [1]} : vector<2xf32> into vector<8xf32>
+  %2 = vector.insert_strided_slice %src, %1 {offsets = [1, 2], strides = [1, 1]} : vector<1x2xf32> into vector<2x4xf32>
+  return %2 : vector<2x4xf32>
+}
+
+
+// -----
+// test the loop
+func.func @test() -> vector<2x4xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %1 = arith.constant dense<1.0> : vector<2x4xf32>
+  //CHECK: scf.for %{{.*}} iter_args(%{{.*}}) -> (vector<8xf32>)
+  %r = scf.for %i = %c0 to %c4 step %c1 iter_args(%arg1 = %1) -> (vector<2x4xf32>) {
+    %2 = arith.addf %1, %arg1 : vector<2x4xf32>
+    scf.yield %2 : vector<2x4xf32>
+  }
+  return %r : vector<2x4xf32>
+}

--- a/test/Transforms/vector-linearize.mlir
+++ b/test/Transforms/vector-linearize.mlir
@@ -259,21 +259,20 @@ func.func @test_vector_transpose_16x16(%arg: vector<16x16xf32>) -> vector<16x16x
 // CHECK:       %[[T3:.*]] = vector.shuffle %[[L3]], %[[L3]] [0, 1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] : vector<4xf32>, vector<4xf32>
 // CHECK:       %[[R4:.*]] = vector.shuffle %[[R3]], %[[T3]] [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 16, 17, 18, 19] : vector<16xf32>, vector<16xf32>
 //
-// CHECK:       %[[V:.*]] = vector.shape_cast %{{.*}} : vector<4x4xf32> to vector<16xf32>
-// CHECK:       %[[S0:.*]] = vector.shuffle %[[V]], %[[V]] [0, 1, 2, 3] : vector<16xf32>, vector<16xf32>
+// CHECK:       %[[S0:.*]] = vector.shuffle %[[R4]], %[[R4]] [0, 1, 2, 3] : vector<16xf32>, vector<16xf32>
 // CHECK:       vector.store %[[S0]], %{{.*}}[%[[C0]], %[[C0]]] : memref<4x4xf32>, vector<4xf32>
 //
-// CHECK:       %[[S1:.*]] = vector.shuffle %[[V]], %[[V]] [4, 5, 6, 7] : vector<16xf32>, vector<16xf32>
+// CHECK:       %[[S1:.*]] = vector.shuffle %[[R4]], %[[R4]] [4, 5, 6, 7] : vector<16xf32>, vector<16xf32>
 // CHECK:       %[[C1:.*]] = arith.constant 1 : index
 // CHECK:       %[[I1:.*]] = arith.addi %[[C0]], %[[C1]] : index
 // CHECK:       vector.store %[[S1]], %{{.*}}[%[[I1]], %[[C0]]] : memref<4x4xf32>, vector<4xf32>
 //
-// CHECK:       %[[S2:.*]] = vector.shuffle %[[V]], %[[V]] [8, 9, 10, 11] : vector<16xf32>, vector<16xf32>
+// CHECK:       %[[S2:.*]] = vector.shuffle %[[R4]], %[[R4]] [8, 9, 10, 11] : vector<16xf32>, vector<16xf32>
 // CHECK:       %[[C2:.*]] = arith.constant 2 : index
 // CHECK:       %[[I2:.*]] = arith.addi %[[C0]], %[[C2]] : index
 // CHECK:       vector.store %[[S2]], %{{.*}}[%[[I2]], %[[C0]]] : memref<4x4xf32>, vector<4xf32>
 //
-// CHECK:       %[[S3:.*]] = vector.shuffle %[[V]], %[[V]] [12, 13, 14, 15] : vector<16xf32>, vector<16xf32>
+// CHECK:       %[[S3:.*]] = vector.shuffle %[[R4]], %[[R4]] [12, 13, 14, 15] : vector<16xf32>, vector<16xf32>
 // CHECK:       %[[C3:.*]] = arith.constant 3 : index
 // CHECK:       %[[I3:.*]] = arith.addi %[[C0]], %[[C3]] : index
 // CHECK:       vector.store %[[S3]], %{{.*}}[%[[I3]], %[[C0]]] : memref<4x4xf32>, vector<4xf32>


### PR DESCRIPTION
This PR moves XeGPUToVC (as well as MathToVC and ArithToVC) pass forward in the pipeline, such that it focuses on converting XeGPU ops into VC intrinsics and maintaining 2D/3D vector view using shapecast (via materialization). And updated VectorLinearize pass with support for loop ops, e.g. scf.for. This change also enables the removal of imex-remove-single-elem pass from current pipelines for XeTile/XeGPU integration tests

Please review these guidelines to help with the review process:
- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [ ] Have you organized your commits logically and ensured each can be built by itself?
