### PR TITLE
Add a patch to support 32, 64 and 128 length vectors in LLVM SPIR-V backend.

### DIFF
--- a/build_tools/patches/0014-Add-32-64-and-128-length-vector-as-supported-vectors.patch
+++ b/build_tools/patches/0014-Add-32-64-and-128-length-vector-as-supported-vectors.patch
@@ -18,7 +18,7 @@ index 30703ee40be0..2f3baa1b6c7e 100644
 @@ -50,6 +50,28 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
    const LLT s64 = LLT::scalar(64);
    const LLT s128 = LLT::scalar(128);
- 
+
 +  // @IMEX, Add 32, 64 and 128 length vector as supported vectors.
 +  // This is needed to support large loads/stores using OpenCL intrinsics in
 +  // MLIR workflow.
@@ -45,7 +45,7 @@ index 30703ee40be0..2f3baa1b6c7e 100644
    const LLT v16s32 = LLT::fixed_vector(16, 32);
    const LLT v16s16 = LLT::fixed_vector(16, 16);
 @@ -99,41 +121,53 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
- 
+
    // TODO: remove copy-pasting here by using concatenation in some way.
    auto allPtrsScalarsAndVectors = {
 -      p0,    p1,    p2,    p3,    p4,     p5,     p6,    p7,    p8,
@@ -73,11 +73,11 @@ index 30703ee40be0..2f3baa1b6c7e 100644
 +                     v16s8,  v16s16, v16s32,  v16s64,  v32s1,  v32s8,  v32s16,
 +                     v32s32, v32s64, v64s1,   v64s8,   v64s16, v64s32, v64s64,
 +                     v128s1, v128s8, v128s16, v128s32, v128s64};
- 
+
    auto allShaderVectors = {v2s1, v2s8, v2s16, v2s32, v2s64,
                             v3s1, v3s8, v3s16, v3s32, v3s64,
                             v4s1, v4s8, v4s16, v4s32, v4s64};
- 
+
    auto allScalarsAndVectors = {
 -      s1,    s8,    s16,   s32,   s64,    s128,   v2s1,  v2s8,
 -      v2s16, v2s32, v2s64, v3s1,  v3s8,   v3s16,  v3s32, v3s64,
@@ -89,7 +89,7 @@ index 30703ee40be0..2f3baa1b6c7e 100644
 +      v8s32,  v8s64,  v16s1,  v16s8,   v16s16,  v16s32, v16s64, v32s1,
 +      v32s8,  v32s16, v32s32, v32s64,  v64s1,   v64s8,  v64s16, v64s32,
 +      v64s64, v128s1, v128s8, v128s16, v128s32, v128s64};
- 
+
    auto allIntScalarsAndVectors = {
 -      s8,    s16,   s32,   s64,   s128,   v2s8,   v2s16, v2s32, v2s64,
 -      v3s8,  v3s16, v3s32, v3s64, v4s8,   v4s16,  v4s32, v4s64, v8s8,
@@ -99,15 +99,15 @@ index 30703ee40be0..2f3baa1b6c7e 100644
 +      v8s8,   v8s16,  v8s32,  v8s64,  v16s8,   v16s16,  v16s32, v16s64,
 +      v32s1,  v32s8,  v32s16, v32s32, v32s64,  v64s1,   v64s8,  v64s16,
 +      v64s32, v64s64, v128s1, v128s8, v128s16, v128s32, v128s64};
- 
+
 -  auto allBoolScalarsAndVectors = {s1, v2s1, v3s1, v4s1, v8s1, v16s1};
 +  auto allBoolScalarsAndVectors = {s1,   v2s1,  v3s1,  v4s1,
 +                                   v8s1, v16s1, v32s1, v64s1};
- 
+
    auto allIntScalars = {s8, s16, s32, s64, s128};
- 
+
    auto allFloatScalarsAndF16Vector2AndVector4s = {s16, s32, s64, v2s16, v4s16};
- 
+
    auto allFloatScalarsAndVectors = {
 -      s16,   s32,   s64,   v2s16, v2s32, v2s64, v3s16,  v3s32,  v3s64,
 -      v4s16, v4s32, v4s64, v8s16, v8s32, v8s64, v16s16, v16s32, v16s64};
@@ -115,7 +115,7 @@ index 30703ee40be0..2f3baa1b6c7e 100644
 +      v4s16,  v4s32,  v4s64,  v8s16,   v8s32,   v8s64,  v16s16, v16s32, v16s64,
 +      v32s1,  v32s8,  v32s16, v32s32,  v32s64,  v64s1,  v64s8,  v64s16, v64s32,
 +      v64s64, v128s1, v128s8, v128s16, v128s32, v128s64};
- 
+
    auto allFloatAndIntScalarsAndPtrs = {s8, s16, s32, s64, p0, p1,  p2,  p3, p4,
                                         p5, p6,  p7,  p8,  p9, p10, p11, p12};
 @@ -170,7 +204,9 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
@@ -126,19 +126,18 @@ index 30703ee40be0..2f3baa1b6c7e 100644
 +
 +  // @IMEX, make the max vector size to be 128 for now.
 +  uint32_t MaxVectorSize = ST.isShader() ? 4 : 128;
- 
+
    for (auto Opc : getTypeFoldingSupportedOpcodes()) {
      if (Opc != G_EXTRACT_VECTOR_ELT)
 @@ -531,7 +567,8 @@ bool SPIRVLegalizerInfo::legalizeIntrinsic(LegalizerHelper &Helper,
      LLT DstTy = MRI.getType(DstReg);
      LLT SrcTy = MRI.getType(SrcReg);
- 
+
 -    int32_t MaxVectorSize = ST.isShader() ? 4 : 16;
 +    // @IMEX make the max vector size to be 128
 +    int32_t MaxVectorSize = ST.isShader() ? 4 : 128;
- 
+
      bool DstNeedsLegalization = false;
      bool SrcNeedsLegalization = false;
--- 
+--
 2.43.0
-


### PR DESCRIPTION
This is needed to unblock internal issue 1425.
This is temporary solution, once we converge on a better solution, this patch should be dropped.

Please review these guidelines to help with the review process:
- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, a reproducer, or a reference to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
- [x] Have you organized your commits logically and ensured each can be built by itself?
