### PR TITLE
docs: fix 23 typos in documentation

### DIFF
--- a/docs/Tools/ImexRunner.md
+++ b/docs/Tools/ImexRunner.md
@@ -1,12 +1,12 @@
 # imex-runner.py
 
-IMEX provides an pass driver similar to mlir-opt called imex-opt. imex-opt is an extended version of mlir-opt capable of running IMEX passes. Although imex-opt is useful for testing passes it lacks a couple of user friendly feature. First, imex-opt does not have a file format for defining pass pipeline. So pass pipeline setup is passed as a usually long sequence of command line arguments. Second, imex-opt is pass driver without any other features. There are several common usage cases where imex-opt is used as part of command line pipeline like using FileCheck for checking pass outputs or using mlir-cpu-runner for testing end-to-end execution. In such common cases, it would be nice to have tool that glues things together without users to type whole chain of tools connected by pipes.
+IMEX provides a pass driver similar to mlir-opt called imex-opt. imex-opt is an extended version of mlir-opt capable of running IMEX passes. Although imex-opt is useful for testing passes it lacks a couple of user friendly features. First, imex-opt does not have a file format for defining pass pipeline. So pass pipeline setup is passed as a usually long sequence of command line arguments. Second, imex-opt is pass driver without any other features. There are several common usage cases where imex-opt is used as part of command line pipeline like using FileCheck for checking pass outputs or using mlir-cpu-runner for testing end-to-end execution. In such common cases, it would be nice to have tool that glues things together without users to type whole chain of tools connected by pipes.
 imex-runner.py was designed as a tool that wraps imex-opt and other common tools to provide a simpler user experience.
 
 ## Features
 ## Pass pipeline file
-Pass pipeline is a text file with extension .pp the allows user to save mlir pass pipeline in a text format. It is based on mlir's Textual Pass Pipeline Specification with some extensions.
-The format support C++ style single line comment. Add supports listing one pass name per line. The format is converted by imex-runner.py in to mlir' Textual Pass Pipeline Specification by stripping out comments and auto inserting commas. Users can use indentation along with listing one pass per line for an easier to read layout. Whitespaces are stripped automatically.
+Pass pipeline is a text file with extension .pp that allows user to save mlir pass pipeline in a text format. It is based on mlir's Textual Pass Pipeline Specification with some extensions.
+The format supports C++ style single line comment. It also supports listing one pass name per line. The format is converted by imex-runner.py in to mlir' Textual Pass Pipeline Specification by stripping out comments and auto inserting commas. Users can use indentation along with listing one pass per line for an easier to read layout. Whitespaces are stripped automatically.
 ### Example
 
 ```
@@ -35,7 +35,7 @@ The Pass pipeline file will be read by imex-runner.py and will be expanded into:
 ## Supporting common fixed workflow
 imex-runner.py supports several common workflows. The setup is running imex-opt followed by an optional runner(executing some mlir dialect on hardware) followed by an optional FileCheck utility. By opting in and out of the optional parts, user can cover common use cases like running passes with and without checking, end-to-end execution by running passes for lowering and executing though a runner with and without result checking with FileCheck.
 ## IMEX feature based conditional execution
-imex-runner.py support conditional excution based on available features. Current supported features are vulkan-runner, l0-runtime, sycl-runtime.
+imex-runner.py supports conditional execution based on available features. Current supported features are vulkan-runner, l0-runtime, sycl-runtime.
 For example, if you would like imex-runner.py to execute only if vulkan-runner is available, you can do the following.
 ```
 imex-runner.py --requires=vulkan-runner <rest of options>

--- a/docs/Transforms/BF16ToGpu.md
+++ b/docs/Transforms/BF16ToGpu.md
@@ -3,7 +3,7 @@
 
 BF16ToGPU pass transforms gpu dialect with bf16 dtype to a form that can be lowered to
 spirv and execute on Intel GPUs.
-Since bf16 is not a type directly supported by spirv, bf16 type is passes as an i16 type to
+Since bf16 is not a type directly supported by spirv, bf16 type is passed as an i16 type to
 spirv functions. This requires changing gpu.launch_func (caller) and gpu.func (callee).
 
 * Caller side changes are as follows:  
@@ -18,8 +18,8 @@ gpu.func's bf16 arguments replaced with i16 arguments. bf16 type usage inside gp
 can be divided into two different types. First, operations that interpret bits according to
 bf16 specification. Second, operations that only care about the size of the types.
 First type of operations include most of Arithmetic dialect and Math dialect operations
-expect for bit cast. The operation's bf16 operands and results types are replaced with f32.
-bf16 operands are replaced with a seqeuence i16 to bf16 bitcast followed by bf16 to f32 extf.
+except for bit cast. The operation's bf16 operands and results types are replaced with f32.
+bf16 operands are replaced with a sequence i16 to bf16 bitcast followed by bf16 to f32 extf.
 bf16 results are replaced with a sequence of f32 to bf16 truncf followed by bf16 to i16 bitcast.
 The resulting code, in summary, has two parts.
     1) bf16 operations emulated by f32 operations with the help of widening and truncating.

--- a/docs/Transforms/InsertGpuAllocs.md
+++ b/docs/Transforms/InsertGpuAllocs.md
@@ -60,11 +60,11 @@ As shown in the example above, the memref.allocs in the IR are referring to devi
 
 ## Limitations of this pass.
 
-1. This pass only supports only memref::AllocOp and not its variants like memref::AllocaOp, memref::AllocaScopeOp & AllocaScopeReturnOp.
+1. This pass only supports memref::AllocOp and not its variants like memref::AllocaOp, memref::AllocaScopeOp & AllocaScopeReturnOp.
 2. This pass needs to be run before the GpuKernelOutlining pass since it operates on gpu.launch blocks and not on gpu.launch_func.
 3. This pass only covers static shapes and shapes with unknown dims and known rank.
 
-Note: We plan to add support for these limitations in incremental future PR's.
+Note: We plan to add support for these limitations in incremental future PRs.
 
 ## Reason for this Custom Pass:
 

--- a/docs/Transforms/SetSPIRVAbiAttribute.md
+++ b/docs/Transforms/SetSPIRVAbiAttribute.md
@@ -1,7 +1,7 @@
 # SetSPIRVAbiAttribute Pass
 
 
-The SetSPIRVAbiAttribute pass, adds a kernel attribute called spv.entry_point_abi to the kernel function. Since SPIR-V programs themselves are not enough for running workloads on GPU; a companion host application is needed to manage the resources referenced by SPIR-V programs and dispatch the workload. It is also quite possible that both those programs are written by different frond-end languages.Hence the need to add the entry point abi.
+The SetSPIRVAbiAttribute pass, adds a kernel attribute called spv.entry_point_abi to the kernel function. Since SPIR-V programs themselves are not enough for running workloads on GPU; a companion host application is needed to manage the resources referenced by SPIR-V programs and dispatch the workload. It is also quite possible that both those programs are written by different front-end languages. Hence the need to add the entry point abi.
 spv.entry_point_abi is a struct attribute that should be attached to the entry function. Some of the lowering passes expect this attribute to perform the lowering.
 
 # Example

--- a/docs/Transforms/SetSPIRVCapabilities.md
+++ b/docs/Transforms/SetSPIRVCapabilities.md
@@ -1,7 +1,7 @@
 # SetSPIRVCapabilities Pass
 
 
-SPIR-V aims to support multiple execution environments. These execution environments affect the availability of certain SPIR-V features. SPIR-V compilation should also take into consideration the execution environment, so we generate SPIR-V modules valid for the target environment. This is conveyed by the spv.target_env  attribute. The SetSPIRVCapabilities pass, adds these various capabilties for the SPIR-V execution. The attribute #spv.vce has a few fields:
+SPIR-V aims to support multiple execution environments. These execution environments affect the availability of certain SPIR-V features. SPIR-V compilation should also take into consideration the execution environment, so we generate SPIR-V modules valid for the target environment. This is conveyed by the spv.target_env  attribute. The SetSPIRVCapabilities pass, adds these various capabilities for the SPIR-V execution. The attribute #spv.vce has a few fields:
 
 A #spv.vce (spirv::VerCapExtAttr) attribute:
 1. The target SPIR-V version.
@@ -68,4 +68,4 @@ As shown in the example above, the pass adds the SPIR-V capabilites as an attrib
 
 ## Reason for this Custom Pass:
 
-Upstream does not have a pass which does these conversions. This pass add a lot of things specific to Intel GPU. So, maybe we can have it as a custom pass rather than upstreaming.
+Upstream does not have a pass which does these conversions. This pass adds a lot of things specific to Intel GPU. So, maybe we can have it as a custom pass rather than upstreaming.

--- a/docs/rfcs/DistRuntimeDialect.md
+++ b/docs/rfcs/DistRuntimeDialect.md
@@ -122,7 +122,7 @@ Arguments:
 
 `gShape`, `lOffsets`, `bbOffsets` and `bbSizes` are variadic arguments with same
 size `r` where `r` is the rank of the global array (e.g., one number for each
-dimension of the global array). 1trim Returns an `AsyncHandle`, the left and the
+dimension of the global array). Returns an `AsyncHandle`, the left and the
 right halo.
 
 Syntax:

--- a/docs/rfcs/GPUXDialect.md
+++ b/docs/rfcs/GPUXDialect.md
@@ -4,12 +4,12 @@ Core MLIR Team
 
 ## Summary
 
-The GPUX dialect allows us to expose stream/device/context creation/destruction ops.These ops are required by the underlying runtimes (Level zero & Sycl) for explicit stream/context/device creation. Hence, we propose the GPUX dialect as an extension of the upstream GPU dialect.
+The GPUX dialect allows us to expose stream/device/context creation/destruction ops. These ops are required by the underlying runtimes (Level zero & Sycl) for explicit stream/context/device creation. Hence, we propose the GPUX dialect as an extension of the upstream GPU dialect.
 The GPUX dialect will also have some of the upstream GPU dialect ops extended with an added argument for stream in those ops.
 
 ## Motivation
 
-Upstream MLIR has a Dialect called the [GPU Dialect](https://mlir.llvm.org/docs/Dialects/GPU/) which provides middle-level abstractions for launching GPU kernels following a programming model similar to that of CUDA or OpenCL. The upstream dialect exposes all the operation required to launch the kernel on a GPU device. But, the drawback with the upstream dialect is it does not expose Stream as an operation in the dialect. For example, if the user wants to launch the kernel on a particular stream(provided by the user), there is no way to do that today. For the upstream dialect, stream is created internally while lowering to LLVM runtime calls and it refers specifically to the CUDA stream. Therefore, the need to create a GPUX Dialect arises. The GPUX dialect is an extension of the upstream GPU dialect with following ops - CreateDeviceOp, DestroyDeviceOp, CreateContextOp, DestroyContextOp, CreateStreamOp, DestroyStreamOp, LaunchFuncOp, AllocOp, DeallocOp, WaitOp, MemcpyOp & MemsetOp.
+Upstream MLIR has a Dialect called the [GPU Dialect](https://mlir.llvm.org/docs/Dialects/GPU/) which provides middle-level abstractions for launching GPU kernels following a programming model similar to that of CUDA or OpenCL. The upstream dialect exposes all the operations required to launch the kernel on a GPU device. But, the drawback with the upstream dialect is it does not expose Stream as an operation in the dialect. For example, if the user wants to launch the kernel on a particular stream(provided by the user), there is no way to do that today. For the upstream dialect, stream is created internally while lowering to LLVM runtime calls and it refers specifically to the CUDA stream. Therefore, the need to create a GPUX Dialect arises. The GPUX dialect is an extension of the upstream GPU dialect with following ops - CreateDeviceOp, DestroyDeviceOp, CreateContextOp, DestroyContextOp, CreateStreamOp, DestroyStreamOp, LaunchFuncOp, AllocOp, DeallocOp, WaitOp, MemcpyOp & MemsetOp.
 
 ## Proposal
 
@@ -151,7 +151,7 @@ operation ::= gpu.wait custom<AsyncDependencies>(type($asyncToken), $asyncDepend
               $gpux_stream attr-dict
 ```
 
-This op is an extension of upstream gpu.wait op with one added argument for stream on which to wait on.
+This op is an extension of upstream gpu.wait op with one added argument for stream on which to wait.
 
 
 #### gpux.memcpy (gpux::MemcpyOp)

--- a/docs/rfcs/RegionDialect.md
+++ b/docs/rfcs/RegionDialect.md
@@ -8,9 +8,9 @@ We propose a basic region concept which allows groups of operations to carry ann
 
 ## Motivation
 
-At this point there is not standard and convenient way in MLIR to annotate operations or groups of operations in way that can by default persists unrelated passes. Attributes often do not survive passes like the canonicalizer. Annotations using use-def chains are more persistent but using them can become relatively involved.
+At this point there is no standard and convenient way in MLIR to annotate operations or groups of operations in way that can by default persist unrelated passes. Attributes often do not survive passes like the canonicalizer. Annotations using use-def chains are more persistent but using them can become relatively involved.
 
-One example for the need of persistent annotations is the compute-follows-data model: data is allocated in a specific location, like a GPU, and operations on that data are expected to be executed in the same location (e.g. on the same device). The location might be assigned in a higher-level tensor dialect but the actual lowering for the specific device will happen much later when the information of the higher level dialect is gone. This requires some mechanism to persists annotations from a higher level dialect to lower levels.
+One example for the need of persistent annotations is the compute-follows-data model: data is allocated in a specific location, like a GPU, and operations on that data are expected to be executed in the same location (e.g. on the same device). The location might be assigned in a higher-level tensor dialect but the actual lowering for the specific device will happen much later when the information of the higher level dialect is gone. This requires some mechanism to persist annotations from a higher level dialect to lower levels.
 
 ## Proposal
 

--- a/docs/rfcs/template.md
+++ b/docs/rfcs/template.md
@@ -7,7 +7,7 @@ Short description of proposed solution.
 Explain motivation for the proposed idea.
 If you are proposing an optimization pass, please explain the applicable scenario and expected performance gain. It needs to address below criteria:
 - The new dialect needs to introduce unique features which we don’t think upstream dialect has interests to cover, and we believe that it could be up-streamed to core MLIR in the future.  
-- The new dialect should facilitate certain compile-time optimizations which otherwise cannot or very hard to achieve. In other words, there should be compile-time optimizations which requires the computation to be represented using the new dialects. If there is no compile-time optimization required, the new capability introduced by dialect could be represented  as functions in a standardized MLIR module to facilitate code reuse.
+- The new dialect should facilitate certain compile-time optimizations which otherwise cannot or are very hard to achieve. In other words, there should be compile-time optimizations which require the computation to be represented using the new dialects. If there is no compile-time optimization required, the new capability introduced by dialect could be represented  as functions in a standardized MLIR module to facilitate code reuse.
 
 ## Proposal
 A Full and detailed description of proposal.


### PR DESCRIPTION
## Summary

Fix 23 typos across 9 documentation files. Comments/docs only - no code, no
identifiers, and no behavioural change.

- **docs/Transforms/BF16ToGpu.md**: `is passes as` -> `is passed as`; `expect for bit cast` -> `except for bit cast`; `seqeuence` -> `sequence`
- **docs/rfcs/GPUXDialect.md**: `ops.These` -> `ops. These`; `all the operation required` -> `all the operations required`; `on which to wait on.` -> `on which to wait.`
- **docs/rfcs/DistRuntimeDialect.md**: dropped a stray `1trim` token left in the middle of a sentence
- **docs/Transforms/SetSPIRVCapabilities.md**: `capabilties` -> `capabilities`; `This pass add` -> `This pass adds`
- **docs/rfcs/RegionDialect.md**: `there is not standard` -> `there is no standard`; `persists` -> `persist` (x2)
- **docs/Tools/ImexRunner.md**: `an pass driver` -> `a pass driver`; `user friendly feature.` -> `user friendly features.`; `the allows user` -> `that allows user`; `The format support` -> `The format supports`; `Add supports listing` -> `It also supports listing`; `support conditional excution` -> `supports conditional execution`
- **docs/Transforms/SetSPIRVAbiAttribute.md**: `frond-end languages.Hence` -> `front-end languages. Hence`
- **docs/Transforms/InsertGpuAllocs.md**: `only supports only` -> `only supports`; `PR's` -> `PRs`
- **docs/rfcs/template.md**: `cannot or very hard` -> `cannot or are very hard`; `which requires the computation` -> `which require the computation`

Commit is DCO signed-off per the Intel org CONTRIBUTING guide.

PR checklist notes: documentation-only change, so there is nothing to test on CPU
or GPU devices and no new compiler warnings are possible. Single logical commit.