### PR TITLE
[XeGPUToXeVM] Clean up outdated vblocks calculation

### DIFF
--- a/lib/Conversion/XeGPUToXeVM/XeGPUToXeVM.cpp
+++ b/lib/Conversion/XeGPUToXeVM/XeGPUToXeVM.cpp
@@ -275,12 +275,6 @@ class LoadStorePrefetchNdToXeVMPattern : public OpConversionPattern<OpType> {
     auto tileW = tdescTy.getDimSize(1);
     auto tileH = tdescTy.getDimSize(0);
     int32_t vblocks = tdescTy.getArrayLength();
-    // TODO: Why is vblocks calculated like this?
-    // if (elemBitSize == 16) {
-    //   vblocks = (tileW + 16 - 1) / 16;
-    //   tileW = 16;
-    // }
-
     if constexpr (std::is_same_v<OpType, StoreNdOp>) {
       VectorType srcVecTy = cast<VectorType>(op.getValue().getType());
       auto l1 = translateStoreXeGPUCacheHint(op.getL1Hint());


### PR DESCRIPTION
Removing commented code snippet that calculates xevm ops arguments

Please review these guidelines to help with the review process:
- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [ ] Have you organized your commits logically and ensured each can be built by itself?
