### PR TITLE
Revert "Use mlir_sycl_runtime for XeVM integration tests. (#1079)"

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,6 @@ endif()
 set(IMEX_TEST_DEPENDS
         imex-opt
         imex-cpu-runner
-        mlir-runner
         mlir_c_runner_utils
         mlir_runner_utils
         imex_runner_utils
@@ -47,7 +46,7 @@ if(IMEX_ENABLE_VULKAN_RUNNER)
         )
 endif()
 
-if(IMEX_SPIRV_BACKEND_ENABLED)
+if(IMEX_ENABLE_SYCL_RUNTIME)
     list(APPEND IMEX_TEST_DEPENDS
         mlir_sycl_runtime
         )

--- a/test/Integration/Dialect/XeGPUToXeVM/loadstore_nd.mlir
+++ b/test/Integration/Dialect/XeGPUToXeVM/loadstore_nd.mlir
@@ -1,7 +1,7 @@
-// RUN: %python_executable %imex_runner --requires=sycl-runtime,spirv-backend -i %s --pass-pipeline-file=%p/xegpu-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime,spirv-backend -i %s --pass-pipeline-file=%p/xegpu-to-llvm.pp \
 // RUN:                                       --runner imex-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%mlir_sycl_runtime --filecheck
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
 
 module @gemm attributes {gpu.container_module} {
   gpu.module @kernel {

--- a/test/Integration/Dialect/XeGPUToXeVM/loadstore_nd_dpas.mlir
+++ b/test/Integration/Dialect/XeGPUToXeVM/loadstore_nd_dpas.mlir
@@ -1,7 +1,7 @@
-// RUN: %python_executable %imex_runner --requires=sycl-runtime,spirv-backend -i %s --pass-pipeline-file=%p/xegpu-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime,spirv-backend -i %s --pass-pipeline-file=%p/xegpu-to-llvm.pp \
 // RUN:                                       --runner imex-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%mlir_sycl_runtime --filecheck
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
 
 #sg_map_a_f16 = #xegpu.layout<lane_layout = [1, 16], lane_data = [1, 1]>
 #sg_map_b_f16 = #xegpu.layout<lane_layout = [1, 16], lane_data = [2, 1]>

--- a/test/Integration/Dialect/XeGPUToXeVM/loadstore_nd_prefetch.mlir
+++ b/test/Integration/Dialect/XeGPUToXeVM/loadstore_nd_prefetch.mlir
@@ -1,7 +1,7 @@
-// RUN: %python_executable %imex_runner --requires=sycl-runtime,spirv-backend -i %s --pass-pipeline-file=%p/xegpu-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime,spirv-backend -i %s --pass-pipeline-file=%p/xegpu-to-llvm.pp \
 // RUN:                                       --runner imex-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%mlir_sycl_runtime --filecheck
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
 
 module @gemm attributes {gpu.container_module} {
   gpu.module @kernel {

--- a/test/Integration/Dialect/XeGPUToXeVM/loadstore_nd_update_offset.mlir
+++ b/test/Integration/Dialect/XeGPUToXeVM/loadstore_nd_update_offset.mlir
@@ -1,7 +1,7 @@
-// RUN: %python_executable %imex_runner --requires=sycl-runtime,spirv-backend -i %s --pass-pipeline-file=%p/xegpu-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime,spirv-backend -i %s --pass-pipeline-file=%p/xegpu-to-llvm.pp \
 // RUN:                                       --runner imex-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%mlir_sycl_runtime --filecheck
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
 
 module @gemm attributes {gpu.container_module} {
   gpu.module @kernel {

--- a/test/Integration/Dialect/XeGPUToXeVM/loadstore_scatter_chunk_size_1.mlir
+++ b/test/Integration/Dialect/XeGPUToXeVM/loadstore_scatter_chunk_size_1.mlir
@@ -1,7 +1,7 @@
-// RUN: %python_executable %imex_runner --requires=sycl-runtime,spirv-backend -i %s --pass-pipeline-file=%p/xegpu-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime,spirv-backend -i %s --pass-pipeline-file=%p/xegpu-to-llvm.pp \
 // RUN:                                       --runner imex-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%mlir_sycl_runtime --filecheck
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
 
 module @gemm attributes {gpu.container_module} {
   gpu.module @kernel {

--- a/test/Integration/Dialect/XeGPUToXeVM/loadstore_scatter_chunk_size_1_non_contig_offsets.mlir
+++ b/test/Integration/Dialect/XeGPUToXeVM/loadstore_scatter_chunk_size_1_non_contig_offsets.mlir
@@ -1,7 +1,7 @@
-// RUN: %python_executable %imex_runner --requires=sycl-runtime,spirv-backend -i %s --pass-pipeline-file=%p/xegpu-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime,spirv-backend -i %s --pass-pipeline-file=%p/xegpu-to-llvm.pp \
 // RUN:                                       --runner imex-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%mlir_sycl_runtime --filecheck
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
 
 module @gemm attributes {gpu.container_module} {
   gpu.module @kernel {

--- a/test/Integration/Dialect/XeGPUToXeVM/loadstore_scatter_chunk_size_1_update_offset.mlir
+++ b/test/Integration/Dialect/XeGPUToXeVM/loadstore_scatter_chunk_size_1_update_offset.mlir
@@ -1,7 +1,7 @@
-// RUN: %python_executable %imex_runner --requires=sycl-runtime,spirv-backend -i %s --pass-pipeline-file=%p/xegpu-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime,spirv-backend -i %s --pass-pipeline-file=%p/xegpu-to-llvm.pp \
 // RUN:                                       --runner imex-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%mlir_sycl_runtime --filecheck
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
 
 module @gemm attributes {gpu.container_module} {
   gpu.module @kernel {

--- a/test/Integration/Dialect/XeGPUToXeVM/loadstore_scatter_chunk_size_2.mlir
+++ b/test/Integration/Dialect/XeGPUToXeVM/loadstore_scatter_chunk_size_2.mlir
@@ -1,7 +1,7 @@
-// RUN: %python_executable %imex_runner --requires=sycl-runtime,spirv-backend -i %s --pass-pipeline-file=%p/xegpu-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime,spirv-backend -i %s --pass-pipeline-file=%p/xegpu-to-llvm.pp \
 // RUN:                                       --runner imex-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%mlir_sycl_runtime --filecheck
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
 module @gemm attributes {gpu.container_module} {
   gpu.module @kernel {
     gpu.func @load_store_2d(%src: memref<128xf32, 1>, %dst: memref<128xf32, 1>) kernel {

--- a/test/Integration/Dialect/XeVM/xevm_block_dpas.mlir
+++ b/test/Integration/Dialect/XeVM/xevm_block_dpas.mlir
@@ -1,7 +1,7 @@
-// RUN: %python_executable %imex_runner --requires=sycl-runtime,spirv-backend -i %s --pass-pipeline-file=%p/xevm-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime,spirv-backend -i %s --pass-pipeline-file=%p/xevm-to-llvm.pp \
 // RUN:                                       --runner imex-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%mlir_sycl_runtime --filecheck
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
 
 module @gemm attributes {gpu.container_module} {
   gpu.module @kernel {

--- a/test/Integration/Dialect/XeVM/xevm_block_load_store.mlir
+++ b/test/Integration/Dialect/XeVM/xevm_block_load_store.mlir
@@ -1,7 +1,7 @@
-// RUN: %python_executable %imex_runner --requires=sycl-runtime,spirv-backend -i %s --pass-pipeline-file=%p/xevm-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime,spirv-backend -i %s --pass-pipeline-file=%p/xevm-to-llvm.pp \
 // RUN:                                       --runner imex-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%mlir_sycl_runtime --filecheck
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
 
 module @gemm attributes {gpu.container_module} {
 

--- a/test/Integration/Dialect/XeVM/xevm_block_load_store_transpose.mlir
+++ b/test/Integration/Dialect/XeVM/xevm_block_load_store_transpose.mlir
@@ -1,7 +1,7 @@
-// RUN: %python_executable %imex_runner --requires=sycl-runtime,spirv-backend -i %s --pass-pipeline-file=%p/xevm-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime,spirv-backend -i %s --pass-pipeline-file=%p/xevm-to-llvm.pp \
 // RUN:                                       --runner imex-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%mlir_sycl_runtime --filecheck
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
 
 module @gemm attributes {gpu.container_module} {
   gpu.module @kernel {

--- a/test/Integration/Dialect/XeVM/xevm_block_load_store_vnni.mlir
+++ b/test/Integration/Dialect/XeVM/xevm_block_load_store_vnni.mlir
@@ -1,7 +1,7 @@
-// RUN: %python_executable %imex_runner --requires=sycl-runtime,spirv-backend -i %s --pass-pipeline-file=%p/xevm-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime,spirv-backend -i %s --pass-pipeline-file=%p/xevm-to-llvm.pp \
 // RUN:                                       --runner imex-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%mlir_sycl_runtime --filecheck
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
 
 module @gemm attributes {gpu.container_module} {
   gpu.module @kernel {

--- a/test/Integration/Dialect/XeVM/xevm_store_cst.mlir
+++ b/test/Integration/Dialect/XeVM/xevm_store_cst.mlir
@@ -1,7 +1,7 @@
-// RUN: %python_executable %imex_runner --requires=sycl-runtime,spirv-backend -i %s --pass-pipeline-file=%p/xevm-to-llvm.pp \
+// RUN: %python_executable %imex_runner --requires=l0-runtime,spirv-backend -i %s --pass-pipeline-file=%p/xevm-to-llvm.pp \
 // RUN:                                       --runner imex-cpu-runner -e main \
 // RUN:                                       --entry-point-result=void \
-// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%mlir_sycl_runtime --filecheck
+// RUN:                                       --shared-libs=%irunner_utils,%mlir_runner_utils,%mlir_c_runner_utils,%levelzero_runtime --filecheck
 
 module @gemm attributes {gpu.container_module} {
 

--- a/tools/imex-runner/imex-runner.py.in
+++ b/tools/imex-runner/imex-runner.py.in
@@ -55,7 +55,7 @@ imex_enable_l0_runtime = @IMEX_ENABLE_L0_RUNTIME@
 imex_enable_sycl_runtime = @IMEX_ENABLE_SYCL_RUNTIME@
 imex_enable_spirv_backend = @IMEX_SPIRV_BACKEND_ENABLED@
 
-runner_choices = ['imex-cpu-runner', 'mlir-runner']
+runner_choices = ['imex-cpu-runner']
 enabled_features = []
 all_features = ['vulkan-runner', 'l0-runtime', 'sycl-runtime', 'igpu-fp64', 'spirv-backend']
 if imex_enable_vulkan_runner:


### PR DESCRIPTION
This reverts commit 84dd0092d870e9a2d948da7746e8c3498cba8fe1.

Please review these guidelines to help with the review process:
- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [ ] Have you organized your commits logically and ensured each can be built by itself?
