### PR TITLE
[ExecutionEngine][LevelZeroRuntimeWrapper]Fix maximum timestamp value calculation.

### DIFF
--- a/lib/ExecutionEngine/LEVELZERORUNTIME/LevelZeroRuntimeWrappers.cpp
+++ b/lib/ExecutionEngine/LEVELZERORUNTIME/LevelZeroRuntimeWrappers.cpp
@@ -187,7 +187,9 @@ public:
     deviceProperties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
     CHECK_ZE_RESULT(zeDeviceGetProperties(zeDevice_, &deviceProperties));
     zeTimestampMaxValue_ =
-        ((1ULL << deviceProperties.kernelTimestampValidBits) - 1ULL);
+        (deviceProperties.kernelTimestampValidBits == 64)
+            ? std::numeric_limits<uint64_t>::max()
+            : ((1ULL << deviceProperties.kernelTimestampValidBits) - 1ULL);
     zeTimerResolution_ = deviceProperties.timerResolution;
 
     ze_event_desc_t eventDesc = {


### PR DESCRIPTION
Previous calculation method used to assume the kernelTimestampValidBits be always <64. However, that is not the case,
sometimes the kernelTimestampValidBits can be 64 (i.e., BMG). This patch fixes that issue.

More details available in internal issue: 1358.

Please review these guidelines to help with the review process:
- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [ ] Have you organized your commits logically and ensured each can be built by itself?
