### PR TITLE
[Vector Linearize] Use upstream linearize for poison op

### DIFF
--- a/lib/Transforms/VectorLinearize.cpp
+++ b/lib/Transforms/VectorLinearize.cpp
@@ -119,7 +119,6 @@ struct VectorLinearizePass final
     target.addLegalOp<mlir::vector::ShapeCastOp>();
     target.addLegalOp<mlir::vector::ExtractOp>();
     target.addLegalDialect<mlir::xegpu::XeGPUDialect>();
-
   }
 };
 } // namespace
@@ -127,4 +126,3 @@ struct VectorLinearizePass final
 std::unique_ptr<mlir::Pass> imex::createVectorLinearizePass() {
   return std::make_unique<VectorLinearizePass>();
 }
-


### PR DESCRIPTION
Upstream handles linearization of poison op so no need to have separate pattern im imex linearization pass

Please review these guidelines to help with the review process:
- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [ ] Have you organized your commits logically and ensured each can be built by itself?
