### PR TITLE
[TEST] Enable optimize transpose test back

### DIFF
--- a/test/Integration/Dialect/XeGPU/lit.local.cfg
+++ b/test/Integration/Dialect/XeGPU/lit.local.cfg
@@ -16,7 +16,6 @@ local_excludes = [
                     'gemm_4kx4kx4k_dpas_sized_loads_f16_f16_f32.mlir',
                     'unranked_memref.vc.mlir',  # host code lowering has issues. spirv binary generated is identical to ranked_dynamic_memref.vc.mlir
                     'xegpu-to-vc.mlir', # 128xf32 is not a supported 1D vector length for load/store
-                    'optimize_transpose_array_length.mlir', # temp exclude until 1:N conversion is fixed
                  ]
 
 if(not config.imex_enable_pvc_target):


### PR DESCRIPTION
1ToN conversion should work now so should the e2e optimize transpose test thus enabling it back

Please review these guidelines to help with the review process:
- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [ ] Have you organized your commits logically and ensured each can be built by itself?
