### PR TITLE
Add a patch for profile support in upstream LevelZeroRuntimeWrapper.

### DIFF
--- a/build_tools/patches/0013-Add-profile-support-in-upstream-LevelZeroRuntimeWrap.patch
+++ b/build_tools/patches/0013-Add-profile-support-in-upstream-LevelZeroRuntimeWrap.patch
@@ -13,7 +13,7 @@ index d0728274b94c..c728e3576f11 100644
 +++ b/mlir/lib/ExecutionEngine/LevelZeroRuntimeWrappers.cpp
 @@ -13,12 +13,16 @@
  #include "llvm/ADT/Twine.h"
- 
+
  #include "level_zero/ze_api.h"
 +#include <algorithm>
 +#include <atomic>
@@ -27,11 +27,11 @@ index d0728274b94c..c728e3576f11 100644
 +#include <numeric>
  #include <unordered_set>
  #include <vector>
- 
+
 @@ -328,6 +332,92 @@ struct DynamicEventPool {
    }
  };
- 
+
 +// EventPool TimeStamp events, needed for profiling
 +struct TimeStampEventPool {
 +  static constexpr size_t kNumEventsPerPool{128};
@@ -124,7 +124,7 @@ index d0728274b94c..c728e3576f11 100644
 @@ -338,6 +428,75 @@ static DynamicEventPool &getDynamicEventPool() {
    return dynEventPool;
  }
- 
+
 +// Thread-local lazy singleton accessor
 +static TimeStampEventPool &getTimeStampEventPool() {
 +  thread_local static TimeStampEventPool pool{&getRtContext()};
@@ -200,7 +200,7 @@ index d0728274b94c..c728e3576f11 100644
 @@ -407,6 +566,98 @@ static ze_module_handle_t loadModule(const void *data, size_t dataSize) {
    return zeModule;
  }
- 
+
 +//===----------------------------------------------------------------------===//
 +// Utilities
 +//===----------------------------------------------------------------------===//
@@ -321,7 +321,7 @@ index d0728274b94c..c728e3576f11 100644
 +    return allocDeviceMemory(size, alignment, isShared);
    });
  }
- 
+
 @@ -537,7 +772,6 @@ extern "C" void mgpuLaunchKernel(ze_kernel_handle_t kernel, size_t gridX,
                                   size_t sharedMemBytes, StreamWrapper *stream,
                                   void **params, void ** /*extra*/,
@@ -401,6 +401,5 @@ index d0728274b94c..c728e3576f11 100644
    stream->enqueueOp([&](ze_event_handle_t newEvent, uint32_t numWaitEvents,
                          ze_event_handle_t *waitEvents) {
      L0_SAFE_CALL(zeCommandListAppendLaunchKernel(
--- 
+--
 2.43.0
-


### PR DESCRIPTION
Add profile (execution time) support in upstream LevelZeroRuntimeWrapper.

We are using upstream LevelZeroRuntimeWrapper in IMEX SIMT/SIMD path. 
However, the upstream LevelZeroRuntimeWrapper does not have profiling support 
that we had in old downstream wrappers. This patch adds that support using 
LevelZero timstamp event-based profiling. One can use similar environment
variables used in downstream wrappers (i.e, `IMEX_ENABLE_PROFILING=1`)
to do different kind of profiling. 

This patch also fixes an issue described in internal issue: 1358.
The issue stems from maximum timestamp value calculation method.
Previously, the code made assumption that the deviceProperties.kernelTimestampValidBits
is always less than 64 bit, and hence use `(1ULL << deviceProperties.kernelTimestampValidBits) - 1ULL)`
to calculate maximum timeStampValue. It works fine if device_properties.kernelTimestampValidBits is 
less the size of ULL type in bits (usually 64 bits). However, it fails if if the number 
device_properties.kernelTimestampValidBits is >= ULL type in bits (64). This patch fixes that using:

```
zeTimestampMaxValue = (deviceProperties.kernelTimestampValidBits == 64)
                              ? std::numeric_limits<uint64_t>::max()
                              : ((1ULL << deviceProperties.kernelTimestampValidBits) - 1ULL);
    zeTimerResolution = deviceProperties.timerResolution;
```



Please review these guidelines to help with the review process:
- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [ ] Have you organized your commits logically and ensured each can be built by itself?
