### PR TITLE
Daily LLVM pulldown: bump to e0d0d3db9dd4

### DIFF
--- a/build_tools/llvm_version.txt
+++ b/build_tools/llvm_version.txt
@@ -1,1 +1,1 @@
-e6bd7887070e92bba3615de04d3fdefde4beb2de
+e0d0d3db9dd47ab9649ebb356ce404b55a2e4a77


### PR DESCRIPTION
Automated daily LLVM pulldown (mirrored from internal repo after CI passed).

Bumps `build_tools/llvm_version.txt` to llvm/llvm-project @ `e0d0d3db9dd47ab9649ebb356ce404b55a2e4a77`.